### PR TITLE
Implement retry for user deletion

### DIFF
--- a/msgraph/users.go
+++ b/msgraph/users.go
@@ -140,6 +140,7 @@ func (c *UsersClient) Delete(ctx context.Context, id string) (int, error) {
 		},
 	}
 
+	// TODO: Add a proper retry mechanism in the perforRequest function
 	retryDeletion := func(resp *http.Response, o *odata.OData) bool {
 		retries := 3
 		backoff := 2 * time.Second
@@ -147,8 +148,8 @@ func (c *UsersClient) Delete(ctx context.Context, id string) (int, error) {
 		if resp.StatusCode == http.StatusNotFound {
 			for retry := 0; retry < retries; retry++ {
 				time.Sleep(backoff)
-				_, _, _, err := c.BaseClient.Delete(ctx, input)
-				if err == nil {
+				_, status, _, err := c.BaseClient.Delete(ctx, input)
+				if err == nil && containsStatusCode(input.ValidStatusCodes, status) {
 					return true
 				}
 			}


### PR DESCRIPTION
Implementing retry for user deletion due to Graph API inconsistency when deleting a user right after creating it.

The API will return a 200 status code on the GET request indicating that the user has been created. However if you call the DELETE endpoint right after, it will return a 404 because it did not have time to spread user creation on API nodes.

After discussion with @manicminer, implementing retry here seems to be the cleaner way to handle this.

Maybe we should try to implement a proper retry mechanism in the future in the performRequest function as it only handles retries on rate-limiting related status codes for now.