### PR TITLE
Support OData queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,15 +21,13 @@ import (
 	"github.com/manicminer/hamilton/auth"
 	"github.com/manicminer/hamilton/environments"
 	"github.com/manicminer/hamilton/msgraph"
+	"github.com/manicminer/hamilton/odata"
 )
 
 var (
-	tenantId           = os.Getenv("TENANT_ID")
-	tenantDomain       = os.Getenv("TENANT_DOMAIN")
-	clientId           = os.Getenv("CLIENT_ID")
-	clientCertificate  = os.Getenv("CLIENT_CERTIFICATE")
-	clientCertPassword = os.Getenv("CLIENT_CERTIFICATE_PASSWORD")
-	clientSecret       = os.Getenv("CLIENT_SECRET")
+	tenantId     = os.Getenv("TENANT_ID")
+	clientId     = os.Getenv("CLIENT_ID")
+	clientSecret = os.Getenv("CLIENT_SECRET")
 )
 
 func main() {
@@ -51,14 +49,15 @@ func main() {
 	client := msgraph.NewUsersClient(tenantId)
 	client.BaseClient.Authorizer = authorizer
 
-	users, _, err := client.List(ctx, "")
+	users, _, err := client.List(ctx, odata.Query{})
 	if err != nil {
-		log.Fatal(err)
+		log.Println(err)
+		return
 	}
 	if users == nil {
-		log.Fatalln("bad API response, nil result received")
+		log.Println("bad API response, nil result received")
+		return
 	}
-
 	for _, user := range *users {
 		fmt.Printf("%s: %s <%s>\n", *user.ID, *user.DisplayName, *user.UserPrincipalName)
 	}

--- a/aadgraph/client.go
+++ b/aadgraph/client.go
@@ -239,6 +239,7 @@ func (c Client) Delete(ctx context.Context, input DeleteHttpRequestInput) (*http
 
 // GetHttpRequestInput configures a GET request.
 type GetHttpRequestInput struct {
+	DisablePaging    bool
 	ValidStatusCodes []int
 	ValidStatusFunc  ValidStatusFunc
 	Uri              Uri
@@ -294,7 +295,7 @@ func (c Client) Get(ctx context.Context, input GetHttpRequestInput) (*http.Respo
 			return nil, status, o, err
 		}
 
-		if firstOdata.NextLink == nil || firstOdata.Value == nil {
+		if input.DisablePaging || firstOdata.NextLink == nil || firstOdata.Value == nil {
 			// No more pages, reassign response body and return
 			resp.Body = ioutil.NopCloser(bytes.NewBuffer(respBody))
 			return resp, status, o, nil

--- a/example/example.go
+++ b/example/example.go
@@ -9,6 +9,7 @@ import (
 	"github.com/manicminer/hamilton/auth"
 	"github.com/manicminer/hamilton/environments"
 	"github.com/manicminer/hamilton/msgraph"
+	"github.com/manicminer/hamilton/odata"
 )
 
 var (
@@ -36,7 +37,7 @@ func main() {
 	client := msgraph.NewUsersClient(tenantId)
 	client.BaseClient.Authorizer = authorizer
 
-	users, _, err := client.List(ctx, "")
+	users, _, err := client.List(ctx, odata.Query{})
 	if err != nil {
 		log.Println(err)
 		return

--- a/internal/utils/pointers.go
+++ b/internal/utils/pointers.go
@@ -5,6 +5,16 @@ func BoolPtr(b bool) *bool {
 	return &b
 }
 
+// IntPtr returns a pointer to the provided int variable.
+func IntPtr(i int) *int {
+	return &i
+}
+
+// Int32Ptr returns a pointer to the provided int32 variable.
+func Int32Ptr(i int32) *int32 {
+	return &i
+}
+
 // StringPtr returns a pointer to the provided string variable.
 func StringPtr(s string) *string {
 	return &s

--- a/msgraph/app_role_assignments_test.go
+++ b/msgraph/app_role_assignments_test.go
@@ -310,26 +310,26 @@ func testAppRoleAssignmentsClient_List(t *testing.T, c AppRoleAssignmentsClientT
 func testAppRoleAssignmentsClient_Remove(t *testing.T, c AppRoleAssignmentsClientTest, id, appRoleAssignmentId string) {
 	status, err := c.client.Remove(c.connection.Context, id, appRoleAssignmentId)
 	if err != nil {
-		t.Fatalf("AppRoleAssignmentsClient.Delete(): %v", err)
+		t.Fatalf("AppRoleAssignmentsClient.Remove(): %v", err)
 	}
 	if status < 200 || status >= 300 {
-		t.Fatalf("AppRoleAssignmentsClient.Delete(): invalid status: %d", status)
+		t.Fatalf("AppRoleAssignmentsClient.Remove(): invalid status: %d", status)
 	}
 }
 
 func testAppRoleAssignmentsClient_Assign(t *testing.T, c AppRoleAssignmentsClientTest, principalId, resourceServicePrincipalId, appRoleId string) (appRoleAssignment *msgraph.AppRoleAssignment) {
 	appRoleAssignment, status, err := c.client.Assign(c.connection.Context, principalId, resourceServicePrincipalId, appRoleId)
 	if err != nil {
-		t.Fatalf("AppRoleAssignmentsClient.Create(): %v", err)
+		t.Fatalf("AppRoleAssignmentsClient.Assign(): %v", err)
 	}
 	if status < 200 || status >= 300 {
-		t.Fatalf("AppRoleAssignmentsClient.Create(): invalid status: %d", status)
+		t.Fatalf("AppRoleAssignmentsClient.Assign(): invalid status: %d", status)
 	}
 	if appRoleAssignment == nil {
-		t.Fatal("AppRoleAssignmentsClient.Create(): appRoleAssignment was nil")
+		t.Fatal("AppRoleAssignmentsClient.Assign(): appRoleAssignment was nil")
 	}
 	if appRoleAssignment.Id == nil {
-		t.Fatal("AppRoleAssignmentsClient.Create(): appRoleAssignment.Id was nil")
+		t.Fatal("AppRoleAssignmentsClient.Assign(): appRoleAssignment.Id was nil")
 	}
 	return
 }

--- a/msgraph/applications.go
+++ b/msgraph/applications.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	"net/url"
 
 	"github.com/manicminer/hamilton/odata"
 )
@@ -24,17 +23,14 @@ func NewApplicationsClient(tenantId string) *ApplicationsClient {
 	}
 }
 
-// List returns a list of Applications, optionally filtered using OData.
-func (c *ApplicationsClient) List(ctx context.Context, filter string) (*[]Application, int, error) {
-	params := url.Values{}
-	if filter != "" {
-		params.Add("$filter", filter)
-	}
+// List returns a list of Applications, optionally queried using OData.
+func (c *ApplicationsClient) List(ctx context.Context, query odata.Query) (*[]Application, int, error) {
 	resp, status, _, err := c.BaseClient.Get(ctx, GetHttpRequestInput{
+		DisablePaging:    query.Top > 0,
 		ValidStatusCodes: []int{http.StatusOK},
 		Uri: Uri{
 			Entity:      "/applications",
-			Params:      params,
+			Params:      query.Values(),
 			HasTenantId: true,
 		},
 	})
@@ -194,17 +190,14 @@ func (c *ApplicationsClient) DeletePermanently(ctx context.Context, id string) (
 	return status, nil
 }
 
-// ListDeleted retrieves a list of recently deleted applications, optionally filtered using OData.
-func (c *ApplicationsClient) ListDeleted(ctx context.Context, filter string) (*[]Application, int, error) {
-	params := url.Values{}
-	if filter != "" {
-		params.Add("$filter", filter)
-	}
+// ListDeleted retrieves a list of recently deleted applications, optionally queried using OData.
+func (c *ApplicationsClient) ListDeleted(ctx context.Context, query odata.Query) (*[]Application, int, error) {
 	resp, status, _, err := c.BaseClient.Get(ctx, GetHttpRequestInput{
+		DisablePaging:    query.Top > 0,
 		ValidStatusCodes: []int{http.StatusOK},
 		Uri: Uri{
 			Entity:      "/directory/deleteditems/microsoft.graph.application",
-			Params:      params,
+			Params:      query.Values(),
 			HasTenantId: true,
 		},
 	})
@@ -317,7 +310,7 @@ func (c *ApplicationsClient) ListOwners(ctx context.Context, id string) (*[]stri
 		ValidStatusCodes:       []int{http.StatusOK},
 		Uri: Uri{
 			Entity:      fmt.Sprintf("/applications/%s/owners", id),
-			Params:      url.Values{"$select": []string{"id"}},
+			Params:      odata.Query{Select: []string{"id"}}.Values(),
 			HasTenantId: true,
 		},
 	})
@@ -354,7 +347,7 @@ func (c *ApplicationsClient) GetOwner(ctx context.Context, applicationId, ownerI
 		ValidStatusCodes:       []int{http.StatusOK},
 		Uri: Uri{
 			Entity:      fmt.Sprintf("/applications/%s/owners/%s/$ref", applicationId, ownerId),
-			Params:      url.Values{"$select": []string{"id,url"}},
+			Params:      odata.Query{Select: []string{"id", "url"}}.Values(),
 			HasTenantId: true,
 		},
 	})
@@ -492,10 +485,10 @@ func (c *ApplicationsClient) ListExtensions(ctx context.Context, id string) (*[]
 	return &data.ApplicationExtension, status, nil
 }
 
-// Create creates a new ApplicationExtention.
-func (c *ApplicationsClient) CreateExtension(ctx context.Context, applicationExtention ApplicationExtension, id string) (*ApplicationExtension, int, error) {
+// Create creates a new ApplicationExtension.
+func (c *ApplicationsClient) CreateExtension(ctx context.Context, applicationExtension ApplicationExtension, id string) (*ApplicationExtension, int, error) {
 	var status int
-	body, err := json.Marshal(applicationExtention)
+	body, err := json.Marshal(applicationExtension)
 	if err != nil {
 		return nil, status, fmt.Errorf("json.Marshal(): %v", err)
 	}

--- a/msgraph/applications_test.go
+++ b/msgraph/applications_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/manicminer/hamilton/internal/test"
 	"github.com/manicminer/hamilton/internal/utils"
 	"github.com/manicminer/hamilton/msgraph"
+	"github.com/manicminer/hamilton/odata"
 )
 
 type ApplicationsClientTest struct {
@@ -100,7 +101,7 @@ func testApplicationsClient_Update(t *testing.T, c ApplicationsClientTest, a msg
 }
 
 func testApplicationsClient_List(t *testing.T, c ApplicationsClientTest) (applications *[]msgraph.Application) {
-	applications, _, err := c.client.List(c.connection.Context, "")
+	applications, _, err := c.client.List(c.connection.Context, odata.Query{})
 	if err != nil {
 		t.Fatalf("ApplicationsClient.List(): %v", err)
 	}
@@ -124,8 +125,8 @@ func testApplicationsClient_Get(t *testing.T, c ApplicationsClientTest, id strin
 	return
 }
 
-func testApplicationsClient_CreateExtension(t *testing.T, c ApplicationsClientTest, applicationExtention msgraph.ApplicationExtension, id string) string {
-	extension, status, err := c.client.CreateExtension(c.connection.Context, applicationExtention, id)
+func testApplicationsClient_CreateExtension(t *testing.T, c ApplicationsClientTest, applicationExtension msgraph.ApplicationExtension, id string) string {
+	extension, status, err := c.client.CreateExtension(c.connection.Context, applicationExtension, id)
 	if err != nil {
 		t.Fatalf("ApplicationsClient.CreateExtension(): %v", err)
 	}
@@ -157,10 +158,10 @@ func testApplicationsClient_ListExtension(t *testing.T, c ApplicationsClientTest
 func testApplicationsClient_DeleteExtension(t *testing.T, c ApplicationsClientTest, extensionId, id string) {
 	status, err := c.client.DeleteExtension(c.connection.Context, id, extensionId)
 	if err != nil {
-		t.Fatalf("ApplicationsClient.ListExtensions(): %v", err)
+		t.Fatalf("ApplicationsClient.DeleteExtension(): %v", err)
 	}
 	if status < 200 || status >= 300 {
-		t.Fatalf("ApplicationsClient.ListExtensions(): invalid status: %d", status)
+		t.Fatalf("ApplicationsClient.DeleteExtension(): invalid status: %d", status)
 	}
 }
 
@@ -299,7 +300,10 @@ func testApplicationsClient_RemovePassword(t *testing.T, c ApplicationsClientTes
 }
 
 func testApplicationsClient_ListDeleted(t *testing.T, c ApplicationsClientTest, expectedId string) (deletedApps *[]msgraph.Application) {
-	deletedApps, status, err := c.client.ListDeleted(c.connection.Context, "")
+	deletedApps, status, err := c.client.ListDeleted(c.connection.Context, odata.Query{
+		Filter: fmt.Sprintf("id eq '%s'", expectedId),
+		Top:    10,
+	})
 	if err != nil {
 		t.Fatalf("ApplicationsClient.ListDeleted(): %v", err)
 	}
@@ -310,7 +314,7 @@ func testApplicationsClient_ListDeleted(t *testing.T, c ApplicationsClientTest, 
 		t.Fatal("ApplicationsClient.ListDeleted(): deletedApps was nil")
 	}
 	if len(*deletedApps) == 0 {
-		t.Fatal("ApplicationsClient.ListDeleted(): expected at least 1 deleted application. was: 0")
+		t.Fatal("ApplicationsClient.ListDeleted(): expected at least 1 deleted application, was: 0")
 	}
 	found := false
 	for _, app := range *deletedApps {
@@ -320,7 +324,7 @@ func testApplicationsClient_ListDeleted(t *testing.T, c ApplicationsClientTest, 
 		}
 	}
 	if !found {
-		t.Fatalf("ApplicationsClient.ListDeleted(): expected appId %q in result", expectedId)
+		t.Fatalf("ApplicationsClient.ListDeleted(): expected app ID %q in result", expectedId)
 	}
 	return
 }

--- a/msgraph/client.go
+++ b/msgraph/client.go
@@ -286,6 +286,7 @@ func (c Client) Delete(ctx context.Context, input DeleteHttpRequestInput) (*http
 // GetHttpRequestInput configures a GET request.
 type GetHttpRequestInput struct {
 	ConsistencyFailureFunc ConsistencyFailureFunc
+	DisablePaging          bool
 	ValidStatusCodes       []int
 	ValidStatusFunc        ValidStatusFunc
 	Uri                    Uri
@@ -349,7 +350,7 @@ func (c Client) Get(ctx context.Context, input GetHttpRequestInput) (*http.Respo
 			return nil, status, o, err
 		}
 
-		if firstOdata.NextLink == nil || firstOdata.Value == nil {
+		if input.DisablePaging || firstOdata.NextLink == nil || firstOdata.Value == nil {
 			// No more pages, reassign response body and return
 			resp.Body = io.NopCloser(bytes.NewBuffer(respBody))
 			return resp, status, o, nil

--- a/msgraph/conditionalaccesspolicy.go
+++ b/msgraph/conditionalaccesspolicy.go
@@ -7,7 +7,8 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	"net/url"
+
+	"github.com/manicminer/hamilton/odata"
 )
 
 // ConditionalAccessPolicyClient performs operations on ConditionalAccessPolicy.
@@ -22,17 +23,14 @@ func NewConditionalAccessPolicyClient(tenantId string) *ConditionalAccessPolicyC
 	}
 }
 
-// List returns a list of ConditionalAccessPolicy, optionally filtered using OData.
-func (c *ConditionalAccessPolicyClient) List(ctx context.Context, filter string) (*[]ConditionalAccessPolicy, int, error) {
-	params := url.Values{}
-	if filter != "" {
-		params.Add("$filter", filter)
-	}
+// List returns a list of ConditionalAccessPolicy, optionally queried using OData.
+func (c *ConditionalAccessPolicyClient) List(ctx context.Context, query odata.Query) (*[]ConditionalAccessPolicy, int, error) {
 	resp, status, _, err := c.BaseClient.Get(ctx, GetHttpRequestInput{
+		DisablePaging:    query.Top > 0,
 		ValidStatusCodes: []int{http.StatusOK},
 		Uri: Uri{
 			Entity:      "/identity/conditionalAccess/policies",
-			Params:      params,
+			Params:      query.Values(),
 			HasTenantId: true,
 		},
 	})

--- a/msgraph/conditionalaccesspolicy_test.go
+++ b/msgraph/conditionalaccesspolicy_test.go
@@ -9,13 +9,14 @@ import (
 	"github.com/manicminer/hamilton/internal/test"
 	"github.com/manicminer/hamilton/internal/utils"
 	"github.com/manicminer/hamilton/msgraph"
+	"github.com/manicminer/hamilton/odata"
 )
 
 type ConditionalAccessPolicyTest struct {
 	connection   *test.Connection
 	policyClient *msgraph.ConditionalAccessPolicyClient
-	groupClient  *msgraph.GroupsClient
-	userClient   *msgraph.UsersClient
+	groupsClient *msgraph.GroupsClient
+	usersClient  *msgraph.UsersClient
 	randomString string
 }
 
@@ -28,11 +29,11 @@ func TestConditionalAccessPolicyClient(t *testing.T) {
 	c.policyClient = msgraph.NewConditionalAccessPolicyClient(c.connection.AuthConfig.TenantID)
 	c.policyClient.BaseClient.Authorizer = c.connection.Authorizer
 
-	c.groupClient = msgraph.NewGroupsClient(c.connection.AuthConfig.TenantID)
-	c.groupClient.BaseClient.Authorizer = c.connection.Authorizer
+	c.groupsClient = msgraph.NewGroupsClient(c.connection.AuthConfig.TenantID)
+	c.groupsClient.BaseClient.Authorizer = c.connection.Authorizer
 
-	c.userClient = msgraph.NewUsersClient(c.connection.AuthConfig.TenantID)
-	c.userClient.BaseClient.Authorizer = c.connection.Authorizer
+	c.usersClient = msgraph.NewUsersClient(c.connection.AuthConfig.TenantID)
+	c.usersClient.BaseClient.Authorizer = c.connection.Authorizer
 
 	testAppId := string(environments.PublishedApis["AzureDevOps"])
 	testIncGroup := testGroup_Create(t, c, "inc")
@@ -123,7 +124,7 @@ func testConditionalAccessPolicysClient_Update(t *testing.T, c ConditionalAccess
 }
 
 func testConditionalAccessPolicysClient_List(t *testing.T, c ConditionalAccessPolicyTest) (policies *[]msgraph.ConditionalAccessPolicy) {
-	policies, _, err := c.policyClient.List(c.connection.Context, "")
+	policies, _, err := c.policyClient.List(c.connection.Context, odata.Query{Top: 10})
 	if err != nil {
 		t.Fatalf("ConditionalAccessPolicyClient.List(): %v", err)
 	}
@@ -144,7 +145,7 @@ func testConditionalAccessPolicysClient_Delete(t *testing.T, c ConditionalAccess
 }
 
 func testGroup_Create(t *testing.T, c ConditionalAccessPolicyTest, prefix string) (group *msgraph.Group) {
-	group, _, err := c.groupClient.Create(c.connection.Context, msgraph.Group{
+	group, _, err := c.groupsClient.Create(c.connection.Context, msgraph.Group{
 		DisplayName:     utils.StringPtr(fmt.Sprintf("%s-test-group-%s", prefix, c.randomString)),
 		MailEnabled:     utils.BoolPtr(false),
 		MailNickname:    utils.StringPtr(fmt.Sprintf("%s-test-group-%s", prefix, c.randomString)),
@@ -152,20 +153,20 @@ func testGroup_Create(t *testing.T, c ConditionalAccessPolicyTest, prefix string
 	})
 
 	if err != nil {
-		t.Fatalf("ConditionalAccessPolicyClient.Create() - Could not create test group: %v", err)
+		t.Fatalf("GroupsClient.Create() - Could not create test group: %v", err)
 	}
 	return
 }
 
 func testGroup_Delete(t *testing.T, c ConditionalAccessPolicyTest, group *msgraph.Group) {
-	_, err := c.groupClient.Delete(c.connection.Context, *group.ID)
+	_, err := c.groupsClient.Delete(c.connection.Context, *group.ID)
 	if err != nil {
-		t.Fatalf("ConditionalAccessPolicyClient.Create() - Could not delete test group: %v", err)
+		t.Fatalf("GroupsClient.Delete() - Could not delete test group: %v", err)
 	}
 }
 
 func testUser_Create(t *testing.T, c ConditionalAccessPolicyTest) (user *msgraph.User) {
-	user, _, err := c.userClient.Create(c.connection.Context, msgraph.User{
+	user, _, err := c.usersClient.Create(c.connection.Context, msgraph.User{
 		AccountEnabled:    utils.BoolPtr(true),
 		DisplayName:       utils.StringPtr("Test User"),
 		MailNickname:      utils.StringPtr(fmt.Sprintf("test-user-%s", c.randomString)),
@@ -176,14 +177,14 @@ func testUser_Create(t *testing.T, c ConditionalAccessPolicyTest) (user *msgraph
 	})
 
 	if err != nil {
-		t.Fatalf("ConditionalAccessPolicyClient.Create() - Could not create test user: %v", err)
+		t.Fatalf("UsersClient.Create() - Could not create test user: %v", err)
 	}
 	return
 }
 
 func testUser_Delete(t *testing.T, c ConditionalAccessPolicyTest, user *msgraph.User) {
-	_, err := c.userClient.Delete(c.connection.Context, *user.ID)
+	_, err := c.usersClient.Delete(c.connection.Context, *user.ID)
 	if err != nil {
-		t.Fatalf("ConditionalAccessPolicyClient.Create() - Could not delete test user: %v", err)
+		t.Fatalf("UsersClient.Delete() - Could not delete test user: %v", err)
 	}
 }

--- a/msgraph/directory_audit_reports.go
+++ b/msgraph/directory_audit_reports.go
@@ -6,7 +6,8 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	"net/url"
+
+	"github.com/manicminer/hamilton/odata"
 )
 
 // DirectoryAuditReportsClient performs operations on directory Audit reports.
@@ -21,17 +22,14 @@ func NewDirectoryAuditReportsClient(tenantId string) *DirectoryAuditReportsClien
 	}
 }
 
-// List returns a list of Directory audit report logs, optionally filtered using OData.
-func (c *DirectoryAuditReportsClient) List(ctx context.Context, filter string) (*[]DirectoryAudit, int, error) {
-	params := url.Values{}
-	if filter != "" {
-		params.Add("$filter", filter)
-	}
+// List returns a list of Directory audit report logs, optionally queried using OData.
+func (c *DirectoryAuditReportsClient) List(ctx context.Context, query odata.Query) (*[]DirectoryAudit, int, error) {
 	resp, status, _, err := c.BaseClient.Get(ctx, GetHttpRequestInput{
+		DisablePaging:    query.Top > 0,
 		ValidStatusCodes: []int{http.StatusOK},
 		Uri: Uri{
 			Entity:      "/auditLogs/directoryAudits",
-			Params:      params,
+			Params:      query.Values(),
 			HasTenantId: true,
 		},
 	})

--- a/msgraph/directory_audit_reports_test.go
+++ b/msgraph/directory_audit_reports_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/manicminer/hamilton/auth"
 	"github.com/manicminer/hamilton/internal/test"
 	"github.com/manicminer/hamilton/msgraph"
+	"github.com/manicminer/hamilton/odata"
 )
 
 type DirectoryAuditReportsClientTest struct {
@@ -25,7 +26,7 @@ func TestDirectoryAuditReportsTest(t *testing.T) {
 }
 
 func testDirectoryAuditReports_List(t *testing.T, c DirectoryAuditReportsClientTest) (dirLogs *[]msgraph.DirectoryAudit) {
-	dirLogs, status, err := c.client.List(c.connection.Context, "")
+	dirLogs, status, err := c.client.List(c.connection.Context, odata.Query{Top: 10})
 
 	if status < 200 || status >= 300 {
 		t.Fatalf("DirectoryAuditReportsClient.List(): invalid status: %d", status)

--- a/msgraph/directory_roles.go
+++ b/msgraph/directory_roles.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	"net/url"
 
 	"github.com/manicminer/hamilton/odata"
 )
@@ -81,7 +80,7 @@ func (c *DirectoryRolesClient) ListMembers(ctx context.Context, id string) (*[]s
 		ValidStatusCodes: []int{http.StatusOK},
 		Uri: Uri{
 			Entity:      fmt.Sprintf("/directoryRoles/%s/members", id),
-			Params:      url.Values{"$select": []string{"id"}},
+			Params:      odata.Query{Select: []string{"id"}}.Values(),
 			HasTenantId: true,
 		},
 	})
@@ -194,7 +193,7 @@ func (c *DirectoryRolesClient) GetMember(ctx context.Context, directoryRoleId, m
 		ValidStatusCodes: []int{http.StatusOK},
 		Uri: Uri{
 			Entity:      fmt.Sprintf("/directoryRoles/%s/members/%s/$ref", directoryRoleId, memberId),
-			Params:      url.Values{"$select": []string{"id,url"}},
+			Params:      odata.Query{Select: []string{"id", "url"}}.Values(),
 			HasTenantId: true,
 		},
 	})

--- a/msgraph/groups.go
+++ b/msgraph/groups.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	"net/url"
 
 	"github.com/manicminer/hamilton/odata"
 )
@@ -23,17 +22,14 @@ func NewGroupsClient(tenantId string) *GroupsClient {
 	}
 }
 
-// List returns a list of Groups, optionally filtered using OData.
-func (c *GroupsClient) List(ctx context.Context, filter string) (*[]Group, int, error) {
-	params := url.Values{}
-	if filter != "" {
-		params.Add("$filter", filter)
-	}
+// List returns a list of Groups, optionally queried using OData.
+func (c *GroupsClient) List(ctx context.Context, query odata.Query) (*[]Group, int, error) {
 	resp, status, _, err := c.BaseClient.Get(ctx, GetHttpRequestInput{
+		DisablePaging:    query.Top > 0,
 		ValidStatusCodes: []int{http.StatusOK},
 		Uri: Uri{
 			Entity:      "/groups",
-			Params:      params,
+			Params:      query.Values(),
 			HasTenantId: true,
 		},
 	})
@@ -190,18 +186,15 @@ func (c *GroupsClient) DeletePermanently(ctx context.Context, id string) (int, e
 	return status, nil
 }
 
-// ListDeleted retrieves a list of recently deleted O365 groups, optionally filtered using OData.
+// ListDeleted retrieves a list of recently deleted O365 groups, optionally queried using OData.
 // TODO: add test coverage once API supports creating O365 groups
-func (c *GroupsClient) ListDeleted(ctx context.Context, filter string) (*[]Group, int, error) {
-	params := url.Values{}
-	if filter != "" {
-		params.Add("$filter", filter)
-	}
+func (c *GroupsClient) ListDeleted(ctx context.Context, query odata.Query) (*[]Group, int, error) {
 	resp, status, _, err := c.BaseClient.Get(ctx, GetHttpRequestInput{
+		DisablePaging:    query.Top > 0,
 		ValidStatusCodes: []int{http.StatusOK},
 		Uri: Uri{
 			Entity:      "/directory/deleteditems/microsoft.graph.group",
-			Params:      params,
+			Params:      query.Values(),
 			HasTenantId: true,
 		},
 	})
@@ -253,7 +246,7 @@ func (c *GroupsClient) ListMembers(ctx context.Context, id string) (*[]string, i
 		ValidStatusCodes:       []int{http.StatusOK},
 		Uri: Uri{
 			Entity:      fmt.Sprintf("/groups/%s/members", id),
-			Params:      url.Values{"$select": []string{"id"}},
+			Params:      odata.Query{Select: []string{"id"}}.Values(),
 			HasTenantId: true,
 		},
 	})
@@ -290,7 +283,7 @@ func (c *GroupsClient) GetMember(ctx context.Context, groupId, memberId string) 
 		ValidStatusCodes:       []int{http.StatusOK},
 		Uri: Uri{
 			Entity:      fmt.Sprintf("/groups/%s/members/%s/$ref", groupId, memberId),
-			Params:      url.Values{"$select": []string{"id,url"}},
+			Params:      odata.Query{Select: []string{"id", "url"}}.Values(),
 			HasTenantId: true,
 		},
 	})
@@ -416,7 +409,7 @@ func (c *GroupsClient) ListOwners(ctx context.Context, id string) (*[]string, in
 		ValidStatusCodes:       []int{http.StatusOK},
 		Uri: Uri{
 			Entity:      fmt.Sprintf("/groups/%s/owners", id),
-			Params:      url.Values{"$select": []string{"id"}},
+			Params:      odata.Query{Select: []string{"id"}}.Values(),
 			HasTenantId: true,
 		},
 	})
@@ -453,7 +446,7 @@ func (c *GroupsClient) GetOwner(ctx context.Context, groupId, ownerId string) (*
 		ValidStatusCodes:       []int{http.StatusOK},
 		Uri: Uri{
 			Entity:      fmt.Sprintf("/groups/%s/owners/%s/$ref", groupId, ownerId),
-			Params:      url.Values{"$select": []string{"id,url"}},
+			Params:      odata.Query{Select: []string{"id", "url"}}.Values(),
 			HasTenantId: true,
 		},
 	})

--- a/msgraph/groups_test.go
+++ b/msgraph/groups_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/manicminer/hamilton/internal/test"
 	"github.com/manicminer/hamilton/internal/utils"
 	"github.com/manicminer/hamilton/msgraph"
+	"github.com/manicminer/hamilton/odata"
 )
 
 type GroupsClientTest struct {
@@ -112,7 +113,7 @@ func testGroupsClient_Update(t *testing.T, c GroupsClientTest, g msgraph.Group) 
 }
 
 func testGroupsClient_List(t *testing.T, c GroupsClientTest) (groups *[]msgraph.Group) {
-	groups, _, err := c.client.List(c.connection.Context, "")
+	groups, _, err := c.client.List(c.connection.Context, odata.Query{Top: 10})
 	if err != nil {
 		t.Fatalf("GroupsClient.List(): %v", err)
 	}

--- a/msgraph/identity_providers_test.go
+++ b/msgraph/identity_providers_test.go
@@ -97,9 +97,9 @@ func testIdentityProvidersClient_Get(t *testing.T, c IdentityProvidersClientTest
 		t.Fatal("IdentityProvidersClient.Get(): provider was nil")
 	}
 	if provider.ID == nil {
-		t.Fatal("IdentityProvidersClient.Create(): provider.ID was nil")
+		t.Fatal("IdentityProvidersClient.Get(): provider.ID was nil")
 	}
-		return
+	return
 }
 
 func testIdentityProvidersClient_Delete(t *testing.T, c IdentityProvidersClientTest, id string) {

--- a/msgraph/namedlocations.go
+++ b/msgraph/namedlocations.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	"net/url"
 
 	"github.com/manicminer/hamilton/internal/utils"
 	"github.com/manicminer/hamilton/odata"
@@ -24,18 +23,14 @@ func NewNamedLocationsClient(tenantId string) *NamedLocationsClient {
 	}
 }
 
-// List returns a list of Named Locations, optionally filtered using OData.
-func (c *NamedLocationsClient) List(ctx context.Context, filter string) (*[]NamedLocation, int, error) {
-	params := url.Values{}
-	if filter != "" {
-		params.Add("$filter", filter)
-	}
-
+// List returns a list of Named Locations, optionally queried using OData.
+func (c *NamedLocationsClient) List(ctx context.Context, query odata.Query) (*[]NamedLocation, int, error) {
 	resp, status, _, err := c.BaseClient.Get(ctx, GetHttpRequestInput{
+		DisablePaging:    query.Top > 0,
 		ValidStatusCodes: []int{http.StatusOK},
 		Uri: Uri{
 			Entity:      "/identity/conditionalAccess/namedLocations",
-			Params:      params,
+			Params:      query.Values(),
 			HasTenantId: true,
 		},
 	})

--- a/msgraph/namedlocations_test.go
+++ b/msgraph/namedlocations_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/manicminer/hamilton/internal/test"
 	"github.com/manicminer/hamilton/internal/utils"
 	"github.com/manicminer/hamilton/msgraph"
+	"github.com/manicminer/hamilton/odata"
 )
 
 type NamedLocationsClientTest struct {
@@ -59,7 +60,7 @@ func TestNamedLocationsClient(t *testing.T) {
 	testNamedLocationsClient_UpdateIP(t, c, *ipNamedLocation)
 	testNamedLocationsClient_UpdateCountry(t, c, *countryNamedLocation)
 
-	testNamedLocationsClient_List(t, c, "")
+	testNamedLocationsClient_List(t, c)
 	// Running get after the update to give the API a chance to catch up
 	testNamedLocationsClient_GetIP(t, c, *ipNamedLocation.ID)
 	testNamedLocationsClient_GetCountry(t, c, *countryNamedLocation.ID)
@@ -107,13 +108,13 @@ func testNamedLocationsClient_CreateCountry(t *testing.T, c NamedLocationsClient
 func testNamedLocationsClient_GetIP(t *testing.T, c NamedLocationsClientTest, id string) (ipNamedLocation *msgraph.IPNamedLocation) {
 	ipNamedLocation, status, err := c.client.GetIP(c.connection.Context, id)
 	if err != nil {
-		t.Fatalf("IPNamedLocationsClient.Get(): %v", err)
+		t.Fatalf("IPNamedLocationsClient.GetIP(): %v", err)
 	}
 	if status < 200 || status >= 300 {
-		t.Fatalf("IPNamedLocationsClient.Get(): invalid status: %d", status)
+		t.Fatalf("IPNamedLocationsClient.GetIP(): invalid status: %d", status)
 	}
 	if ipNamedLocation == nil {
-		t.Fatal("IPNamedLocationsClient.Get(): ipNamedLocation was nil")
+		t.Fatal("IPNamedLocationsClient.GetIP(): ipNamedLocation was nil")
 	}
 	return
 }
@@ -171,8 +172,8 @@ func testNamedLocationsClient_UpdateCountry(t *testing.T, c NamedLocationsClient
 	}
 }
 
-func testNamedLocationsClient_List(t *testing.T, c NamedLocationsClientTest, f string) (namedLocations *[]msgraph.NamedLocation) {
-	namedLocations, _, err := c.client.List(c.connection.Context, f)
+func testNamedLocationsClient_List(t *testing.T, c NamedLocationsClientTest) (namedLocations *[]msgraph.NamedLocation) {
+	namedLocations, _, err := c.client.List(c.connection.Context, odata.Query{})
 	if err != nil {
 		t.Fatalf("NamedLocationsClient.List(): %v", err)
 	}

--- a/msgraph/serviceprincipals_test.go
+++ b/msgraph/serviceprincipals_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/manicminer/hamilton/internal/test"
 	"github.com/manicminer/hamilton/internal/utils"
 	"github.com/manicminer/hamilton/msgraph"
+	"github.com/manicminer/hamilton/odata"
 )
 
 type ServicePrincipalsClientTest struct {
@@ -225,7 +226,7 @@ func testServicePrincipalsClient_Update(t *testing.T, c ServicePrincipalsClientT
 }
 
 func testServicePrincipalsClient_List(t *testing.T, c ServicePrincipalsClientTest) (servicePrincipals *[]msgraph.ServicePrincipal) {
-	servicePrincipals, _, err := c.client.List(c.connection.Context, "")
+	servicePrincipals, _, err := c.client.List(c.connection.Context, odata.Query{Top: 10})
 	if err != nil {
 		t.Fatalf("ServicePrincipalsClient.List(): %v", err)
 	}
@@ -260,7 +261,7 @@ func testServicePrincipalsClient_Delete(t *testing.T, c ServicePrincipalsClientT
 }
 
 func testServicePrincipalsClient_ListGroupMemberships(t *testing.T, c ServicePrincipalsClientTest, id string) (groups *[]msgraph.Group) {
-	groups, _, err := c.client.ListGroupMemberships(c.connection.Context, id, "")
+	groups, _, err := c.client.ListGroupMemberships(c.connection.Context, id, odata.Query{})
 	if err != nil {
 		t.Fatalf("ServicePrincipalsClient.ListGroupMemberships(): %v", err)
 	}
@@ -277,9 +278,7 @@ func testServicePrincipalsClient_ListGroupMemberships(t *testing.T, c ServicePri
 }
 
 func testServicePrincipalsClient_AddPassword(t *testing.T, c ServicePrincipalsClientTest, a *msgraph.ServicePrincipal) *msgraph.PasswordCredential {
-	pwd := msgraph.PasswordCredential{
-		DisplayName: utils.StringPtr("test password"),
-	}
+	pwd := msgraph.PasswordCredential{}
 	newPwd, status, err := c.client.AddPassword(c.connection.Context, *a.ID, pwd)
 	if err != nil {
 		t.Fatalf("ServicePrincipalsClient.AddPassword(): %v", err)
@@ -289,9 +288,6 @@ func testServicePrincipalsClient_AddPassword(t *testing.T, c ServicePrincipalsCl
 	}
 	if newPwd.SecretText == nil || len(*newPwd.SecretText) == 0 {
 		t.Fatalf("ServicePrincipalsClient.AddPassword(): nil or empty secretText returned by API")
-	}
-	if *newPwd.DisplayName != *pwd.DisplayName {
-		t.Fatalf("ServicePrincipalsClient.AddPassword(): password names do not match")
 	}
 	return newPwd
 }
@@ -391,16 +387,16 @@ func testServicePrincipalsClient_RemoveOwners(t *testing.T, c ServicePrincipalsC
 func testServicePrincipalsClient_AssignAppRole(t *testing.T, c ServicePrincipalsClientTest, principalId, resourceId, appRoleId string) (appRoleAssignment *msgraph.AppRoleAssignment) {
 	appRoleAssignment, status, err := c.client.AssignAppRoleForResource(c.connection.Context, principalId, resourceId, appRoleId)
 	if err != nil {
-		t.Fatalf("ServicePrincipalsClient.Create(): %v", err)
+		t.Fatalf("ServicePrincipalsClient.AssignAppRoleForResource(): %v", err)
 	}
 	if status < 200 || status >= 300 {
-		t.Fatalf("ServicePrincipalsClient.Create(): invalid status: %d", status)
+		t.Fatalf("ServicePrincipalsClient.AssignAppRoleForResource(): invalid status: %d", status)
 	}
 	if appRoleAssignment == nil {
-		t.Fatal("ServicePrincipalsClient.Create(): appRoleAssignment was nil")
+		t.Fatal("ServicePrincipalsClient.AssignAppRoleForResource(): appRoleAssignment was nil")
 	}
 	if appRoleAssignment.Id == nil {
-		t.Fatal("ServicePrincipalsClient.Create(): appRoleAssignment.Id was nil")
+		t.Fatal("ServicePrincipalsClient.AssignAppRoleForResource(): appRoleAssignment.Id was nil")
 	}
 	return
 }
@@ -408,10 +404,10 @@ func testServicePrincipalsClient_AssignAppRole(t *testing.T, c ServicePrincipals
 func testServicePrincipalsClient_ListAppRoleAssignments(t *testing.T, c ServicePrincipalsClientTest, resourceId string) (appRoleAssignments *[]msgraph.AppRoleAssignment) {
 	appRoleAssignments, _, err := c.client.ListAppRoleAssignments(c.connection.Context, resourceId)
 	if err != nil {
-		t.Fatalf("ServicePrincipalsClient.List(): %v", err)
+		t.Fatalf("ServicePrincipalsClient.ListAppRoleAssignments(): %v", err)
 	}
 	if appRoleAssignments == nil {
-		t.Fatal("ServicePrincipalsClient.List(): appRoleAssignments was nil")
+		t.Fatal("ServicePrincipalsClient.ListAppRoleAssignments(): appRoleAssignments was nil")
 	}
 	return
 }
@@ -419,9 +415,9 @@ func testServicePrincipalsClient_ListAppRoleAssignments(t *testing.T, c ServiceP
 func testServicePrincipalsClient_RemoveAppRoleAssignment(t *testing.T, c ServicePrincipalsClientTest, resourceId, appRoleAssignmentId string) {
 	status, err := c.client.RemoveAppRoleAssignment(c.connection.Context, resourceId, appRoleAssignmentId)
 	if err != nil {
-		t.Fatalf("ServicePrincipalsClient.Delete(): %v", err)
+		t.Fatalf("ServicePrincipalsClient.RemoveAppRoleAssignment(): %v", err)
 	}
 	if status < 200 || status >= 300 {
-		t.Fatalf("ServicePrincipalsClient.Delete(): invalid status: %d", status)
+		t.Fatalf("ServicePrincipalsClient.RemoveAppRoleAssignment(): invalid status: %d", status)
 	}
 }

--- a/msgraph/sign_in_reports.go
+++ b/msgraph/sign_in_reports.go
@@ -6,7 +6,8 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	"net/url"
+
+	"github.com/manicminer/hamilton/odata"
 )
 
 // SignInReports Client performs operations on Sign in reports.
@@ -21,17 +22,14 @@ func NewSignInLogsClient(tenantId string) *SignInReportsClient {
 	}
 }
 
-// List returns a list of Sign-in Reports, optionally filtered using OData.
-func (c *SignInReportsClient) List(ctx context.Context, filter string) (*[]SignInReport, int, error) {
-	params := url.Values{}
-	if filter != "" {
-		params.Add("$filter", filter)
-	}
+// List returns a list of Sign-in Reports, optionally queried using OData.
+func (c *SignInReportsClient) List(ctx context.Context, query odata.Query) (*[]SignInReport, int, error) {
 	resp, status, _, err := c.BaseClient.Get(ctx, GetHttpRequestInput{
+		DisablePaging:    query.Top > 0,
 		ValidStatusCodes: []int{http.StatusOK},
 		Uri: Uri{
 			Entity:      "/auditLogs/signIns",
-			Params:      params,
+			Params:      query.Values(),
 			HasTenantId: true,
 		},
 	})

--- a/msgraph/sign_in_reports_test.go
+++ b/msgraph/sign_in_reports_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/manicminer/hamilton/auth"
 	"github.com/manicminer/hamilton/internal/test"
 	"github.com/manicminer/hamilton/msgraph"
+	"github.com/manicminer/hamilton/odata"
 )
 
 type SignInReportsClientTest struct {
@@ -25,7 +26,7 @@ func TestSignInReportsTest(t *testing.T) {
 }
 
 func testSignInReports_List(t *testing.T, c SignInReportsClientTest) (signInLogs *[]msgraph.SignInReport) {
-	signInLogs, status, err := c.client.List(c.connection.Context, "")
+	signInLogs, status, err := c.client.List(c.connection.Context, odata.Query{Top: 10})
 
 	if status < 200 || status >= 300 {
 		t.Fatalf("SignInReportsClient.List(): invalid status: %d", status)

--- a/msgraph/users_test.go
+++ b/msgraph/users_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/manicminer/hamilton/internal/test"
 	"github.com/manicminer/hamilton/internal/utils"
 	"github.com/manicminer/hamilton/msgraph"
+	"github.com/manicminer/hamilton/odata"
 )
 
 type UsersClientTest struct {
@@ -106,7 +107,7 @@ func testUsersClient_Update(t *testing.T, c UsersClientTest, u msgraph.User) {
 }
 
 func testUsersClient_List(t *testing.T, c UsersClientTest) (users *[]msgraph.User) {
-	users, _, err := c.client.List(c.connection.Context, "")
+	users, _, err := c.client.List(c.connection.Context, odata.Query{Top: 10})
 	if err != nil {
 		t.Fatalf("UsersClient.List(): %v", err)
 	}
@@ -165,7 +166,7 @@ func testUsersClient_DeletePermanently(t *testing.T, c UsersClientTest, id strin
 }
 
 func testUsersClient_ListGroupMemberships(t *testing.T, c UsersClientTest, id string) (groups *[]msgraph.Group) {
-	groups, _, err := c.client.ListGroupMemberships(c.connection.Context, id, "")
+	groups, _, err := c.client.ListGroupMemberships(c.connection.Context, id, odata.Query{})
 	if err != nil {
 		t.Fatalf("UsersClient.ListGroupMemberships(): %v", err)
 	}
@@ -182,7 +183,10 @@ func testUsersClient_ListGroupMemberships(t *testing.T, c UsersClientTest, id st
 }
 
 func testUsersClient_ListDeleted(t *testing.T, c UsersClientTest, expectedId string) (deletedUsers *[]msgraph.User) {
-	deletedUsers, status, err := c.client.ListDeleted(c.connection.Context, "")
+	deletedUsers, status, err := c.client.ListDeleted(c.connection.Context, odata.Query{
+		Filter: fmt.Sprintf("id eq '%s'", expectedId),
+		Top:    10,
+	})
 	if err != nil {
 		t.Fatalf("UsersClient.ListDeleted(): %v", err)
 	}

--- a/odata/query.go
+++ b/odata/query.go
@@ -1,0 +1,110 @@
+package odata
+
+import (
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+type Query struct {
+	// Count includes a count of the total number of items in a collection alongside the page of data values
+	Count bool
+
+	// Expand includes the expanded resource or collection referenced by a single relationship
+	Expand Expand
+
+	// Filter retrieves just a subset of a collection, or relationships like members, memberOf, transitiveMembers, and transitiveMemberOf
+	Filter string
+
+	// Format specifies the media format of the items returned
+	Format Format
+
+	// OrderBy specify the sort order of the items returned
+	OrderBy OrderBy
+
+	// Search restricts the results of a request to match a search criterion
+	Search string // complicated
+
+	// Select returns a set of properties that are different than the default set for an individual resource or a collection of resources
+	Select []string
+
+	// Skip sets the number of items to skip at the start of a collection
+	Skip int
+
+	// Top specifies the page size of the result set
+	Top int
+}
+
+func (q Query) Values() url.Values {
+	p := url.Values{}
+	if q.Count {
+		p.Add("$count", fmt.Sprintf("%t", q.Count))
+	}
+	if expand := q.Expand.String(); expand != "" {
+		p.Add("$expand", expand)
+	}
+	if q.Filter != "" {
+		p.Add("$filter", q.Filter)
+	}
+	if format := string(q.Format); format != "" {
+		p.Add("$format", format)
+	}
+	if orderBy := q.OrderBy.String(); orderBy != "" {
+		p.Add("$orderby", orderBy)
+	}
+	if q.Search != "" {
+		p.Add("$search", fmt.Sprintf(`"%s"`, q.Search))
+	}
+	if len(q.Select) > 0 {
+		p.Add("$select", strings.Join(q.Select, ","))
+	}
+	if q.Skip > 0 {
+		p.Add("$skip", strconv.Itoa(q.Skip))
+	}
+	if q.Top > 0 {
+		p.Add("$top", strconv.Itoa(q.Top))
+	}
+	return p
+}
+
+type Expand struct {
+	Relationship string
+	Select       []string
+}
+
+func (e Expand) String() (val string) {
+	val = e.Relationship
+	if len(e.Select) > 0 {
+		val = fmt.Sprintf("%s($select=%s)", val, strings.Join(e.Select, ","))
+	}
+	return
+}
+
+type Format string
+
+const (
+	FormatJson Format = "json"
+	FormatAtom Format = "atom"
+	FormatXml  Format = "xml"
+)
+
+type Direction string
+
+const (
+	Ascending  Direction = "asc"
+	Descending Direction = "desc"
+)
+
+type OrderBy struct {
+	Field     string
+	Direction Direction
+}
+
+func (o OrderBy) String() (val string) {
+	val = o.Field
+	if val != "" && o.Direction != "" {
+		val = fmt.Sprintf("%s %s", val, o.Direction)
+	}
+	return
+}

--- a/odata/query_test.go
+++ b/odata/query_test.go
@@ -1,0 +1,88 @@
+package odata_test
+
+import (
+	"net/url"
+	"reflect"
+	"testing"
+
+	"github.com/manicminer/hamilton/odata"
+)
+
+func TestQuery(t *testing.T) {
+	type testCase struct {
+		query    odata.Query
+		expected url.Values
+	}
+	testCases := []testCase{
+		{
+			query:    odata.Query{},
+			expected: url.Values{},
+		},
+		{
+			query: odata.Query{
+				Count:  true,
+				Format: odata.FormatAtom,
+				Skip:   20,
+				Top:    10,
+			},
+			expected: url.Values{
+				"$count":  []string{"true"},
+				"$format": []string{"atom"},
+				"$skip":   []string{"20"},
+				"$top":    []string{"10"},
+			},
+		},
+		{
+			query: odata.Query{
+				OrderBy: odata.OrderBy{
+					Field:     "displayName",
+					Direction: "desc",
+				},
+			},
+			expected: url.Values{
+				"$orderby": []string{"displayName desc"},
+			},
+		},
+		{
+			query: odata.Query{
+				Expand: odata.Expand{
+					Relationship: "children",
+					Select:       []string{"id", "childName"},
+				},
+			},
+			expected: url.Values{
+				"$expand": []string{"children($select=id,childName)"},
+			},
+		},
+		{
+			query: odata.Query{
+				Filter: "startsWith(displayName,'Widgets')",
+			},
+			expected: url.Values{
+				"$filter": []string{"startsWith(displayName,'Widgets')"},
+			},
+		},
+		{
+			query: odata.Query{
+				Search: "displayName:Astley",
+			},
+			expected: url.Values{
+				"$search": []string{`"displayName:Astley"`},
+			},
+		},
+		{
+			query: odata.Query{
+				Select: []string{"id", "userPrincipalName"},
+			},
+			expected: url.Values{
+				"$select": []string{"id,userPrincipalName"},
+			},
+		},
+	}
+	for n, c := range testCases {
+		v := c.query.Values()
+		if !reflect.DeepEqual(v, c.expected) {
+			t.Errorf("test case %d: expected %#v, got %#v", n, c.expected, v)
+		}
+	}
+}


### PR DESCRIPTION
This introduces support for [OData query parameters](https://docs.microsoft.com/en-us/graph/query-parameters) via a new type `odata.Query{}`. Instead of accepting a filter string, all clients now accept an instance of `odata.Query{}` which encapsulates any combination of odata queries such as `$filter`, `$search`, `$top` etc. All documented parameters are supported and wrapped lightly where sensible.

⚠️ This is a breaking change that updates many client method signatures (mostly ones that begin with `List`).

## Example

```go
apps, status, err := appsClient.List(ctx, odata.Query{
	Filter: fmt.Sprintf("startsWith(displayName,'%s')", searchTerm),
	OrderBy: odata.OrderBy{
		Field:     "displayName",
		Direction: "asc",
	},
	Top: 10,
})
```