### PR TITLE
API support for directory role templates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 example/example
 vendor/
+.idea

--- a/msgraph/directory_role_templates.go
+++ b/msgraph/directory_role_templates.go
@@ -20,9 +20,8 @@ func NewDirectoryRoleTemplatesClient(tenantId string) *DirectoryRoleTemplatesCli
 	}
 }
 
-// List returns a list of DirectoryRoleTemplates, optionally filtered using OData.
+// List returns a list of DirectoryRoleTemplates.
 func (c *DirectoryRoleTemplatesClient) List(ctx context.Context) (*[]DirectoryRoleTemplate, int, error) {
-
 	resp, status, _, err := c.BaseClient.Get(ctx, GetHttpRequestInput{
 		ValidStatusCodes: []int{http.StatusOK},
 		Uri: Uri{

--- a/msgraph/directory_role_templates.go
+++ b/msgraph/directory_role_templates.go
@@ -1,0 +1,66 @@
+package msgraph
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+)
+
+// DirectoryRoleTemplatesClient performs operations on DirectoryRoleTemplates.
+type DirectoryRoleTemplatesClient struct {
+	BaseClient Client
+}
+
+// NewDirectoryRoleTemplatesClient returns a new DirectoryRoleTemplatesClient
+func NewDirectoryRoleTemplatesClient(tenantId string) *DirectoryRoleTemplatesClient {
+	return &DirectoryRoleTemplatesClient{
+		BaseClient: NewClient(Version10, tenantId),
+	}
+}
+
+// List returns a list of DirectoryRoleTemplates, optionally filtered using OData.
+func (c *DirectoryRoleTemplatesClient) List(ctx context.Context) (*[]DirectoryRoleTemplate, int, error) {
+
+	resp, status, _, err := c.BaseClient.Get(ctx, GetHttpRequestInput{
+		ValidStatusCodes: []int{http.StatusOK},
+		Uri: Uri{
+			Entity:      "/directoryRoleTemplates",
+			HasTenantId: true,
+		},
+	})
+	if err != nil {
+		return nil, status, err
+	}
+	defer resp.Body.Close()
+	respBody, _ := ioutil.ReadAll(resp.Body)
+	var data struct {
+		DirectoryRoleTemplates []DirectoryRoleTemplate `json:"value"`
+	}
+	if err := json.Unmarshal(respBody, &data); err != nil {
+		return nil, status, err
+	}
+	return &data.DirectoryRoleTemplates, status, nil
+}
+
+// Get retrieves an DirectoryRoleTemplates manifest.
+func (c *DirectoryRoleTemplatesClient) Get(ctx context.Context, id string) (*DirectoryRoleTemplate, int, error) {
+	resp, status, _, err := c.BaseClient.Get(ctx, GetHttpRequestInput{
+		ValidStatusCodes: []int{http.StatusOK},
+		Uri: Uri{
+			Entity:      fmt.Sprintf("/directoryRoleTemplates/%s", id),
+			HasTenantId: true,
+		},
+	})
+	if err != nil {
+		return nil, status, err
+	}
+	defer resp.Body.Close()
+	respBody, _ := ioutil.ReadAll(resp.Body)
+	var dirRoleTemplate DirectoryRoleTemplate
+	if err := json.Unmarshal(respBody, &dirRoleTemplate); err != nil {
+		return nil, status, err
+	}
+	return &dirRoleTemplate, status, nil
+}

--- a/msgraph/directory_role_templates_test.go
+++ b/msgraph/directory_role_templates_test.go
@@ -1,0 +1,52 @@
+package msgraph_test
+
+import (
+	"testing"
+
+	"github.com/manicminer/hamilton/auth"
+	"github.com/manicminer/hamilton/internal/test"
+	"github.com/manicminer/hamilton/msgraph"
+)
+
+type DirectoryRoleTemplatesClientTest struct {
+	connection   *test.Connection
+	client       *msgraph.DirectoryRoleTemplatesClient
+	randomString string
+}
+
+func TestDirectoryRoleTemplatesClient(t *testing.T) {
+	c := DirectoryRoleTemplatesClientTest{
+		connection:   test.NewConnection(auth.MsGraph, auth.TokenVersion2),
+		randomString: test.RandomString(),
+	}
+	c.client = msgraph.NewDirectoryRoleTemplatesClient(c.connection.AuthConfig.TenantID)
+	c.client.BaseClient.Authorizer = c.connection.Authorizer
+
+	directoryRoleTemplates := testDirectoryRoleTemplatesClient_List(t, c)
+	testDirectoryRoleTemplatesClient_Get(t, c, *(*directoryRoleTemplates)[0].ID)
+}
+
+func testDirectoryRoleTemplatesClient_List(t *testing.T, c DirectoryRoleTemplatesClientTest) (directoryRoleTemplates *[]msgraph.DirectoryRoleTemplate) {
+	directoryRoleTemplates, _, err := c.client.List(c.connection.Context)
+	if err != nil {
+		t.Fatalf("DirectoryRoleTemplatesClient.List(): %v", err)
+	}
+	if directoryRoleTemplates == nil {
+		t.Fatal("DirectoryRoleTemplatesClient.List(): directoryRoleTemplates was nil")
+	}
+	return
+}
+
+func testDirectoryRoleTemplatesClient_Get(t *testing.T, c DirectoryRoleTemplatesClientTest, id string) (directoryRoleTemplate *msgraph.DirectoryRoleTemplate) {
+	domain, status, err := c.client.Get(c.connection.Context, id)
+	if err != nil {
+		t.Fatalf("DirectoryRoleTemplatesClient.Get(): %v", err)
+	}
+	if status < 200 || status >= 300 {
+		t.Fatalf("DirectoryRoleTemplatesClient.Get(): invalid status: %d", status)
+	}
+	if domain == nil {
+		t.Fatal("DirectoryRoleTemplatesClient.Get(): domain was nil")
+	}
+	return
+}

--- a/msgraph/models.go
+++ b/msgraph/models.go
@@ -712,3 +712,11 @@ type VerifiedPublisher struct {
 	DisplayName         *string    `json:"displayName,omitempty"`
 	VerifiedPublisherId *string    `json:"verifiedPublisherId,omitempty"`
 }
+
+// DirectoryRoleTemplate describes a Directory Role Template.
+type DirectoryRoleTemplate struct {
+	ID              *string    `json:"id,omitempty"`
+	DeletedDateTime *time.Time `json:"deletedDateTime,omitempty"`
+	Description     *string    `json:"description,omitempty"`
+	DisplayName     *string    `json:"displayName,omitempty"`
+}


### PR DESCRIPTION
Hi @manicminer, 
started recently evaluating your project and see if it fits my needs. As part of the process, I just created a tiny PR that will add API support for the directory role templates on the Microsoft Graph API. Kindly please review when you get some time. Thanks.
