### PR TITLE
Restore deleted API for apps, groups, and users

### DIFF
--- a/msgraph/applications_test.go
+++ b/msgraph/applications_test.go
@@ -41,6 +41,8 @@ func TestApplicationsClient(t *testing.T) {
 	testApplicationsClient_Delete(t, c, *app.ID)
 	testApplicationsClient_ListDeleted(t, c, *app.ID)
 	testApplicationsClient_GetDeleted(t, c, *app.ID)
+	testApplicationsClient_RestoreDeleted(t, c, *app.ID)
+	testApplicationsClient_Delete(t, c, *app.ID)
 	testApplicationsClient_DeletePermanently(t, c, *app.ID)
 }
 
@@ -142,6 +144,25 @@ func testApplicationsClient_DeletePermanently(t *testing.T, c ApplicationsClient
 	}
 	if status < 200 || status >= 300 {
 		t.Fatalf("ApplicationsClient.DeletePermanently(): invalid status: %d", status)
+	}
+}
+
+func testApplicationsClient_RestoreDeleted(t *testing.T, c ApplicationsClientTest, id string) {
+	application, status, err := c.client.RestoreDeleted(c.connection.Context, id)
+	if err != nil {
+		t.Fatalf("ApplicationsClient.RestoreDeleted(): %v", err)
+	}
+	if status < 200 || status >= 300 {
+		t.Fatalf("ApplicationsClient.RestoreDeleted(): invalid status: %d", status)
+	}
+	if application == nil {
+		t.Fatal("ApplicationsClient.RestoreDeleted(): application was nil")
+	}
+	if application.ID == nil {
+		t.Fatal("ApplicationsClient.RestoreDeleted(): application.ID was nil")
+	}
+	if *application.ID != id {
+		t.Fatal("ApplicationsClient.RestoreDeleted(): application ids do not match")
 	}
 }
 

--- a/msgraph/users_test.go
+++ b/msgraph/users_test.go
@@ -73,6 +73,8 @@ func TestUsersClient(t *testing.T) {
 	testUsersClient_Delete(t, c, *user.ID)
 	testUsersClient_ListDeleted(t, c, *user.ID)
 	testUsersClient_GetDeleted(t, c, *user.ID)
+	testUsersClient_RestoreDeleted(t, c, *user.ID)
+	testUsersClient_Delete(t, c, *user.ID)
 	testUsersClient_DeletePermanently(t, c, *user.ID)
 }
 
@@ -204,4 +206,23 @@ func testUsersClient_ListDeleted(t *testing.T, c UsersClientTest, expectedId str
 		t.Fatalf("UsersClient.ListDeleted(): expected userId %q in result", expectedId)
 	}
 	return
+}
+
+func testUsersClient_RestoreDeleted(t *testing.T, c UsersClientTest, id string) {
+	user, status, err := c.client.RestoreDeleted(c.connection.Context, id)
+	if err != nil {
+		t.Fatalf("UsersClient.RestoreDeleted(): %v", err)
+	}
+	if status < 200 || status >= 300 {
+		t.Fatalf("UsersClient.RestoreDeleted(): invalid status: %d", status)
+	}
+	if user == nil {
+		t.Fatal("UsersClient.RestoreDeleted(): user was nil")
+	}
+	if user.ID == nil {
+		t.Fatal("UsersClient.RestoreDeleted(): user.ID was nil")
+	}
+	if *user.ID != id {
+		t.Fatal("UsersClient.RestoreDeleted(): user ids do not match")
+	}
 }


### PR DESCRIPTION
Add support for restoring deleted applications/users/groups.([doc](https://docs.microsoft.com/en-us/graph/api/directory-deleteditems-restore?view=graph-rest-1.0&tabs=http))