### PR TITLE
Delete permanently API for apps, groups, and users

### DIFF
--- a/msgraph/applications.go
+++ b/msgraph/applications.go
@@ -173,6 +173,22 @@ func (c *ApplicationsClient) Delete(ctx context.Context, id string) (int, error)
 	return status, nil
 }
 
+// DeletePermanently removes a deleted Application permanently.
+// id is the object ID of the application.
+func (c *ApplicationsClient) DeletePermanently(ctx context.Context, id string) (int, error) {
+	_, status, _, err := c.BaseClient.Delete(ctx, DeleteHttpRequestInput{
+		ValidStatusCodes: []int{http.StatusNoContent},
+		Uri: Uri{
+			Entity:      fmt.Sprintf("/directory/deletedItems/%s", id),
+			HasTenantId: true,
+		},
+	})
+	if err != nil {
+		return status, fmt.Errorf("ApplicationsClient.BaseClient.Delete(): %v", err)
+	}
+	return status, nil
+}
+
 // ListDeleted retrieves a list of recently deleted applications, optionally filtered using OData.
 func (c *ApplicationsClient) ListDeleted(ctx context.Context, filter string) (*[]Application, int, error) {
 	params := url.Values{}

--- a/msgraph/applications_test.go
+++ b/msgraph/applications_test.go
@@ -41,6 +41,7 @@ func TestApplicationsClient(t *testing.T) {
 	testApplicationsClient_Delete(t, c, *app.ID)
 	testApplicationsClient_ListDeleted(t, c, *app.ID)
 	testApplicationsClient_GetDeleted(t, c, *app.ID)
+	testApplicationsClient_DeletePermanently(t, c, *app.ID)
 }
 
 func TestApplicationsClient_groupMembershipClaims(t *testing.T) {
@@ -131,6 +132,16 @@ func testApplicationsClient_Delete(t *testing.T, c ApplicationsClientTest, id st
 	}
 	if status < 200 || status >= 300 {
 		t.Fatalf("ApplicationsClient.Delete(): invalid status: %d", status)
+	}
+}
+
+func testApplicationsClient_DeletePermanently(t *testing.T, c ApplicationsClientTest, id string) {
+	status, err := c.client.DeletePermanently(c.connection.Context, id)
+	if err != nil {
+		t.Fatalf("ApplicationsClient.DeletePermanently(): %v", err)
+	}
+	if status < 200 || status >= 300 {
+		t.Fatalf("ApplicationsClient.DeletePermanently(): invalid status: %d", status)
 	}
 }
 

--- a/msgraph/groups.go
+++ b/msgraph/groups.go
@@ -109,6 +109,7 @@ func (c *GroupsClient) Get(ctx context.Context, id string) (*Group, int, error) 
 }
 
 // GetDeleted retrieves a deleted O365 Group.
+// TODO: add test coverage once API supports creating O365 groups.
 func (c *GroupsClient) GetDeleted(ctx context.Context, id string) (*Group, int, error) {
 	resp, status, _, err := c.BaseClient.Get(ctx, GetHttpRequestInput{
 		ValidStatusCodes: []int{http.StatusOK},
@@ -159,6 +160,22 @@ func (c *GroupsClient) Delete(ctx context.Context, id string) (int, error) {
 		ValidStatusCodes: []int{http.StatusNoContent},
 		Uri: Uri{
 			Entity:      fmt.Sprintf("/groups/%s", id),
+			HasTenantId: true,
+		},
+	})
+	if err != nil {
+		return status, fmt.Errorf("GroupsClient.BaseClient.Delete(): %v", err)
+	}
+	return status, nil
+}
+
+// DeletePermanently removes a deleted O365 Group permanently.
+// TODO: add test coverage once API supports creating O365 groups.
+func (c *GroupsClient) DeletePermanently(ctx context.Context, id string) (int, error) {
+	_, status, _, err := c.BaseClient.Delete(ctx, DeleteHttpRequestInput{
+		ValidStatusCodes: []int{http.StatusNoContent},
+		Uri: Uri{
+			Entity:      fmt.Sprintf("/directory/deletedItems/%s", id),
 			HasTenantId: true,
 		},
 	})

--- a/msgraph/users.go
+++ b/msgraph/users.go
@@ -166,6 +166,21 @@ func (c *UsersClient) Delete(ctx context.Context, id string) (int, error) {
 	return status, nil
 }
 
+// DeletePermanently removes a deleted User permanently.
+func (c *UsersClient) DeletePermanently(ctx context.Context, id string) (int, error) {
+	_, status, _, err := c.BaseClient.Delete(ctx, DeleteHttpRequestInput{
+		ValidStatusCodes: []int{http.StatusNoContent},
+		Uri: Uri{
+			Entity:      fmt.Sprintf("/directory/deletedItems/%s", id),
+			HasTenantId: true,
+		},
+	})
+	if err != nil {
+		return status, fmt.Errorf("UsersClient.BaseClient.Delete(): %v", err)
+	}
+	return status, nil
+}
+
 // ListDeleted retrieves a list of recently deleted users, optionally filtered using OData.
 func (c *UsersClient) ListDeleted(ctx context.Context, filter string) (*[]User, int, error) {
 	params := url.Values{}

--- a/msgraph/users_test.go
+++ b/msgraph/users_test.go
@@ -73,6 +73,7 @@ func TestUsersClient(t *testing.T) {
 	testUsersClient_Delete(t, c, *user.ID)
 	testUsersClient_ListDeleted(t, c, *user.ID)
 	testUsersClient_GetDeleted(t, c, *user.ID)
+	testUsersClient_DeletePermanently(t, c, *user.ID)
 }
 
 func testUsersClient_Create(t *testing.T, c UsersClientTest, u msgraph.User) (user *msgraph.User) {
@@ -148,6 +149,16 @@ func testUsersClient_Delete(t *testing.T, c UsersClientTest, id string) {
 	}
 	if status < 200 || status >= 300 {
 		t.Fatalf("UsersClient.Delete(): invalid status: %d", status)
+	}
+}
+
+func testUsersClient_DeletePermanently(t *testing.T, c UsersClientTest, id string) {
+	status, err := c.client.DeletePermanently(c.connection.Context, id)
+	if err != nil {
+		t.Fatalf("UsersClient.DeletePermanently(): %v", err)
+	}
+	if status < 200 || status >= 300 {
+		t.Fatalf("UsersClient.DeletePermanently(): invalid status: %d", status)
 	}
 }
 


### PR DESCRIPTION
Add support for deleting an already removed application/user/group permanently. ([doc](https://docs.microsoft.com/en-us/graph/api/directory-deleteditems-delete?view=graph-rest-1.0&tabs=http))