### PR TITLE
Get deleted API for apps, groups, and users

### DIFF
--- a/msgraph/applications.go
+++ b/msgraph/applications.go
@@ -120,7 +120,7 @@ func (c *ApplicationsClient) GetDeleted(ctx context.Context, id string) (*Applic
 		},
 	})
 	if err != nil {
-		return nil, status, fmt.Errorf("ApplicationsClient.BaseClient.GetDeleted(): %v", err)
+		return nil, status, fmt.Errorf("ApplicationsClient.BaseClient.Get(): %v", err)
 	}
 	defer resp.Body.Close()
 	respBody, err := ioutil.ReadAll(resp.Body)

--- a/msgraph/applications.go
+++ b/msgraph/applications.go
@@ -109,6 +109,31 @@ func (c *ApplicationsClient) Get(ctx context.Context, id string) (*Application, 
 	return &application, status, nil
 }
 
+// GetDeleted retrieves a deleted Application manifest.
+// id is the object ID of the application.
+func (c *ApplicationsClient) GetDeleted(ctx context.Context, id string) (*Application, int, error) {
+	resp, status, _, err := c.BaseClient.Get(ctx, GetHttpRequestInput{
+		ValidStatusCodes: []int{http.StatusOK},
+		Uri: Uri{
+			Entity:      fmt.Sprintf("/directory/deletedItems/%s", id),
+			HasTenantId: true,
+		},
+	})
+	if err != nil {
+		return nil, status, fmt.Errorf("ApplicationsClient.BaseClient.GetDeleted(): %v", err)
+	}
+	defer resp.Body.Close()
+	respBody, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, status, fmt.Errorf("ioutil.ReadAll(): %v", err)
+	}
+	var application Application
+	if err := json.Unmarshal(respBody, &application); err != nil {
+		return nil, status, fmt.Errorf("json.Unmarshal(): %v", err)
+	}
+	return &application, status, nil
+}
+
 // Update amends the manifest of an existing Application.
 func (c *ApplicationsClient) Update(ctx context.Context, application Application) (int, error) {
 	var status int

--- a/msgraph/applications_test.go
+++ b/msgraph/applications_test.go
@@ -40,6 +40,7 @@ func TestApplicationsClient(t *testing.T) {
 	testApplicationsClient_List(t, c)
 	testApplicationsClient_Delete(t, c, *app.ID)
 	testApplicationsClient_ListDeleted(t, c, *app.ID)
+	testApplicationsClient_GetDeleted(t, c, *app.ID)
 }
 
 func TestApplicationsClient_groupMembershipClaims(t *testing.T) {
@@ -105,6 +106,20 @@ func testApplicationsClient_Get(t *testing.T, c ApplicationsClientTest, id strin
 	}
 	if application == nil {
 		t.Fatal("ApplicationsClient.Get(): application was nil")
+	}
+	return
+}
+
+func testApplicationsClient_GetDeleted(t *testing.T, c ApplicationsClientTest, id string) (application *msgraph.Application) {
+	application, status, err := c.client.GetDeleted(c.connection.Context, id)
+	if err != nil {
+		t.Fatalf("ApplicationsClient.GetDeleted(): %v", err)
+	}
+	if status < 200 || status >= 300 {
+		t.Fatalf("ApplicationsClient.GetDeleted(): invalid status: %d", status)
+	}
+	if application == nil {
+		t.Fatal("ApplicationsClient.GetDeleted(): application was nil")
 	}
 	return
 }

--- a/msgraph/groups.go
+++ b/msgraph/groups.go
@@ -108,6 +108,30 @@ func (c *GroupsClient) Get(ctx context.Context, id string) (*Group, int, error) 
 	return &group, status, nil
 }
 
+// GetDeleted retrieves a deleted O365 Group.
+func (c *GroupsClient) GetDeleted(ctx context.Context, id string) (*Group, int, error) {
+	resp, status, _, err := c.BaseClient.Get(ctx, GetHttpRequestInput{
+		ValidStatusCodes: []int{http.StatusOK},
+		Uri: Uri{
+			Entity:      fmt.Sprintf("/directory/deletedItems/%s", id),
+			HasTenantId: true,
+		},
+	})
+	if err != nil {
+		return nil, status, fmt.Errorf("GroupsClient.BaseClient.GetDeleted(): %v", err)
+	}
+	defer resp.Body.Close()
+	respBody, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, status, fmt.Errorf("ioutil.ReadAll(): %v", err)
+	}
+	var group Group
+	if err := json.Unmarshal(respBody, &group); err != nil {
+		return nil, status, fmt.Errorf("json.Unmarshal(): %v", err)
+	}
+	return &group, status, nil
+}
+
 // Update amends an existing Group.
 func (c *GroupsClient) Update(ctx context.Context, group Group) (int, error) {
 	var status int

--- a/msgraph/groups.go
+++ b/msgraph/groups.go
@@ -118,7 +118,7 @@ func (c *GroupsClient) GetDeleted(ctx context.Context, id string) (*Group, int, 
 		},
 	})
 	if err != nil {
-		return nil, status, fmt.Errorf("GroupsClient.BaseClient.GetDeleted(): %v", err)
+		return nil, status, fmt.Errorf("GroupsClient.BaseClient.Get(): %v", err)
 	}
 	defer resp.Body.Close()
 	respBody, err := ioutil.ReadAll(resp.Body)

--- a/msgraph/users.go
+++ b/msgraph/users.go
@@ -106,6 +106,30 @@ func (c *UsersClient) Get(ctx context.Context, id string) (*User, int, error) {
 	return &user, status, nil
 }
 
+// GetDeleted retrieves a deleted User.
+func (c *UsersClient) GetDeleted(ctx context.Context, id string) (*User, int, error) {
+	resp, status, _, err := c.BaseClient.Get(ctx, GetHttpRequestInput{
+		ValidStatusCodes: []int{http.StatusOK},
+		Uri: Uri{
+			Entity:      fmt.Sprintf("/directory/deletedItems/%s", id),
+			HasTenantId: true,
+		},
+	})
+	if err != nil {
+		return nil, status, fmt.Errorf("UsersClient.BaseClient.GetDeleted(): %v", err)
+	}
+	defer resp.Body.Close()
+	respBody, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, status, fmt.Errorf("ioutil.ReadAll(): %v", err)
+	}
+	var user User
+	if err := json.Unmarshal(respBody, &user); err != nil {
+		return nil, status, fmt.Errorf("json.Unmarshal(): %v", err)
+	}
+	return &user, status, nil
+}
+
 // Update amends an existing User.
 func (c *UsersClient) Update(ctx context.Context, user User) (int, error) {
 	var status int

--- a/msgraph/users.go
+++ b/msgraph/users.go
@@ -116,7 +116,7 @@ func (c *UsersClient) GetDeleted(ctx context.Context, id string) (*User, int, er
 		},
 	})
 	if err != nil {
-		return nil, status, fmt.Errorf("UsersClient.BaseClient.GetDeleted(): %v", err)
+		return nil, status, fmt.Errorf("UsersClient.BaseClient.Get(): %v", err)
 	}
 	defer resp.Body.Close()
 	respBody, err := ioutil.ReadAll(resp.Body)

--- a/msgraph/users_test.go
+++ b/msgraph/users_test.go
@@ -72,6 +72,7 @@ func TestUsersClient(t *testing.T) {
 
 	testUsersClient_Delete(t, c, *user.ID)
 	testUsersClient_ListDeleted(t, c, *user.ID)
+	testUsersClient_GetDeleted(t, c, *user.ID)
 }
 
 func testUsersClient_Create(t *testing.T, c UsersClientTest, u msgraph.User) (user *msgraph.User) {
@@ -122,6 +123,20 @@ func testUsersClient_Get(t *testing.T, c UsersClientTest, id string) (user *msgr
 	}
 	if user == nil {
 		t.Fatal("UsersClient.Get(): user was nil")
+	}
+	return
+}
+
+func testUsersClient_GetDeleted(t *testing.T, c UsersClientTest, id string) (user *msgraph.User) {
+	user, status, err := c.client.GetDeleted(c.connection.Context, id)
+	if err != nil {
+		t.Fatalf("UsersClient.GetDeleted(): %v", err)
+	}
+	if status < 200 || status >= 300 {
+		t.Fatalf("UsersClient.GetDeleted(): invalid status: %d", status)
+	}
+	if user == nil {
+		t.Fatal("UsersClient.GetDeleted(): user was nil")
 	}
 	return
 }


### PR DESCRIPTION
Add support for retrieving deleted applications, groups, and users. (i.e. basically [this](https://docs.microsoft.com/en-us/graph/api/directory-deleteditems-get?view=graph-rest-1.0&tabs=http) page)

Notes to the reviewer:
I wasn't quite sure how to approach this, as it is basically a code duplication. The HTTP request is the same (`/directory/deletedItems`), but different types will be returned in the end. I was thinking of introducing a `msgraph/directory.go` with `GetDeleted()`, but that didn't feel right. So I decided to keep this decoupled under separate clients, even if it is a code duplication somehow.

p.s. Groups without tests for the same (https://github.com/manicminer/hamilton/pull/48) reason. 