### PR TITLE
Fix body marshalling for addPassword

### DIFF
--- a/msgraph/applications.go
+++ b/msgraph/applications.go
@@ -151,7 +151,11 @@ func (c *ApplicationsClient) Delete(ctx context.Context, id string) (int, error)
 // AddPassword appends a new password credential to an Application.
 func (c *ApplicationsClient) AddPassword(ctx context.Context, applicationId string, passwordCredential PasswordCredential) (*PasswordCredential, int, error) {
 	var status int
-	body, err := json.Marshal(passwordCredential)
+	body, err := json.Marshal(struct {
+		PwdCredential PasswordCredential `json:"passwordCredential"`
+	}{
+		PwdCredential: passwordCredential,
+	})
 	if err != nil {
 		return nil, status, fmt.Errorf("json.Marshal(): %v", err)
 	}

--- a/msgraph/applications_test.go
+++ b/msgraph/applications_test.go
@@ -183,6 +183,9 @@ func testApplicationsClient_AddPassword(t *testing.T, c ApplicationsClientTest, 
 	if newPwd.SecretText == nil || len(*newPwd.SecretText) == 0 {
 		t.Fatalf("ApplicationsClient.AddPassword(): nil or empty secretText returned by API")
 	}
+	if *newPwd.DisplayName != *pwd.DisplayName {
+		t.Fatalf("ApplicationsClient.AddPassword(): password names do not match")
+	}
 	return newPwd
 }
 

--- a/msgraph/serviceprincipals.go
+++ b/msgraph/serviceprincipals.go
@@ -337,7 +337,11 @@ func (c *ServicePrincipalsClient) ListGroupMemberships(ctx context.Context, id s
 // AddPassword appends a new password credential to a Service Principal.
 func (c *ServicePrincipalsClient) AddPassword(ctx context.Context, servicePrincipalId string, passwordCredential PasswordCredential) (*PasswordCredential, int, error) {
 	var status int
-	body, err := json.Marshal(passwordCredential)
+	body, err := json.Marshal(struct {
+		PwdCredential PasswordCredential `json:"passwordCredential"`
+	}{
+		PwdCredential: passwordCredential,
+	})
 	if err != nil {
 		return nil, status, fmt.Errorf("json.Marshal(): %v", err)
 	}

--- a/msgraph/serviceprincipals_test.go
+++ b/msgraph/serviceprincipals_test.go
@@ -183,7 +183,9 @@ func testServicePrincipalsClient_ListGroupMemberships(t *testing.T, c ServicePri
 }
 
 func testServicePrincipalsClient_AddPassword(t *testing.T, c ServicePrincipalsClientTest, a *msgraph.ServicePrincipal) *msgraph.PasswordCredential {
-	pwd := msgraph.PasswordCredential{}
+	pwd := msgraph.PasswordCredential{
+		DisplayName: utils.StringPtr("test password"),
+	}
 	newPwd, status, err := c.client.AddPassword(c.connection.Context, *a.ID, pwd)
 	if err != nil {
 		t.Fatalf("ServicePrincipalsClient.AddPassword(): %v", err)
@@ -193,6 +195,9 @@ func testServicePrincipalsClient_AddPassword(t *testing.T, c ServicePrincipalsCl
 	}
 	if newPwd.SecretText == nil || len(*newPwd.SecretText) == 0 {
 		t.Fatalf("ServicePrincipalsClient.AddPassword(): nil or empty secretText returned by API")
+	}
+	if *newPwd.DisplayName != *pwd.DisplayName {
+		t.Fatalf("ServicePrincipalsClient.AddPassword(): password names do not match")
 	}
 	return newPwd
 }


### PR DESCRIPTION
The current `AddPassword()` implementation uses incorrect body format.
```
{
  "displayName": "new-secret-name"
}
```
This causes the inability to set custom `displayName`, `startDate`, `endDate`, etc. 
By using the current implementation, a response looks like the following:
```
{
    "@odata.context": "https://graph.microsoft.com/v1.0/$metadata#microsoft.graph.passwordCredential",
    "customKeyIdentifier": null,
    "displayName": null,                                                     
    "endDateTime": "2023-05-26T05:23:25.656173Z",  
    "hint": "e3o",
    "keyId": "2f96d8fa-ef50-463c-ab14-ba209c1417b5",
    "secretText": "*************",
    "startDateTime": "2021-05-26T05:23:25.656173Z"
}
```
In ^ this case, the name will be empty, and the expiration date will be set to default 2 years.

***
According to the Azure [doc](https://docs.microsoft.com/en-us/graph/api/serviceprincipal-addpassword?view=graph-rest-1.0&tabs=http#request), a body must be wrapped with an extra layer.
```
{
  "passwordCredential": {
    "displayName": "new-secret-name"
  }
}
```

By using the new implementation, a response looks like the following:
```
{
    "@odata.context": "https://graph.microsoft.com/v1.0/$metadata#microsoft.graph.passwordCredential",
    "customKeyIdentifier": null,
    "displayName": "new-secret-name",
    "endDateTime": "2022-05-26T05:31:58.1922512Z",
    "hint": "38B",
    "keyId": "bef3bd9e-08bb-4db3-a724-1a8963e38156",
    "secretText": "********",
    "startDateTime": "2021-05-26T05:31:58.1922512Z"
}
```

Adapted the test cases to cover this scenario.