### PR TITLE
Add support for directory role

### DIFF
--- a/msgraph/directory_role_templates_test.go
+++ b/msgraph/directory_role_templates_test.go
@@ -38,15 +38,15 @@ func testDirectoryRoleTemplatesClient_List(t *testing.T, c DirectoryRoleTemplate
 }
 
 func testDirectoryRoleTemplatesClient_Get(t *testing.T, c DirectoryRoleTemplatesClientTest, id string) (directoryRoleTemplate *msgraph.DirectoryRoleTemplate) {
-	domain, status, err := c.client.Get(c.connection.Context, id)
+	directoryRoleTemplate, status, err := c.client.Get(c.connection.Context, id)
 	if err != nil {
 		t.Fatalf("DirectoryRoleTemplatesClient.Get(): %v", err)
 	}
 	if status < 200 || status >= 300 {
 		t.Fatalf("DirectoryRoleTemplatesClient.Get(): invalid status: %d", status)
 	}
-	if domain == nil {
-		t.Fatal("DirectoryRoleTemplatesClient.Get(): domain was nil")
+	if directoryRoleTemplate == nil {
+		t.Fatal("DirectoryRoleTemplatesClient.Get(): directoryRoleTemplate was nil")
 	}
 	return
 }

--- a/msgraph/directory_roles.go
+++ b/msgraph/directory_roles.go
@@ -1,0 +1,222 @@
+package msgraph
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"regexp"
+
+	"github.com/manicminer/hamilton/odata"
+)
+
+// DirectoryRolesClient performs operations on DirectoryRoles.
+type DirectoryRolesClient struct {
+	BaseClient Client
+}
+
+// NewDirectoryRolesClient returns a new DirectoryRolesClient
+func NewDirectoryRolesClient(tenantId string) *DirectoryRolesClient {
+	return &DirectoryRolesClient{
+		BaseClient: NewClient(Version10, tenantId),
+	}
+}
+
+// List returns a list of DirectoryRoles.
+func (c *DirectoryRolesClient) List(ctx context.Context) (*[]DirectoryRole, int, error) {
+	resp, status, _, err := c.BaseClient.Get(ctx, GetHttpRequestInput{
+		ValidStatusCodes: []int{http.StatusOK},
+		Uri: Uri{
+			Entity:      "/directoryRoles",
+			HasTenantId: true,
+		},
+	})
+	if err != nil {
+		return nil, status, fmt.Errorf("DirectoryRolesClient.BaseClient.Get(): %v", err)
+	}
+	defer resp.Body.Close()
+	respBody, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, status, fmt.Errorf("ioutil.ReadAll(): %v", err)
+	}
+	var data struct {
+		DirectoryRoles []DirectoryRole `json:"value"`
+	}
+	if err := json.Unmarshal(respBody, &data); err != nil {
+		return nil, status, fmt.Errorf("json.Unmarshal(): %v", err)
+	}
+	return &data.DirectoryRoles, status, nil
+}
+
+// Get retrieves an DirectoryRoles manifest.
+func (c *DirectoryRolesClient) Get(ctx context.Context, id string) (*DirectoryRole, int, error) {
+	resp, status, _, err := c.BaseClient.Get(ctx, GetHttpRequestInput{
+		ValidStatusCodes: []int{http.StatusOK},
+		Uri: Uri{
+			Entity:      fmt.Sprintf("/directoryRoles/%s", id),
+			HasTenantId: true,
+		},
+	})
+	if err != nil {
+		return nil, status, fmt.Errorf("DirectoryRolesClient.BaseClient.Get(): %v", err)
+	}
+	defer resp.Body.Close()
+	respBody, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, status, fmt.Errorf("ioutil.ReadAll(): %v", err)
+	}
+	var dirRole DirectoryRole
+	if err := json.Unmarshal(respBody, &dirRole); err != nil {
+		return nil, status, fmt.Errorf("json.Unmarshal(): %v", err)
+	}
+	return &dirRole, status, nil
+}
+
+// ListMembers retrieves the members of the specified directory role.
+// id is the object ID of the directory role.
+func (c *DirectoryRolesClient) ListMembers(ctx context.Context, id string) (*[]string, int, error) {
+	resp, status, _, err := c.BaseClient.Get(ctx, GetHttpRequestInput{
+		ValidStatusCodes: []int{http.StatusOK},
+		Uri: Uri{
+			Entity:      fmt.Sprintf("/directoryRoles/%s/members", id),
+			Params:      url.Values{"$select": []string{"id"}},
+			HasTenantId: true,
+		},
+	})
+	if err != nil {
+		return nil, status, fmt.Errorf("DirectoryRolesClient.BaseClient.Get(): %v", err)
+	}
+	defer resp.Body.Close()
+	respBody, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, status, fmt.Errorf("ioutil.ReadAll(): %v", err)
+	}
+	var data struct {
+		Members []struct {
+			Type string `json:"@odata.type"`
+			Id   string `json:"id"`
+		} `json:"value"`
+	}
+	if err := json.Unmarshal(respBody, &data); err != nil {
+		return nil, status, fmt.Errorf("json.Unmarshal(): %v", err)
+	}
+	ret := make([]string, len(data.Members))
+	for i, v := range data.Members {
+		ret[i] = v.Id
+	}
+	return &ret, status, nil
+}
+
+// AddMembers adds a new member to a Directory Role.
+// First populate the Members field of the DirectoryRole using the AppendMember method of the model, then call this method.
+func (c *DirectoryRolesClient) AddMembers(ctx context.Context, directoryRole *DirectoryRole) (int, error) {
+	var status int
+	if directoryRole.ID == nil {
+		return status, errors.New("cannot update directory role with nil ID")
+	}
+	if directoryRole.Members == nil {
+		return status, errors.New("cannot update directory role with nil Owners")
+	}
+	for _, member := range *directoryRole.Members {
+		// don't fail if an member already exists
+		checkMemberAlreadyExists := func(resp *http.Response, o *odata.OData) bool {
+			if resp.StatusCode == http.StatusBadRequest {
+				if o.Error != nil {
+					re := regexp.MustCompile("One or more added object references already exist")
+					if re.MatchString(o.Error.String()) {
+						return true
+					}
+				}
+			}
+			return false
+		}
+		data := struct {
+			Member string `json:"@odata.id"`
+		}{
+			Member: member,
+		}
+		body, err := json.Marshal(data)
+		if err != nil {
+			return status, fmt.Errorf("json.Marshal(): %v", err)
+		}
+		_, status, _, err = c.BaseClient.Post(ctx, PostHttpRequestInput{
+			Body:             body,
+			ValidStatusCodes: []int{http.StatusNoContent},
+			ValidStatusFunc:  checkMemberAlreadyExists,
+			Uri: Uri{
+				Entity:      fmt.Sprintf("/directoryRoles/%s/members/$ref", *directoryRole.ID),
+				HasTenantId: true,
+			},
+		})
+		if err != nil {
+			return status, fmt.Errorf("DirectoryRolesClient.BaseClient.Post(): %v", err)
+		}
+	}
+	return status, nil
+}
+
+// RemoveMembers removes members from a Directory Role.
+// id is the object ID of the Directory Role.
+// memberIds is a *[]string containing object IDs of members to remove.
+func (c *DirectoryRolesClient) RemoveMembers(ctx context.Context, directoryRoleId string, memberIds *[]string) (int, error) {
+	var status int
+	if memberIds == nil {
+		return status, errors.New("cannot remove, nil memberIds")
+	}
+	for _, memberId := range *memberIds {
+		// check for membership before attempting deletion
+		if _, status, err := c.GetMember(ctx, directoryRoleId, memberId); err != nil {
+			if status == http.StatusNotFound {
+				continue
+			}
+			return status, err
+		}
+		var err error
+		_, status, _, err = c.BaseClient.Delete(ctx, DeleteHttpRequestInput{
+			ValidStatusCodes: []int{http.StatusNoContent},
+			Uri: Uri{
+				Entity:      fmt.Sprintf("/directoryRoles/%s/members/%s/$ref", directoryRoleId, memberId),
+				HasTenantId: true,
+			},
+		})
+		if err != nil {
+			return status, fmt.Errorf("DirectoryRolesClient.BaseClient.Delete(): %v", err)
+		}
+	}
+	return status, nil
+}
+
+// GetMember retrieves a single member of the specified DirectoryRole.
+// directoryRoleId is the object ID of the directory role.
+// memberId is the object ID of the member object.
+func (c *DirectoryRolesClient) GetMember(ctx context.Context, directoryRoleId, memberId string) (*string, int, error) {
+	resp, status, _, err := c.BaseClient.Get(ctx, GetHttpRequestInput{
+		ValidStatusCodes: []int{http.StatusOK},
+		Uri: Uri{
+			Entity:      fmt.Sprintf("/directoryRoles/%s/members/%s/$ref", directoryRoleId, memberId),
+			Params:      url.Values{"$select": []string{"id,url"}},
+			HasTenantId: true,
+		},
+	})
+	if err != nil {
+		return nil, status, fmt.Errorf("DirectoryRolesClient.BaseClient.Get(): %v", err)
+	}
+	defer resp.Body.Close()
+	respBody, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, status, fmt.Errorf("ioutil.ReadAll(): %v", err)
+	}
+	var data struct {
+		Context string `json:"@odata.context"`
+		Type    string `json:"@odata.type"`
+		Id      string `json:"id"`
+		Url     string `json:"url"`
+	}
+	if err := json.Unmarshal(respBody, &data); err != nil {
+		return nil, status, fmt.Errorf("json.Unmarshal(): %v", err)
+	}
+	return &data.Id, status, nil
+}

--- a/msgraph/directory_roles_test.go
+++ b/msgraph/directory_roles_test.go
@@ -1,0 +1,141 @@
+package msgraph_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/manicminer/hamilton/auth"
+	"github.com/manicminer/hamilton/internal/test"
+	"github.com/manicminer/hamilton/internal/utils"
+	"github.com/manicminer/hamilton/msgraph"
+)
+
+type DirectoryRolesClientTest struct {
+	connection   *test.Connection
+	client       *msgraph.DirectoryRolesClient
+	randomString string
+}
+
+func TestDirectoryRolesClient(t *testing.T) {
+	rs := test.RandomString()
+	// set up groups test client
+	groupsClient := GroupsClientTest{
+		connection:   test.NewConnection(auth.MsGraph, auth.TokenVersion2),
+		randomString: rs,
+	}
+	groupsClient.client = msgraph.NewGroupsClient(groupsClient.connection.AuthConfig.TenantID)
+	groupsClient.client.BaseClient.Authorizer = groupsClient.connection.Authorizer
+
+	// set up directory roles test client
+	dirRolesClient := DirectoryRolesClientTest{
+		connection:   test.NewConnection(auth.MsGraph, auth.TokenVersion2),
+		randomString: rs,
+	}
+	dirRolesClient.client = msgraph.NewDirectoryRolesClient(dirRolesClient.connection.AuthConfig.TenantID)
+	dirRolesClient.client.BaseClient.Authorizer = dirRolesClient.connection.Authorizer
+
+	// list directory roles; usually at least few directory roles are activated within a tenant
+	directoryRoles := testDirectoryRolesClient_List(t, dirRolesClient)
+	directoryRole := (*directoryRoles)[0]
+	testDirectoryRolesClient_Get(t, dirRolesClient, *directoryRole.ID)
+
+	// create a new test group which can be later assigned as a member of the previously listed directory role
+	newGroup := msgraph.Group{
+		DisplayName:     utils.StringPtr("Test Group"),
+		MailEnabled:     utils.BoolPtr(false),
+		MailNickname:    utils.StringPtr(fmt.Sprintf("test-group-%s", groupsClient.randomString)),
+		SecurityEnabled: utils.BoolPtr(true),
+		// required attribute to set if you plan to assign a directory role to an object (e.g. user, group etc)
+		// can be only set on a group creation using MS Graph Beta API
+		IsAssignableToRole: utils.BoolPtr(true),
+	}
+	group := testGroupsClient_Create(t, groupsClient, newGroup)
+
+	// add the test group as a member of directory role
+	directoryRole.AppendMember(dirRolesClient.client.BaseClient.Endpoint, dirRolesClient.client.BaseClient.ApiVersion, *group.ID)
+	testDirectoryRolesClient_AddMembers(t, dirRolesClient, &directoryRole)
+
+	// list members of the directory role; then remove all members to clean up
+	members := testDirectoryRolesClient_ListMembers(t, dirRolesClient, *directoryRole.ID)
+	testDirectoryRolesClient_GetMember(t, dirRolesClient, *directoryRole.ID, (*members)[0])
+	testDirectoryRolesClient_RemoveMembers(t, dirRolesClient, *directoryRole.ID, members)
+
+	// remove the test group to clean up
+	testGroupsClient_Delete(t, groupsClient, *group.ID)
+}
+
+func testDirectoryRolesClient_List(t *testing.T, c DirectoryRolesClientTest) (directoryRoles *[]msgraph.DirectoryRole) {
+	directoryRoles, _, err := c.client.List(c.connection.Context)
+	if err != nil {
+		t.Fatalf("DirectoryRolesClient.List(): %v", err)
+	}
+	if directoryRoles == nil {
+		t.Fatal("DirectoryRolesClient.List(): directoryRoles was nil")
+	}
+	return
+}
+
+func testDirectoryRolesClient_Get(t *testing.T, c DirectoryRolesClientTest, id string) (directoryRole *msgraph.DirectoryRole) {
+	directoryRole, status, err := c.client.Get(c.connection.Context, id)
+	if err != nil {
+		t.Fatalf("DirectoryRolesClient.Get(): %v", err)
+	}
+	if status < 200 || status >= 300 {
+		t.Fatalf("DirectoryRolesClient.Get(): invalid status: %d", status)
+	}
+	if directoryRole == nil {
+		t.Fatal("DirectoryRolesClient.Get(): directoryRole was nil")
+	}
+	return
+}
+
+func testDirectoryRolesClient_ListMembers(t *testing.T, c DirectoryRolesClientTest, id string) (members *[]string) {
+	members, status, err := c.client.ListMembers(c.connection.Context, id)
+	if err != nil {
+		t.Fatalf("DirectoryRolesClient.ListMembers(): %v", err)
+	}
+	if status < 200 || status >= 300 {
+		t.Fatalf("DirectoryRolesClient.ListMembers(): invalid status: %d", status)
+	}
+	if members == nil {
+		t.Fatal("DirectoryRolesClient.ListMembers(): members was nil")
+	}
+	if len(*members) == 0 {
+		t.Fatal("DirectoryRolesClient.ListMembers(): members was empty")
+	}
+	return
+}
+
+func testDirectoryRolesClient_GetMember(t *testing.T, c DirectoryRolesClientTest, dirRoleId string, memberId string) (member *string) {
+	member, status, err := c.client.GetMember(c.connection.Context, dirRoleId, memberId)
+	if err != nil {
+		t.Fatalf("DirectoryRolesClient.GetMember(): %v", err)
+	}
+	if status < 200 || status >= 300 {
+		t.Fatalf("DirectoryRolesClient.GetMember(): invalid status: %d", status)
+	}
+	if member == nil {
+		t.Fatal("DirectoryRolesClient.GetMember(): member was nil")
+	}
+	return
+}
+
+func testDirectoryRolesClient_RemoveMembers(t *testing.T, c DirectoryRolesClientTest, dirRoleId string, memberIds *[]string) {
+	status, err := c.client.RemoveMembers(c.connection.Context, dirRoleId, memberIds)
+	if err != nil {
+		t.Fatalf("DirectoryRolesClient.RemoveMembers(): %v", err)
+	}
+	if status < 200 || status >= 300 {
+		t.Fatalf("DirectoryRolesClient.RemoveMembers(): invalid status: %d", status)
+	}
+}
+
+func testDirectoryRolesClient_AddMembers(t *testing.T, c DirectoryRolesClientTest, dirRole *msgraph.DirectoryRole) {
+	status, err := c.client.AddMembers(c.connection.Context, dirRole)
+	if err != nil {
+		t.Fatalf("DirectoryRolesClient.AddMembers(): %v", err)
+	}
+	if status < 200 || status >= 300 {
+		t.Fatalf("DirectoryRolesClient.AddMembers(): invalid status: %d", status)
+	}
+}

--- a/msgraph/models.go
+++ b/msgraph/models.go
@@ -329,6 +329,26 @@ type DirectoryRoleTemplate struct {
 	DisplayName     *string    `json:"displayName,omitempty"`
 }
 
+type DirectoryRole struct {
+	ID             *string `json:"id,omitempty"`
+	Description    *string `json:"description,omitempty"`
+	DisplayName    *string `json:"displayName,omitempty"`
+	RoleTemplateId *string `json:"roleTemplateId,omitempty"`
+
+	Members *[]string `json:"-"`
+}
+
+// AppendMember appends a new member object URI to the Members slice.
+func (d *DirectoryRole) AppendMember(endpoint environments.ApiEndpoint, apiVersion ApiVersion, id string) {
+	val := fmt.Sprintf("%s/%s/directoryObjects/%s", endpoint, apiVersion, id)
+	var members []string
+	if d.Members != nil {
+		members = *d.Members
+	}
+	members = append(members, val)
+	d.Members = &members
+}
+
 // Domain describes a Domain object.
 type Domain struct {
 	ID                               *string   `json:"id,omitempty"`
@@ -396,6 +416,7 @@ type Group struct {
 	Theme                         *string                             `json:"theme,omitempty"`
 	UnseenCount                   *int                                `json:"unseenCount,omitempty"`
 	Visibility                    *string                             `json:"visibility,omitempty"`
+	IsAssignableToRole            *bool                               `json:"isAssignableToRole,omitempty"`
 
 	Members *[]string `json:"members@odata.bind,omitempty"`
 	Owners  *[]string `json:"owners@odata.bind,omitempty"`


### PR DESCRIPTION
@manicminer thanks for merging the PR regarding the directory role templates. The next model which makes sense for me to add support for are the directory roles. 

This PR adds basic support for the following operation on the directory role object:
- listing activated directory roles within a tenant; only activated directory roles are available for listing/retrieving. A separate PR will follow adding support to activate the directory role template within a tenant. 
- retrieving a directory role by id
- listing, retrieving and updating members of a directory role

Notes: 
- API for the directory roles do not support PATCH so updating members in batches is not possible afaiu 
- Groups model was updated with an `IsAssignableToRole` attribute available only in the MS Graph Beta API. Groups client is already using beta API so there was no need for change. This attribute can be set only on the group's creation. It is also required to be set for directory role assignment. This operation is part of the tests.  
- Directory role assignments require at least P1 Azure AD Premium level

