### PR TITLE
API rate limiting / retry logic

### DIFF
--- a/base/aadgraph/base.go
+++ b/base/aadgraph/base.go
@@ -1,13 +1,13 @@
 package aadgraph
 
 import (
-	"bytes"
-	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
+	"time"
 
 	"github.com/manicminer/hamilton/auth"
 	"github.com/manicminer/hamilton/base/odata"
@@ -21,6 +21,12 @@ const (
 	Version20 ApiVersion = "2.0"
 )
 
+const (
+	defaultInitialBackoff = 5 * time.Second
+	defaultBackoffCap     = 64 * time.Second
+	requestAttempts       = 10
+)
+
 // ValidStatusFunc is a function that tests whether an HTTP response is considered valid for the particular request.
 type ValidStatusFunc func(response *http.Response, o *odata.OData) bool
 
@@ -32,8 +38,8 @@ type HttpRequestInput interface {
 
 // Uri represents an Azure Active Directory Graph endpoint.
 type Uri struct {
-	Entity      string
-	Params      url.Values
+	Entity string
+	Params url.Values
 }
 
 // GraphClient is any suitable HTTP client.
@@ -104,49 +110,82 @@ func (c Client) performRequest(req *http.Request, input HttpRequestInput) (*http
 		req.Header.Add("User-Agent", c.UserAgent)
 	}
 
-	resp, err := c.httpClient.Do(req)
-	if err != nil {
-		return nil, status, nil, err
+	var resp *http.Response
+	var o odata.OData
+	var err error
+
+	var backoffPower func(int64, int64) int64
+	backoffPower = func(base, exp int64) int64 {
+		if exp <= 1 {
+			return base
+		}
+		return base * backoffPower(base, exp-1)
 	}
 
-	var o odata.OData
-
-	// Check for json content before looking for odata metadata
-	contentType := strings.ToLower(resp.Header.Get("Content-Type"))
-	if strings.HasPrefix(contentType, "application/json") {
-		// Read the response body and close it
-		respBody, err := ioutil.ReadAll(resp.Body)
-		resp.Body.Close()
-		if err != nil {
-			return nil, status, nil, fmt.Errorf("could not read response body: %s", err)
+	var attempts, backoff, multiplier int64
+	for attempts = 0; attempts < requestAttempts; attempts++ {
+		// sleep after the previous failed attempt
+		if attempts > 0 {
+			time.Sleep(time.Duration(backoff))
 		}
 
-		// Unmarshall odata
-		if err := json.Unmarshal(respBody, &o); err != nil {
+		// default exponential backoff
+		multiplier++
+		backoff = int64(defaultInitialBackoff) * backoffPower(2, multiplier)
+		if cap := int64(defaultBackoffCap); backoff > cap {
+			backoff = cap
+		}
+
+		resp, err = c.httpClient.Do(req)
+		if err != nil {
 			return nil, status, nil, err
 		}
 
-		// Reassign the response body
-		resp.Body = ioutil.NopCloser(bytes.NewBuffer(respBody))
-	}
-
-	status = resp.StatusCode
-	if !containsStatusCode(input.GetValidStatusCodes(), status) {
-		f := input.GetValidStatusFunc()
-		if f != nil && f(resp, &o) {
-			return resp, status, &o, nil
+		d, err := odata.FromResponse(resp)
+		if err != nil {
+			return nil, status, &o, err
+		}
+		if d != nil {
+			o = *d
 		}
 
-		var errText string
-		switch {
-		case o.Error != nil && o.Error.String() != "":
-			errText = fmt.Sprintf("OData error: %s", o.Error)
-		default:
-			defer resp.Body.Close()
-			respBody, _ := ioutil.ReadAll(resp.Body)
-			errText = fmt.Sprintf("response: %s", respBody)
+		status = resp.StatusCode
+		if !containsStatusCode(input.GetValidStatusCodes(), status) {
+			f := input.GetValidStatusFunc()
+			if f != nil && f(resp, &o) {
+				return resp, status, &o, nil
+			}
+
+			// rate limiting
+			if containsStatusCode([]int{424, 429, 503}, status) {
+				if o.Error != nil && o.Error.Values != nil {
+					for _, v := range *o.Error.Values {
+						if v.Item == "BackoffTime" {
+							if r, err := strconv.ParseFloat(v.Value, 64); err == nil && r > 0 {
+								// BackoffTime detected, use that instead of default backoff
+								backoff = int64(r * float64(time.Second))
+								multiplier = 0
+							}
+							break
+						}
+					}
+				}
+				continue
+			}
+
+			var errText string
+			switch {
+			case o.Error != nil && o.Error.String() != "":
+				errText = fmt.Sprintf("OData error: %s", o.Error)
+			default:
+				defer resp.Body.Close()
+				respBody, _ := ioutil.ReadAll(resp.Body)
+				errText = fmt.Sprintf("response: %s", respBody)
+			}
+			return nil, status, &o, fmt.Errorf("unexpected status %d with %s", resp.StatusCode, errText)
 		}
-		return nil, status, &o, fmt.Errorf("unexpected status %d with %s", resp.StatusCode, errText)
+
+		break
 	}
 
 	return resp, status, &o, nil

--- a/base/base.go
+++ b/base/base.go
@@ -1,13 +1,13 @@
 package base
 
 import (
-	"bytes"
-	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
+	"time"
 
 	"github.com/manicminer/hamilton/auth"
 	"github.com/manicminer/hamilton/base/odata"
@@ -19,6 +19,12 @@ type ApiVersion string
 const (
 	Version10   ApiVersion = "v1.0"
 	VersionBeta ApiVersion = "beta"
+)
+
+const (
+	defaultInitialBackoff = 1 * time.Second
+	defaultBackoffCap     = 64 * time.Second
+	requestAttempts       = 10
 )
 
 // ValidStatusFunc is a function that tests whether an HTTP response is considered valid for the particular request.
@@ -107,49 +113,77 @@ func (c Client) performRequest(req *http.Request, input HttpRequestInput) (*http
 		req.Header.Add("User-Agent", c.UserAgent)
 	}
 
-	resp, err := c.httpClient.Do(req)
-	if err != nil {
-		return nil, status, nil, err
+	var resp *http.Response
+	var o odata.OData
+	var err error
+
+	var backoffPower func(int64, int64) int64
+	backoffPower = func(base, exp int64) int64 {
+		if exp <= 1 {
+			return base
+		}
+		return base * backoffPower(base, exp-1)
 	}
 
-	var o odata.OData
-
-	// Check for json content before looking for odata metadata
-	contentType := strings.ToLower(resp.Header.Get("Content-Type"))
-	if strings.HasPrefix(contentType, "application/json") {
-		// Read the response body and close it
-		respBody, err := ioutil.ReadAll(resp.Body)
-		resp.Body.Close()
-		if err != nil {
-			return nil, status, nil, fmt.Errorf("could not read response body: %s", err)
+	var attempts, backoff, multiplier int64
+	for attempts = 0; attempts < requestAttempts; attempts++ {
+		// sleep after the previous failed attempt
+		if attempts > 0 {
+			time.Sleep(time.Duration(backoff))
 		}
 
-		// Unmarshall odata
-		if err := json.Unmarshal(respBody, &o); err != nil {
+		// default exponential backoff
+		multiplier++
+		backoff = int64(defaultInitialBackoff) * backoffPower(2, multiplier)
+		if cap := int64(defaultBackoffCap); backoff > cap {
+			backoff = cap
+		}
+
+		resp, err = c.httpClient.Do(req)
+		if err != nil {
 			return nil, status, nil, err
 		}
 
-		// Reassign the response body
-		resp.Body = ioutil.NopCloser(bytes.NewBuffer(respBody))
-	}
-
-	status = resp.StatusCode
-	if !containsStatusCode(input.GetValidStatusCodes(), status) {
-		f := input.GetValidStatusFunc()
-		if f != nil && f(resp, &o) {
-			return resp, status, &o, nil
+		d, err := odata.FromResponse(resp)
+		if err != nil {
+			return nil, status, &o, err
+		}
+		if d != nil {
+			o = *d
 		}
 
-		var errText string
-		switch {
-		case o.Error != nil && o.Error.String() != "":
-			errText = fmt.Sprintf("OData error: %s", o.Error)
-		default:
-			defer resp.Body.Close()
-			respBody, _ := ioutil.ReadAll(resp.Body)
-			errText = fmt.Sprintf("response: %s", respBody)
+		status = resp.StatusCode
+		if !containsStatusCode(input.GetValidStatusCodes(), status) {
+			f := input.GetValidStatusFunc()
+			if f != nil && f(resp, &o) {
+				return resp, status, &o, nil
+			}
+
+			// rate limiting
+			if containsStatusCode([]int{424, 429, 503}, status) {
+				if retryAfter := resp.Header.Get("Retry-After"); retryAfter != "" {
+					if r, err := strconv.ParseFloat(retryAfter, 64); err == nil && r > 0 {
+						// Retry-After header detected, use that instead of default backoff
+						backoff = int64(r * float64(time.Second))
+						multiplier = 0
+					}
+				}
+				continue
+			}
+
+			var errText string
+			switch {
+			case o.Error != nil && o.Error.String() != "":
+				errText = fmt.Sprintf("OData error: %s", o.Error)
+			default:
+				defer resp.Body.Close()
+				respBody, _ := ioutil.ReadAll(resp.Body)
+				errText = fmt.Sprintf("response: %s", respBody)
+			}
+			return nil, status, &o, fmt.Errorf("unexpected status %d with %s", resp.StatusCode, errText)
 		}
-		return nil, status, &o, fmt.Errorf("unexpected status %d with %s", resp.StatusCode, errText)
+
+		break
 	}
 
 	return resp, status, &o, nil

--- a/base/odata/http.go
+++ b/base/odata/http.go
@@ -1,0 +1,39 @@
+package odata
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strings"
+)
+
+// FromResponse parses an http.Response and returns an unmarshalled OData
+// If no odata is present in the response, or the content type is invalid, returns nil
+func FromResponse(resp *http.Response) (*OData, error) {
+	var o OData
+
+	// Check for json content before looking for odata metadata
+	contentType := strings.ToLower(resp.Header.Get("Content-Type"))
+	if strings.HasPrefix(contentType, "application/json") {
+		// Read the response body and close it
+		respBody, err := ioutil.ReadAll(resp.Body)
+		resp.Body.Close()
+		if err != nil {
+			return nil, fmt.Errorf("could not read response body: %s", err)
+		}
+
+		// Unmarshall odata
+		if err := json.Unmarshal(respBody, &o); err != nil {
+			return nil, err
+		}
+
+		// Reassign the response body
+		resp.Body = ioutil.NopCloser(bytes.NewBuffer(respBody))
+
+		return &o, nil
+	}
+
+	return nil, nil
+}

--- a/base/odata/odata.go
+++ b/base/odata/odata.go
@@ -57,7 +57,13 @@ type Error struct {
 	RawMessage      *json.RawMessage `json:"message"` // sometimes a string, sometimes an object :/
 	ClientRequestId *string          `json:"client-request-id"`
 	RequestId       *string          `json:"request-id"`
-	InnerError      *Error           `json:"innerError"` // nested errors
+
+	InnerError *Error `json:"innerError"` // nested errors
+
+	Values *[]struct {
+		Item  string `json:"item"`
+		Value string `json:"value"`
+	} `json:"values"`
 }
 
 func (e *Error) UnmarshalJSON(data []byte) error {


### PR DESCRIPTION
Adopt exponential backoff delay for requests returned with 424, 429 or 500 status

**For MS Graph:**
- start at 1 second, increase by 2^retries seconds up to 64 seconds
- If a "Retry-After" header is seen, parse for seconds and use that instead
- fail after 10 attempts

**For AAD Graph:**
- start at 5 seconds, increase by 2^retries seconds up to 64 seconds
- Parse any odata in the body and if an indicated backoff time is detected, use that instead
- fail after 10 attempts
