### PR TITLE
Add support for service principal app role add, update and remove

### DIFF
--- a/msgraph/models.go
+++ b/msgraph/models.go
@@ -159,6 +159,31 @@ func (a *Application) AppendAppRole(role AppRole) error {
 	return nil
 }
 
+// AppendAppRole adds a new AppRole to a Service Principal, checking to see if it already exists.
+func (s *ServicePrincipal) AppendAppRole(role AppRole) error {
+	if role.ID == nil {
+		return goerrors.New("ID of new role is nil")
+	}
+
+	cap := 1
+	if s.AppRoles != nil {
+		cap += len(*s.AppRoles)
+	}
+
+	newRoles := make([]AppRole, 1, cap)
+	newRoles[0] = role
+
+	for _, v := range *s.AppRoles {
+		if v.ID != nil && *v.ID == *role.ID {
+			return &errors.AlreadyExistsError{Obj: "AppRole", Id: *role.ID}
+		}
+		newRoles = append(newRoles, v)
+	}
+
+	s.AppRoles = &newRoles
+	return nil
+}
+
 // RemoveAppRole removes an AppRole from an Application.
 func (a *Application) RemoveAppRole(role AppRole) error {
 	if role.ID == nil {
@@ -184,6 +209,31 @@ func (a *Application) RemoveAppRole(role AppRole) error {
 	return nil
 }
 
+// RemoveAppRole removes an AppRole from a ServicePrincipal.
+func (s *ServicePrincipal) RemoveAppRole(role AppRole) error {
+	if role.ID == nil {
+		return goerrors.New("ID of role is nil")
+	}
+
+	if s.AppRoles == nil {
+		return goerrors.New("no roles to remove")
+	}
+
+	appRoles := make([]AppRole, 0, len(*s.AppRoles))
+	for _, v := range *s.AppRoles {
+		if v.ID == nil || *v.ID != *role.ID {
+			appRoles = append(appRoles, v)
+		}
+	}
+
+	if len(appRoles) == len(*s.AppRoles) {
+		return goerrors.New("could not find role to remove")
+	}
+
+	s.AppRoles = &appRoles
+	return nil
+}
+
 // UpdateAppRole amends an existing AppRole defined in an Application.
 func (a *Application) UpdateAppRole(role AppRole) error {
 	if role.ID == nil {
@@ -203,6 +253,28 @@ func (a *Application) UpdateAppRole(role AppRole) error {
 	}
 
 	a.AppRoles = &appRoles
+	return nil
+}
+
+// UpdateAppRole amends an existing AppRole defined in a ServicePrincipal.
+func (s *ServicePrincipal) UpdateAppRole(role AppRole) error {
+	if role.ID == nil {
+		return goerrors.New("ID of role is nil")
+	}
+
+	if s.AppRoles == nil {
+		return goerrors.New("no roles to update")
+	}
+
+	appRoles := *s.AppRoles
+	for i, v := range appRoles {
+		if v.ID != nil && *v.ID == *role.ID {
+			appRoles[i] = role
+			break
+		}
+	}
+
+	s.AppRoles = &appRoles
 	return nil
 }
 

--- a/msgraph/models_test.go
+++ b/msgraph/models_test.go
@@ -1,0 +1,133 @@
+package msgraph_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/manicminer/hamilton/internal/test"
+	"github.com/manicminer/hamilton/internal/utils"
+	"github.com/manicminer/hamilton/msgraph"
+)
+
+func TestApplicationAppRoleModel(t *testing.T) {
+	a := msgraph.Application{
+		DisplayName: utils.StringPtr(fmt.Sprintf("test-application-%s", test.RandomString())),
+		AppRoles:    &[]msgraph.AppRole{},
+	}
+	testAppRoleId, _ := uuid.GenerateUUID()
+	appRole := &msgraph.AppRole{
+		ID:        utils.StringPtr(testAppRoleId),
+		IsEnabled: utils.BoolPtr(true),
+	}
+	a = testApplicationAppRole_append(t, a, appRole)
+	a = testApplicationAppRole_update(t, a, appRole)
+	testApplicationAppRole_remove(t, a, appRole)
+
+}
+
+func testApplicationAppRole_append(t *testing.T, application msgraph.Application, appRole *msgraph.AppRole) msgraph.Application {
+	if err := application.AppendAppRole(*appRole); err != nil {
+		t.Fatalf("Application.AppendAppRole(): %t", err)
+	}
+	if application.AppRoles == nil {
+		t.Fatal("Application.AppendAppRole(): application.AppRoles was nil")
+	}
+	if len(*application.AppRoles) != 1 {
+		t.Fatal("Application.AppendAppRole(): application.AppRoles did not contain 1 app role")
+	}
+	if (*application.AppRoles)[0].ID != appRole.ID {
+		t.Fatal("Application.AppendAppRole(): application.AppRoles does not contain new app role")
+	}
+	return application
+}
+
+func testApplicationAppRole_update(t *testing.T, application msgraph.Application, appRole *msgraph.AppRole) msgraph.Application {
+	appRole.IsEnabled = utils.BoolPtr(false)
+	if err := application.UpdateAppRole(*appRole); err != nil {
+		t.Fatalf("Application.UpdateAppRole(): %t", err)
+	}
+	if application.AppRoles == nil {
+		t.Fatal("Application.UpdateAppRole(): application.AppRoles was nil")
+	}
+	if len(*application.AppRoles) != 1 {
+		t.Fatal("Application.UpdateAppRole(): application.AppRoles did not contain 1 app role")
+	}
+	if (*application.AppRoles)[0].IsEnabled != appRole.IsEnabled {
+		t.Fatal("Application.UpdateAppRole(): application.AppRoles does not contain updated role")
+	}
+	return application
+}
+
+func testApplicationAppRole_remove(t *testing.T, application msgraph.Application, appRole *msgraph.AppRole) {
+	if err := application.RemoveAppRole(*appRole); err != nil {
+		t.Fatalf("Application.RemoveAppRole(): %t", err)
+	}
+	if application.AppRoles == nil {
+		t.Fatal("Application.RemoveAppRole(): application.AppRoles was nil")
+	}
+	if len(*application.AppRoles) != 0 {
+		t.Fatal("Application.RemoveAppRole(): application.AppRoles is not empty")
+	}
+}
+
+func TestServicePrincipalAppRoleModel(t *testing.T) {
+	s := msgraph.ServicePrincipal{
+		DisplayName: utils.StringPtr(fmt.Sprintf("test-servicePrincipal-%s", test.RandomString())),
+		AppRoles:    &[]msgraph.AppRole{},
+	}
+	testAppRoleId, _ := uuid.GenerateUUID()
+	appRole := &msgraph.AppRole{
+		ID:        utils.StringPtr(testAppRoleId),
+		IsEnabled: utils.BoolPtr(true),
+	}
+	s = testServicePrincipalAppRole_append(t, s, appRole)
+	s = testServicePrincipalAppRole_update(t, s, appRole)
+	testServicePrincipalAppRole_remove(t, s, appRole)
+
+}
+
+func testServicePrincipalAppRole_append(t *testing.T, servicePrincipal msgraph.ServicePrincipal, appRole *msgraph.AppRole) msgraph.ServicePrincipal {
+	if err := servicePrincipal.AppendAppRole(*appRole); err != nil {
+		t.Fatalf("ServicePrincipal.AppendAppRole(): %t", err)
+	}
+	if servicePrincipal.AppRoles == nil {
+		t.Fatal("ServicePrincipal.AppendAppRole(): servicePrincipal.AppRoles was nil")
+	}
+	if len(*servicePrincipal.AppRoles) != 1 {
+		t.Fatal("ServicePrincipal.AppendAppRole(): servicePrincipal.AppRoles did not contain 1 app role")
+	}
+	if (*servicePrincipal.AppRoles)[0].ID != appRole.ID {
+		t.Fatal("ServicePrincipal.AppendAppRole(): servicePrincipal.AppRoles does not contain new app role")
+	}
+	return servicePrincipal
+}
+
+func testServicePrincipalAppRole_update(t *testing.T, servicePrincipal msgraph.ServicePrincipal, appRole *msgraph.AppRole) msgraph.ServicePrincipal {
+	appRole.IsEnabled = utils.BoolPtr(false)
+	if err := servicePrincipal.UpdateAppRole(*appRole); err != nil {
+		t.Fatalf("ServicePrincipal.UpdateAppRole(): %t", err)
+	}
+	if servicePrincipal.AppRoles == nil {
+		t.Fatal("ServicePrincipal.UpdateAppRole(): servicePrincipal.AppRoles was nil")
+	}
+	if len(*servicePrincipal.AppRoles) != 1 {
+		t.Fatal("ServicePrincipal.UpdateAppRole(): servicePrincipal.AppRoles did not contain 1 app role")
+	}
+	if (*servicePrincipal.AppRoles)[0].IsEnabled != appRole.IsEnabled {
+		t.Fatal("ServicePrincipal.UpdateAppRole(): servicePrincipal.AppRoles does not contain updated role")
+	}
+	return servicePrincipal
+}
+
+func testServicePrincipalAppRole_remove(t *testing.T, servicePrincipal msgraph.ServicePrincipal, appRole *msgraph.AppRole) {
+	if err := servicePrincipal.RemoveAppRole(*appRole); err != nil {
+		t.Fatalf("ServicePrincipal.RemoveAppRole(): %t", err)
+	}
+	if servicePrincipal.AppRoles == nil {
+		t.Fatal("ServicePrincipal.RemoveAppRole(): servicePrincipal.AppRoles was nil")
+	}
+	if len(*servicePrincipal.AppRoles) != 0 {
+		t.Fatal("ServicePrincipal.RemoveAppRole(): servicePrincipal.AppRoles is not empty")
+	}
+}


### PR DESCRIPTION
- Add support for service principal app role add, update and remove
- Added very simple tests for app role manipulation for applications and service principals


N.B. I am not an active contributor and relatively new to the golang community, I welcome any feedback 