### PR TITLE
User: ListGroupMemberships

### DIFF
--- a/auth/claims.go
+++ b/auth/claims.go
@@ -3,8 +3,9 @@ package auth
 import (
 	"encoding/base64"
 	"encoding/json"
-	"golang.org/x/oauth2"
 	"strings"
+
+	"golang.org/x/oauth2"
 )
 
 // Claims is used to unmarshall the claims from a JWT issued by the Microsoft Identity Platform.

--- a/auth/claims.go
+++ b/auth/claims.go
@@ -30,7 +30,7 @@ func ParseClaims(token *oauth2.Token) (claims Claims, err error) {
 		return
 	}
 	jwt := strings.Split(token.AccessToken, ".")
-	payload, err := base64.StdEncoding.DecodeString(jwt[1])
+	payload, err := base64.RawStdEncoding.DecodeString(jwt[1])
 	if err != nil {
 		return
 	}

--- a/clients/users.go
+++ b/clients/users.go
@@ -136,8 +136,8 @@ func (c *UsersClient) Delete(ctx context.Context, id string) (int, error) {
 	return status, nil
 }
 
-// GetMemberGroups returns a list of Groups the user is member of, optionally filtered using OData.
-func (c *UsersClient) GetMemberGroups(ctx context.Context, id string, filter string) (*[]models.Group, int, error) {
+// ListGroupMemberships returns a list of Groups the user is member of, optionally filtered using OData.
+func (c *UsersClient) ListGroupMemberships(ctx context.Context, id string, filter string) (*[]models.Group, int, error) {
 	params := url.Values{}
 	if filter != "" {
 		params.Add("$filter", filter)

--- a/clients/users_test.go
+++ b/clients/users_test.go
@@ -145,7 +145,7 @@ func testUsersClient_GetMemberGroups(t *testing.T, c UsersClientTest, id string)
 	}
 
 	if len(*groups) != 2 {
-		t.Fatalf("UsersClient.GetMemberGroups(): expected groups length 1. was: %d", len(*groups))
+		t.Fatalf("UsersClient.GetMemberGroups(): expected groups length 2. was: %d", len(*groups))
 	}
 
 	return

--- a/clients/users_test.go
+++ b/clients/users_test.go
@@ -16,9 +16,10 @@ type UsersClientTest struct {
 }
 
 func TestUsersClient(t *testing.T) {
+	rs := internal.RandomString()
 	c := UsersClientTest{
 		connection:   internal.NewConnection(),
-		randomString: internal.RandomString(),
+		randomString: rs,
 	}
 	c.client = clients.NewUsersClient(c.connection.AuthConfig.TenantID)
 	c.client.BaseClient.Authorizer = c.connection.Authorizer
@@ -36,6 +37,38 @@ func TestUsersClient(t *testing.T) {
 	user.DisplayName = internal.String(fmt.Sprintf("test-updated-user-%s", c.randomString))
 	testUsersClient_Update(t, c, *user)
 	testUsersClient_List(t, c)
+
+	g := GroupsClientTest{
+		connection:   internal.NewConnection(),
+		randomString: rs,
+	}
+	g.client = clients.NewGroupsClient(g.connection.AuthConfig.TenantID)
+	g.client.BaseClient.Authorizer = g.connection.Authorizer
+
+	newGroupParent := models.Group{
+		DisplayName:     internal.String("Test Group Parent"),
+		MailEnabled:     internal.Bool(false),
+		MailNickname:    internal.String(fmt.Sprintf("test-group-parent-%s", c.randomString)),
+		SecurityEnabled: internal.Bool(true),
+	}
+	newGroupChild := models.Group{
+		DisplayName:     internal.String("Test Group Child"),
+		MailEnabled:     internal.Bool(false),
+		MailNickname:    internal.String(fmt.Sprintf("test-group-child-%s", c.randomString)),
+		SecurityEnabled: internal.Bool(true),
+	}
+
+	groupParent := testGroupsClient_Create(t, g, newGroupParent)
+	groupChild := testGroupsClient_Create(t, g, newGroupChild)
+	groupParent.AppendMember(g.client.BaseClient.Endpoint, g.client.BaseClient.ApiVersion, *groupChild.ID)
+	testGroupsClient_AddMembers(t, g, groupParent)
+	groupChild.AppendMember(g.client.BaseClient.Endpoint, g.client.BaseClient.ApiVersion, *user.ID)
+	testGroupsClient_AddMembers(t, g, groupChild)
+
+	testUsersClient_GetMemberGroups(t, c, *user.ID)
+	testGroupsClient_Delete(t, g, *groupParent.ID)
+	testGroupsClient_Delete(t, g, *groupChild.ID)
+
 	testUsersClient_Delete(t, c, *user.ID)
 }
 
@@ -99,4 +132,21 @@ func testUsersClient_Delete(t *testing.T, c UsersClientTest, id string) {
 	if status < 200 || status >= 300 {
 		t.Fatalf("UsersClient.Delete(): invalid status: %d", status)
 	}
+}
+
+func testUsersClient_GetMemberGroups(t *testing.T, c UsersClientTest, id string) (groups *[]models.Group) {
+	groups, _, err := c.client.GetMemberGroups(c.connection.Context, id, "")
+	if err != nil {
+		t.Fatalf("UsersClient.GetMemberGroups(): %v", err)
+	}
+
+	if groups == nil {
+		t.Fatal("UsersClient.GetMemberGroups(): groups was nil")
+	}
+
+	if len(*groups) != 2 {
+		t.Fatalf("UsersClient.GetMemberGroups(): expected groups length 1. was: %d", len(*groups))
+	}
+
+	return
 }

--- a/clients/users_test.go
+++ b/clients/users_test.go
@@ -65,7 +65,7 @@ func TestUsersClient(t *testing.T) {
 	groupChild.AppendMember(g.client.BaseClient.Endpoint, g.client.BaseClient.ApiVersion, *user.ID)
 	testGroupsClient_AddMembers(t, g, groupChild)
 
-	testUsersClient_GetMemberGroups(t, c, *user.ID)
+	testUsersClient_ListGroupMemberships(t, c, *user.ID)
 	testGroupsClient_Delete(t, g, *groupParent.ID)
 	testGroupsClient_Delete(t, g, *groupChild.ID)
 
@@ -134,18 +134,18 @@ func testUsersClient_Delete(t *testing.T, c UsersClientTest, id string) {
 	}
 }
 
-func testUsersClient_GetMemberGroups(t *testing.T, c UsersClientTest, id string) (groups *[]models.Group) {
-	groups, _, err := c.client.GetMemberGroups(c.connection.Context, id, "")
+func testUsersClient_ListGroupMemberships(t *testing.T, c UsersClientTest, id string) (groups *[]models.Group) {
+	groups, _, err := c.client.ListGroupMemberships(c.connection.Context, id, "")
 	if err != nil {
-		t.Fatalf("UsersClient.GetMemberGroups(): %v", err)
+		t.Fatalf("UsersClient.ListGroupMemberships(): %v", err)
 	}
 
 	if groups == nil {
-		t.Fatal("UsersClient.GetMemberGroups(): groups was nil")
+		t.Fatal("UsersClient.ListGroupMemberships(): groups was nil")
 	}
 
 	if len(*groups) != 2 {
-		t.Fatalf("UsersClient.GetMemberGroups(): expected groups length 2. was: %d", len(*groups))
+		t.Fatalf("UsersClient.ListGroupMemberships(): expected groups length 2. was: %d", len(*groups))
 	}
 
 	return


### PR DESCRIPTION
Changes:
- clients/user.go: Added `ListGroupMemberships` to [list user transitive memberOf](https://docs.microsoft.com/en-us/graph/api/user-list-transitivememberof?view=graph-rest-1.0&tabs=http)
- clients/user_test.go: Added tests for `ListGroupMemberships`
- auth/claims.go: Changed from `base64.StdEncoding.` to `base64.RawStdEncoding.` to fix error decoding access token. This is because JWTs are not padded which StdEncoding is expecting.

Any and all feedback, help, suggestions, edits etc is welcome!