### PR TITLE
add support for identity providers

### DIFF
--- a/msgraph/identity_providers.go
+++ b/msgraph/identity_providers.go
@@ -1,0 +1,163 @@
+package msgraph
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+)
+
+// IdentityProvidersClient performs operations on IdentityProviders.
+type IdentityProvidersClient struct {
+	BaseClient Client
+}
+
+// NewIdentityProvidersClient returns a new IdentityProvidersClient
+func NewIdentityProvidersClient(tenantId string) *IdentityProvidersClient {
+	return &IdentityProvidersClient{
+		BaseClient: NewClient(VersionBeta, tenantId),
+	}
+}
+
+// List returns a list of IdentityProviders.
+func (c *IdentityProvidersClient) List(ctx context.Context) (*[]IdentityProvider, int, error) {
+	resp, status, _, err := c.BaseClient.Get(ctx, GetHttpRequestInput{
+		ValidStatusCodes: []int{http.StatusOK},
+		Uri: Uri{
+			Entity:      "/identity/identityProviders",
+			HasTenantId: true,
+		},
+	})
+	if err != nil {
+		return nil, status, fmt.Errorf("IdentityProvidersClient.BaseClient.Get(): %v", err)
+	}
+	defer resp.Body.Close()
+	respBody, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, status, fmt.Errorf("ioutil.ReadAll(): %v", err)
+	}
+	var data struct {
+		IdentityProviders []IdentityProvider `json:"value"`
+	}
+	if err := json.Unmarshal(respBody, &data); err != nil {
+		return nil, status, fmt.Errorf("json.Unmarshal(): %v", err)
+	}
+	return &data.IdentityProviders, status, nil
+}
+
+// Create creates a new IdentityProvider.
+func (c *IdentityProvidersClient) Create(ctx context.Context, provider IdentityProvider) (*IdentityProvider, int, error) {
+	var status int
+	body, err := json.Marshal(provider)
+	if err != nil {
+		return nil, status, fmt.Errorf("json.Marshal(): %v", err)
+	}
+	resp, status, _, err := c.BaseClient.Post(ctx, PostHttpRequestInput{
+		Body:             body,
+		ValidStatusCodes: []int{http.StatusCreated},
+		Uri: Uri{
+			Entity:      "/identity/identityProviders",
+			HasTenantId: true,
+		},
+	})
+	if err != nil {
+		return nil, status, fmt.Errorf("IdentityProvidersClient.BaseClient.Post(): %v", err)
+	}
+	defer resp.Body.Close()
+	respBody, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, status, fmt.Errorf("ioutil.ReadAll(): %v", err)
+	}
+	var newProvider IdentityProvider
+	if err := json.Unmarshal(respBody, &newProvider); err != nil {
+		return nil, status, fmt.Errorf("json.Unmarshal(): %v", err)
+	}
+	return &newProvider, status, nil
+}
+
+// Get retrieves an IdentityProvider.
+func (c *IdentityProvidersClient) Get(ctx context.Context, id string) (*IdentityProvider, int, error) {
+	resp, status, _, err := c.BaseClient.Get(ctx, GetHttpRequestInput{
+		ValidStatusCodes: []int{http.StatusOK},
+		Uri: Uri{
+			Entity:      fmt.Sprintf("/identity/identityProviders/%s", id),
+			HasTenantId: true,
+		},
+	})
+	if err != nil {
+		return nil, status, fmt.Errorf("IdentityProvidersClient.BaseClient.Get(): %v", err)
+	}
+	defer resp.Body.Close()
+	respBody, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, status, fmt.Errorf("ioutil.ReadAll(): %v", err)
+	}
+	var provider IdentityProvider
+	if err := json.Unmarshal(respBody, &provider); err != nil {
+		return nil, status, fmt.Errorf("json.Unmarshal(): %v", err)
+	}
+	return &provider, status, nil
+}
+
+// Update amends an existing IdentityProvider.
+func (c *IdentityProvidersClient) Update(ctx context.Context, provider IdentityProvider) (int, error) {
+	var status int
+	body, err := json.Marshal(provider)
+	if err != nil {
+		return status, fmt.Errorf("json.Marshal(): %v", err)
+	}
+	_, status, _, err = c.BaseClient.Patch(ctx, PatchHttpRequestInput{
+		Body:             body,
+		ValidStatusCodes: []int{http.StatusNoContent},
+		Uri: Uri{
+			Entity:      fmt.Sprintf("/identity/identityProviders/%s", *provider.ID),
+			HasTenantId: true,
+		},
+	})
+	if err != nil {
+		return status, fmt.Errorf("IdentityProvidersClient.BaseClient.Patch(): %v", err)
+	}
+	return status, nil
+}
+
+// Delete removes a IdentityProvider.
+func (c *IdentityProvidersClient) Delete(ctx context.Context, id string) (int, error) {
+	_, status, _, err := c.BaseClient.Delete(ctx, DeleteHttpRequestInput{
+		ValidStatusCodes: []int{http.StatusNoContent},
+		Uri: Uri{
+			Entity:      fmt.Sprintf("/identity/identityProviders/%s", id),
+			HasTenantId: true,
+		},
+	})
+	if err != nil {
+		return status, fmt.Errorf("IdentityProvidersClient.BaseClient.Delete(): %v", err)
+	}
+	return status, nil
+}
+
+// List returns a list of all available identity provider types.
+func (c *IdentityProvidersClient) ListAvailableProviderTypes(ctx context.Context) (*[]string, int, error) {
+	resp, status, _, err := c.BaseClient.Get(ctx, GetHttpRequestInput{
+		ValidStatusCodes: []int{http.StatusOK},
+		Uri: Uri{
+			Entity:      "/identity/identityProviders/availableProviderTypes",
+			HasTenantId: true,
+		},
+	})
+	if err != nil {
+		return nil, status, fmt.Errorf("IdentityProvidersClient.BaseClient.Get(): %v", err)
+	}
+	defer resp.Body.Close()
+	respBody, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, status, fmt.Errorf("ioutil.ReadAll(): %v", err)
+	}
+	var data struct {
+		IdentityProviderTypes []string `json:"value"`
+	}
+	if err := json.Unmarshal(respBody, &data); err != nil {
+		return nil, status, fmt.Errorf("json.Unmarshal(): %v", err)
+	}
+	return &data.IdentityProviderTypes, status, nil
+}

--- a/msgraph/identity_providers.go
+++ b/msgraph/identity_providers.go
@@ -103,6 +103,9 @@ func (c *IdentityProvidersClient) Get(ctx context.Context, id string) (*Identity
 // Update amends an existing IdentityProvider.
 func (c *IdentityProvidersClient) Update(ctx context.Context, provider IdentityProvider) (int, error) {
 	var status int
+	if provider.ID == nil {
+		return status, errors.New("IdentityProvidersClient.Update(): cannot update identity provider with nil ID")
+	}
 	body, err := json.Marshal(provider)
 	if err != nil {
 		return status, fmt.Errorf("json.Marshal(): %v", err)

--- a/msgraph/identity_providers.go
+++ b/msgraph/identity_providers.go
@@ -3,6 +3,7 @@ package msgraph
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"

--- a/msgraph/identity_providers_test.go
+++ b/msgraph/identity_providers_test.go
@@ -42,6 +42,8 @@ func TestIdentityProvidersClientClient(t *testing.T) {
 	patchIdentityProvider.ClientSecret = utils.StringPtr("1111111111111")
 	testIdentityProvidersClient_Update(t, c, *patchIdentityProvider)
 
+	testIdentityProvidersClient_List(t, c)
+
 	testIdentityProvidersClient_Delete(t, c, *identityProvider.ID)
 }
 
@@ -120,6 +122,4 @@ func testIdentityProvidersClient_ListAvailableProviderTypes(t *testing.T, c Iden
 	if len(*availableIdentityProviders) == 0 {
 		t.Fatal("IdentityProvidersClient.ListAvailableProviderTypes(): expected availableIdentityProviders at least one available provider")
 	}
-
-	return
 }

--- a/msgraph/identity_providers_test.go
+++ b/msgraph/identity_providers_test.go
@@ -1,0 +1,125 @@
+package msgraph_test
+
+import (
+	"testing"
+
+	"github.com/manicminer/hamilton/auth"
+	"github.com/manicminer/hamilton/internal/test"
+	"github.com/manicminer/hamilton/internal/utils"
+	"github.com/manicminer/hamilton/msgraph"
+)
+
+type IdentityProvidersClientTest struct {
+	connection   *test.Connection
+	client       *msgraph.IdentityProvidersClient
+	randomString string
+}
+
+func TestIdentityProvidersClientClient(t *testing.T) {
+	rs := test.RandomString()
+	c := IdentityProvidersClientTest{
+		connection:   test.NewConnection(auth.MsGraph, auth.TokenVersion2),
+		randomString: rs,
+	}
+	c.client = msgraph.NewIdentityProvidersClient(c.connection.AuthConfig.TenantID)
+	c.client.BaseClient.Authorizer = c.connection.Authorizer
+
+	testIdentityProvidersClient_ListAvailableProviderTypes(t, c)
+
+	identityProvider := testIdentityProvidersClient_Create(t, c, msgraph.IdentityProvider{
+		ODataType:    utils.StringPtr("microsoft.graph.socialIdentityProvider"),
+		Name:         utils.StringPtr("Login with Google"),
+		Type:         utils.StringPtr("Google"),
+		ClientId:     utils.StringPtr("56433757-cadd-4135-8431-2c9e3fd68ae8"),
+		ClientSecret: utils.StringPtr("000000000000"),
+	})
+
+	testIdentityProvidersClient_Get(t, c, *identityProvider.ID)
+
+	patchIdentityProvider := &msgraph.IdentityProvider{}
+	patchIdentityProvider.ODataType = identityProvider.ODataType
+	patchIdentityProvider.ID = identityProvider.ID
+	patchIdentityProvider.ClientSecret = utils.StringPtr("1111111111111")
+	testIdentityProvidersClient_Update(t, c, *patchIdentityProvider)
+
+	testIdentityProvidersClient_Delete(t, c, *identityProvider.ID)
+}
+
+func testIdentityProvidersClient_Create(t *testing.T, c IdentityProvidersClientTest, p msgraph.IdentityProvider) (provider *msgraph.IdentityProvider) {
+	provider, status, err := c.client.Create(c.connection.Context, p)
+	if err != nil {
+		t.Fatalf("IdentityProvidersClient.Create(): %v", err)
+	}
+	if status < 200 || status >= 300 {
+		t.Fatalf("IdentityProvidersClient.Create(): invalid status: %d", status)
+	}
+	if provider == nil {
+		t.Fatal("IdentityProvidersClient.Create(): provider was nil")
+	}
+	if provider.ID == nil {
+		t.Fatal("IdentityProvidersClient.Create(): provider.ID was nil")
+	}
+	return
+}
+
+func testIdentityProvidersClient_Update(t *testing.T, c IdentityProvidersClientTest, p msgraph.IdentityProvider) {
+	status, err := c.client.Update(c.connection.Context, p)
+	if err != nil {
+		t.Fatalf("IdentityProvidersClient.Update(): %v", err)
+	}
+	if status < 200 || status >= 300 {
+		t.Fatalf("IdentityProvidersClient.Update(): invalid status: %d", status)
+	}
+}
+
+func testIdentityProvidersClient_List(t *testing.T, c IdentityProvidersClientTest) (providers *[]msgraph.IdentityProvider) {
+	providers, _, err := c.client.List(c.connection.Context)
+	if err != nil {
+		t.Fatalf("IdentityProvidersClient.List(): %v", err)
+	}
+	if providers == nil {
+		t.Fatal("IdentityProvidersClient.List(): providers was nil")
+	}
+	return
+}
+
+func testIdentityProvidersClient_Get(t *testing.T, c IdentityProvidersClientTest, id string) (provider *msgraph.IdentityProvider) {
+	provider, status, err := c.client.Get(c.connection.Context, id)
+	if err != nil {
+		t.Fatalf("IdentityProvidersClient.Get(): %v", err)
+	}
+	if status < 200 || status >= 300 {
+		t.Fatalf("IdentityProvidersClient.Get(): invalid status: %d", status)
+	}
+	if provider == nil {
+		t.Fatal("IdentityProvidersClient.Get(): provider was nil")
+	}
+	return
+}
+
+func testIdentityProvidersClient_Delete(t *testing.T, c IdentityProvidersClientTest, id string) {
+	status, err := c.client.Delete(c.connection.Context, id)
+	if err != nil {
+		t.Fatalf("IdentityProvidersClient.Delete(): %v", err)
+	}
+	if status < 200 || status >= 300 {
+		t.Fatalf("IdentityProvidersClient.Delete(): invalid status: %d", status)
+	}
+}
+
+func testIdentityProvidersClient_ListAvailableProviderTypes(t *testing.T, c IdentityProvidersClientTest) {
+	availableIdentityProviders, _, err := c.client.ListAvailableProviderTypes(c.connection.Context)
+	if err != nil {
+		t.Fatalf("IdentityProvidersClient.ListAvailableProviderTypes(): %v", err)
+	}
+
+	if availableIdentityProviders == nil {
+		t.Fatal("IdentityProvidersClient.ListAvailableProviderTypes(): availableIdentityProviders was nil")
+	}
+
+	if len(*availableIdentityProviders) == 0 {
+		t.Fatal("IdentityProvidersClient.ListAvailableProviderTypes(): expected availableIdentityProviders at least one available provider")
+	}
+
+	return
+}

--- a/msgraph/identity_providers_test.go
+++ b/msgraph/identity_providers_test.go
@@ -96,7 +96,10 @@ func testIdentityProvidersClient_Get(t *testing.T, c IdentityProvidersClientTest
 	if provider == nil {
 		t.Fatal("IdentityProvidersClient.Get(): provider was nil")
 	}
-	return
+	if provider.ID == nil {
+		t.Fatal("IdentityProvidersClient.Create(): provider.ID was nil")
+	}
+		return
 }
 
 func testIdentityProvidersClient_Delete(t *testing.T, c IdentityProvidersClientTest, id string) {

--- a/msgraph/identity_providers_test.go
+++ b/msgraph/identity_providers_test.go
@@ -15,7 +15,7 @@ type IdentityProvidersClientTest struct {
 	randomString string
 }
 
-func TestIdentityProvidersClientClient(t *testing.T) {
+func TestIdentityProvidersClient(t *testing.T) {
 	rs := test.RandomString()
 	c := IdentityProvidersClientTest{
 		connection:   test.NewConnection(auth.MsGraph, auth.TokenVersion2),

--- a/msgraph/models.go
+++ b/msgraph/models.go
@@ -912,3 +912,12 @@ const (
 	BodyTypeText BodyType = "text"
 	BodyTypeHtml BodyType = "html"
 )
+
+type IdentityProvider struct {
+	ODataType    *string `json:"@odata.type,omitempty"`
+	ID           *string `json:"id,omitempty"`
+	ClientId     *string `json:"clientId,omitempty"`
+	ClientSecret *string `json:"clientSecret,omitempty"`
+	Type         *string `json:"identityProviderType,omitempty"`
+	Name         *string `json:"displayName,omitempty"`
+}


### PR DESCRIPTION
Add support for identity providers

- implements the [new endpoint](https://docs.microsoft.com/en-us/graph/api/resources/identityproviderbase?view=graph-rest-beta) in the beta API ([old endpoint for reference](https://docs.microsoft.com/en-us/graph/api/resources/identityprovider?view=graph-rest-beta))
- implements the List, Create, Get, Update, Delete and ListAvailableProviderTypes methods
- requires authentication with IdentityProvider.ReadWrite.All permission/scope
