### PR TITLE
Enable passing in the raw bytes of a PKCS#12 bundle when constructing a client certificate authorizer

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -45,7 +45,7 @@ const (
 // will return (nil, error) and later mechanisms will not be attempted.
 func (c *Config) NewAuthorizer(ctx context.Context, api Api) (Authorizer, error) {
 	if c.EnableClientCertAuth && strings.TrimSpace(c.TenantID) != "" && strings.TrimSpace(c.ClientID) != "" && strings.TrimSpace(c.ClientCertPath) != "" {
-		a, err := NewClientCertificateAuthorizer(ctx, c.Environment, api, c.Version, c.TenantID, c.ClientID, c.ClientCertPath, c.ClientCertPassword)
+		a, err := NewClientCertificateAuthorizer(ctx, c.Environment, api, c.Version, c.TenantID, c.ClientID, c.ClientCertData, c.ClientCertPath, c.ClientCertPassword)
 		if err != nil {
 			return nil, fmt.Errorf("could not configure ClientCertificate Authorizer: %s", err)
 		}
@@ -106,13 +106,16 @@ func NewMsiAuthorizer(ctx context.Context, environment environments.Environment,
 }
 
 // NewClientCertificateAuthorizer returns an authorizer which uses client certificate authentication.
-func NewClientCertificateAuthorizer(ctx context.Context, environment environments.Environment, api Api, tokenVersion TokenVersion, tenantId, clientId, pfxPath, pfxPass string) (Authorizer, error) {
-	pfx, err := ioutil.ReadFile(pfxPath)
-	if err != nil {
-		return nil, fmt.Errorf("could not read pkcs12 store at %q: %s", pfxPath, err)
+func NewClientCertificateAuthorizer(ctx context.Context, environment environments.Environment, api Api, tokenVersion TokenVersion, tenantId, clientId string, pfxData []byte, pfxPath, pfxPass string) (Authorizer, error) {
+	if len(pfxData) == 0 {
+		var err error
+		pfxData, err = ioutil.ReadFile(pfxPath)
+		if err != nil {
+			return nil, fmt.Errorf("could not read pkcs12 store at %q: %s", pfxPath, err)
+		}
 	}
 
-	key, cert, err := pkcs12.Decode(pfx, pfxPass)
+	key, cert, err := pkcs12.Decode(pfxData, pfxPass)
 	if err != nil {
 		return nil, fmt.Errorf("could not decode pkcs12 credential store: %s", err)
 	}

--- a/auth/config.go
+++ b/auth/config.go
@@ -15,7 +15,7 @@ type Config struct {
 	Environment environments.Environment
 
 	// Version specifies the token version  to acquire from Microsoft Identity Platform.
-	// Ignored when using Azure CLI authentication.
+	// Ignored when using Azure CLI or Managed Identity authentication.
 	Version TokenVersion
 
 	// Azure Active Directory tenant to connect to, should be a valid UUID
@@ -36,7 +36,10 @@ type Config struct {
 	// Enables client certificate authentication using client assertions
 	EnableClientCertAuth bool
 
-	// Specifies the path to a client certificate bundle in PFX format
+	// Specifies the contents of a client certificate PKCS#12 bundle
+	ClientCertData []byte
+
+	// Specifies the path to a client certificate PKCS#12 bundle (.pfx file)
 	ClientCertPath string
 
 	// Specifies the encryption password to unlock a client certificate

--- a/internal/test/msi_stub.go
+++ b/internal/test/msi_stub.go
@@ -1,0 +1,44 @@
+package test
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/http"
+)
+
+func MsiStubServer(ctx context.Context, port int, token string) chan bool {
+	handler := http.NewServeMux()
+
+	handler.HandleFunc("/metadata/identity/oauth2/token", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		fmt.Fprintf(w, `{"access_token":"%s","client_id":"00000000-0000-0000-0000-000000000000","expires_in":"86391","expires_on":"1611701390","ext_expires_in":"86399","not_before":"1611614690","resource":"https://graph.microsoft.com/","token_type":"Bearer"}`, token)
+	})
+
+	handler.HandleFunc("/metadata", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		fmt.Fprint(w, `
+`)
+	})
+
+	done := make(chan bool, 1)
+	server := &http.Server{
+		Addr:    fmt.Sprintf("127.0.0.1:%d", port),
+		Handler: handler,
+	}
+
+	go func() {
+		<-done
+		err := server.Shutdown(ctx)
+		if err != nil {
+			log.Fatal("failed to gracefully shut down MSI stub server")
+		}
+	}()
+
+	go func() {
+		log.Println("MSI Stub Service listening on 127.0.0.1:8080")
+		log.Fatal(server.ListenAndServe())
+	}()
+
+	return done
+}

--- a/internal/test/testing.go
+++ b/internal/test/testing.go
@@ -2,6 +2,7 @@ package test
 
 import (
 	"context"
+	"encoding/base64"
 	"log"
 	"os"
 
@@ -10,12 +11,13 @@ import (
 )
 
 var (
-	tenantId           = os.Getenv("TENANT_ID")
-	tenantDomain       = os.Getenv("TENANT_DOMAIN")
-	clientId           = os.Getenv("CLIENT_ID")
-	clientCertificate  = os.Getenv("CLIENT_CERTIFICATE")
-	clientCertPassword = os.Getenv("CLIENT_CERTIFICATE_PASSWORD")
-	clientSecret       = os.Getenv("CLIENT_SECRET")
+	tenantId              = os.Getenv("TENANT_ID")
+	tenantDomain          = os.Getenv("TENANT_DOMAIN")
+	clientId              = os.Getenv("CLIENT_ID")
+	clientCertificate     = os.Getenv("CLIENT_CERTIFICATE")
+	clientCertificatePath = os.Getenv("CLIENT_CERTIFICATE_PATH")
+	clientCertPassword    = os.Getenv("CLIENT_CERTIFICATE_PASSWORD")
+	clientSecret          = os.Getenv("CLIENT_SECRET")
 )
 
 type Connection struct {
@@ -27,13 +29,21 @@ type Connection struct {
 
 // NewConnection configures and returns a Connection for use in tests.
 func NewConnection(api auth.Api, tokenVersion auth.TokenVersion) *Connection {
+	var pfx []byte
+	if clientCertificate != "" {
+		_, err := base64.RawStdEncoding.Decode(pfx, []byte(clientCertificate))
+		if err != nil {
+			log.Fatalf("test.NewConnection(): could not decode value of CLIENT_CERTIFICATE: %v", err)
+		}
+	}
 	t := Connection{
 		AuthConfig: &auth.Config{
 			Environment:            environments.Global,
 			Version:                tokenVersion,
 			TenantID:               tenantId,
 			ClientID:               clientId,
-			ClientCertPath:         clientCertificate,
+			ClientCertData:         pfx,
+			ClientCertPath:         clientCertificatePath,
 			ClientCertPassword:     clientCertPassword,
 			ClientSecret:           clientSecret,
 			EnableClientCertAuth:   true,


### PR DESCRIPTION
- Also, add a simple MSI authentication stub server for testing outside Azure


### Example usage

```go
// pfxData contains a PKCS#12 bundle (.pfx file contents)
auth, err := auth.NewClientCertificateAuthorizer(ctx, environments.Global, auth.MsGraph, auth.TokenVersion2, tenantId, clientId, pfxData, "", pfxPassword)
```

#### Suggestion: base64 encode the bundle for storage in CI systems
```go
var pfxData []byte
if cert := os.Getenv("CLIENT_CERTIFICATE"); cert != "" {
	out := make([]byte, base64.StdEncoding.DecodedLen(len(cert)))
	n, err := base64.StdEncoding.Decode(out, []byte(cert))
	if err != nil {
		// handle err
	}
	pfxData = out[:n]
}

auth, err := auth.NewClientCertificateAuthorizer(ctx, environments.Global, auth.MsGraph, auth.TokenVersion2, tenantId, clientId, pfxData, "", pfxPassword)
```

#### Using NewAuthorizer()

```go
config := &auth.Config{
	Environment:            environments.Global,
	Version:                auth.TokenVersion2,
	TenantID:               tenantId,
	ClientID:               clientId,
	ClientCertData:         pfxData,
	ClientCertPassword:     pfxPassword,
	ClientSecret:           clientSecret,
	EnableClientCertAuth:   true,
	EnableClientSecretAuth: true,
}

authorizer, err = config.NewAuthorizer(ctx, auth.MsGraph)
if err != nil {
	// handle err
}
```