### PR TITLE
Add Support For Schema Extensions

### DIFF
--- a/msgraph/models.go
+++ b/msgraph/models.go
@@ -491,6 +491,11 @@ type EmailAddress struct {
 	Name    *string `json:"name,omitempty"`
 }
 
+type ExtensionSchemaProperty struct {
+	Name *string                         `json:"name,omitempty"`
+	Type ExtensionSchemaPropertyDataType `json:"type,omitempty"`
+}
+
 type GeoCoordinates struct {
 	Altitude  *float64 `json:"altitude,omitempty"`
 	Latitude  *float64 `json:"latitude,omitempty"`
@@ -818,6 +823,15 @@ type ResourceAccess struct {
 
 type SamlSingleSignOnSettings struct {
 	RelayState *string `json:"relayState,omitempty"`
+}
+
+type SchemaExtension struct {
+	ID          *string                      `json:"id,omitempty"`
+	Description *string                      `json:"description,omitempty"`
+	Owner       *string                      `json:"owner,omitempty"`
+	Properties  *[]ExtensionSchemaProperty   `json:"properties,omitempty"`
+	TargetTypes *[]ExtensionSchemaTargetType `json:"targetTypes,omitempty"`
+	Status      *string                      `json:"status,omitempty"`
 }
 
 // ServicePrincipal describes a Service Principal object.

--- a/msgraph/schema_extensions.go
+++ b/msgraph/schema_extensions.go
@@ -6,7 +6,8 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	"net/url"
+
+	"github.com/manicminer/hamilton/odata"
 )
 
 // SchemaExtensionsClient performs operations on Schema Extensions.
@@ -22,16 +23,13 @@ func NewSchemaExtensionsClient(tenantId string) *SchemaExtensionsClient {
 }
 
 // List returns a list of Schema Extensions, optionally filtered using OData.
-func (c *SchemaExtensionsClient) List(ctx context.Context, filter string) (*[]SchemaExtension, int, error) {
-	params := url.Values{}
-	if filter != "" {
-		params.Add("$filter", filter)
-	}
+func (c *SchemaExtensionsClient) List(ctx context.Context, query odata.Query) (*[]SchemaExtension, int, error) {
 	resp, status, _, err := c.BaseClient.Get(ctx, GetHttpRequestInput{
+		DisablePaging:    query.Top > 0,
 		ValidStatusCodes: []int{http.StatusOK},
 		Uri: Uri{
 			Entity:      "/schemaExtensions",
-			Params:      params,
+			Params:      query.Values(),
 			HasTenantId: true,
 		},
 	})

--- a/msgraph/schema_extensions.go
+++ b/msgraph/schema_extensions.go
@@ -1,0 +1,146 @@
+package msgraph
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+)
+
+// SchemaExtensionsClient performs operations on Schema Extensions.
+type SchemaExtensionsClient struct {
+	BaseClient Client
+}
+
+// NewSchemaExtensionsClient returns a new SchemaExtensionsClient.
+func NewSchemaExtensionsClient(tenantId string) *SchemaExtensionsClient {
+	return &SchemaExtensionsClient{
+		BaseClient: NewClient(VersionBeta, tenantId),
+	}
+}
+
+// List returns a list of Schema Extensions, optionally filtered using OData.
+func (c *SchemaExtensionsClient) List(ctx context.Context, filter string) (*[]SchemaExtension, int, error) {
+	params := url.Values{}
+	if filter != "" {
+		params.Add("$filter", filter)
+	}
+	resp, status, _, err := c.BaseClient.Get(ctx, GetHttpRequestInput{
+		ValidStatusCodes: []int{http.StatusOK},
+		Uri: Uri{
+			Entity:      "/schemaExtensions",
+			Params:      params,
+			HasTenantId: true,
+		},
+	})
+	if err != nil {
+		return nil, status, fmt.Errorf("SchemaExtensionsClient.BaseClient.Get(): %v", err)
+	}
+	defer resp.Body.Close()
+	respBody, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, status, fmt.Errorf("ioutil.ReadAll(): %v", err)
+	}
+	var data struct {
+		SchemaExtensions []SchemaExtension `json:"value"`
+	}
+	if err := json.Unmarshal(respBody, &data); err != nil {
+		return nil, status, fmt.Errorf("json.Unmarshal(): %v", err)
+	}
+	return &data.SchemaExtensions, status, nil
+}
+
+// Get retrieves a Schema Extension.
+func (c *SchemaExtensionsClient) Get(ctx context.Context, id string) (*SchemaExtension, int, error) {
+	resp, status, _, err := c.BaseClient.Get(ctx, GetHttpRequestInput{
+		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
+		ValidStatusCodes:       []int{http.StatusOK},
+		Uri: Uri{
+			Entity:      fmt.Sprintf("/schemaExtensions/%s", id),
+			HasTenantId: true,
+		},
+	})
+	if err != nil {
+		return nil, status, fmt.Errorf("SchemaExtensionsClient.BaseClient.Get(): %v", err)
+	}
+	defer resp.Body.Close()
+	respBody, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, status, fmt.Errorf("ioutil.ReadAll(): %v", err)
+	}
+	var schemaExtension SchemaExtension
+	if err := json.Unmarshal(respBody, &schemaExtension); err != nil {
+		return nil, status, fmt.Errorf("json.Unmarshal(): %v", err)
+	}
+	return &schemaExtension, status, nil
+}
+
+// Update amends an existing schema Extension.
+func (c *SchemaExtensionsClient) Update(ctx context.Context, schemaExtension SchemaExtension) (int, error) {
+	var status int
+	body, err := json.Marshal(schemaExtension)
+	if err != nil {
+		return status, fmt.Errorf("json.Marshal(): %v", err)
+	}
+	_, status, _, err = c.BaseClient.Patch(ctx, PatchHttpRequestInput{
+		Body:                   body,
+		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
+		ValidStatusCodes:       []int{http.StatusNoContent},
+		Uri: Uri{
+			Entity:      fmt.Sprintf("/schemaExtensions/%s", *schemaExtension.ID),
+			HasTenantId: true,
+		},
+	})
+	if err != nil {
+		return status, fmt.Errorf("SchemaExtensionsClient.BaseClient.Patch(): %v", err)
+	}
+	return status, nil
+}
+
+// Create creates a new Schema Extension
+func (c *SchemaExtensionsClient) Create(ctx context.Context, schemaExtension SchemaExtension) (*SchemaExtension, int, error) {
+	var status int
+	body, err := json.Marshal(schemaExtension)
+	if err != nil {
+		return nil, status, fmt.Errorf("json.Marshal(): %v", err)
+	}
+	resp, status, _, err := c.BaseClient.Post(ctx, PostHttpRequestInput{
+		Body:             body,
+		ValidStatusCodes: []int{http.StatusCreated},
+		Uri: Uri{
+			Entity:      "/schemaExtensions",
+			HasTenantId: true,
+		},
+	})
+	if err != nil {
+		return nil, status, fmt.Errorf("SchemaExtensionsClient.BaseClient.Post(): %v", err)
+	}
+	defer resp.Body.Close()
+	respBody, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, status, fmt.Errorf("ioutil.ReadAll(): %v", err)
+	}
+	var newSchemaExtension SchemaExtension
+	if err := json.Unmarshal(respBody, &newSchemaExtension); err != nil {
+		return nil, status, fmt.Errorf("json.Unmarshal(): %v", err)
+	}
+	return &newSchemaExtension, status, nil
+}
+
+// Delete removes a schema extension.
+func (c *SchemaExtensionsClient) Delete(ctx context.Context, id string) (int, error) {
+	_, status, _, err := c.BaseClient.Delete(ctx, DeleteHttpRequestInput{
+		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
+		ValidStatusCodes:       []int{http.StatusNoContent},
+		Uri: Uri{
+			Entity:      fmt.Sprintf("/schemaExtensions/%s", id),
+			HasTenantId: true,
+		},
+	})
+	if err != nil {
+		return status, fmt.Errorf("SchemaExtensionsClient.BaseClient.Delete(): %v", err)
+	}
+	return status, nil
+}

--- a/msgraph/schema_extensions_test.go
+++ b/msgraph/schema_extensions_test.go
@@ -1,0 +1,106 @@
+package msgraph_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/manicminer/hamilton/auth"
+	"github.com/manicminer/hamilton/internal/test"
+	"github.com/manicminer/hamilton/internal/utils"
+	"github.com/manicminer/hamilton/msgraph"
+)
+
+type SchemaExtensionsClientTest struct {
+	connection   *test.Connection
+	client       *msgraph.SchemaExtensionsClient
+	randomstring string
+}
+
+func TestSchemaExtensionsClient(t *testing.T) {
+	c := SchemaExtensionsClientTest{
+		connection:   test.NewConnection(auth.MsGraph, auth.TokenVersion2),
+		randomstring: test.RandomString(),
+	}
+
+	property1 := msgraph.ExtensionSchemaProperty{
+		Name: utils.StringPtr("property1"),
+		Type: msgraph.ExtensionSchemaPropertyDataString,
+	}
+
+	property2 := msgraph.ExtensionSchemaProperty{
+		Name: utils.StringPtr("property2"),
+		Type: msgraph.ExtensionSchemaPropertyDataBoolean,
+	}
+
+	targetTypes := []msgraph.ExtensionSchemaTargetType{msgraph.ExtensionSchemaTargetTypeUser}
+	schemaExtension := msgraph.SchemaExtension{
+		Description: utils.StringPtr("This is a description"),
+		ID:          utils.StringPtr(fmt.Sprintf("schemaid%s", c.randomstring)),
+		TargetTypes: &targetTypes,
+		Properties:  &[]msgraph.ExtensionSchemaProperty{property1},
+	}
+
+	c.client = msgraph.NewSchemaExtensionsClient(c.connection.AuthConfig.TenantID)
+	c.client.BaseClient.Authorizer = c.connection.Authorizer
+	schema := testSchemaExtensionsClient_Create(t, c, schemaExtension)
+	testSchemaExtensionsClient_Get(t, c, *schema.ID)
+
+	updateExtension := msgraph.SchemaExtension{
+		Properties: &[]msgraph.ExtensionSchemaProperty{property1, property2},
+		ID:         schema.ID,
+	}
+
+	testSchemaExtensionsClient_Update(t, c, updateExtension)
+	testSchemaExtensionsClient_Delete(t, c, *schema.ID)
+}
+
+func testSchemaExtensionsClient_Create(t *testing.T, c SchemaExtensionsClientTest, s msgraph.SchemaExtension) (schema *msgraph.SchemaExtension) {
+	schema, status, err := c.client.Create(c.connection.Context, s)
+	if err != nil {
+		t.Fatalf("ApplicationsClient.Create(): %v", err)
+	}
+	if status < 200 || status >= 300 {
+		t.Fatalf("SchemaExtensionsClient.Create(): invalid status: %d", status)
+	}
+	if schema == nil {
+		t.Fatal("SchemaExtensionsClient.Create(): schema was nil")
+	}
+	if schema.ID == nil {
+		t.Fatal("SchemaExtensionsClient.Create(): schema.ID was nil")
+	}
+	return
+}
+
+func testSchemaExtensionsClient_Get(t *testing.T, c SchemaExtensionsClientTest, id string) (schema *msgraph.SchemaExtension) {
+	schema, status, err := c.client.Get(c.connection.Context, id)
+	if err != nil {
+		t.Fatalf("SchemaExtensionsClient.Get(): %v", err)
+	}
+	if status < 200 || status >= 300 {
+		t.Fatalf("SchemaExtensionsClient.Get(): invalid status: %d", status)
+	}
+	if schema == nil {
+		t.Fatal("SchemaExtensionsClient.Get(): schema was nil")
+	}
+	return
+}
+
+func testSchemaExtensionsClient_Update(t *testing.T, c SchemaExtensionsClientTest, s msgraph.SchemaExtension) {
+	status, err := c.client.Update(c.connection.Context, s)
+	if err != nil {
+		t.Fatalf("SchemaExtensionsClient.Update(): %v", err)
+	}
+	if status < 200 || status >= 300 {
+		t.Fatalf("SchemaExtensionsClient.Update(): invalid status: %d", status)
+	}
+}
+
+func testSchemaExtensionsClient_Delete(t *testing.T, c SchemaExtensionsClientTest, id string) {
+	status, err := c.client.Delete(c.connection.Context, id)
+	if err != nil {
+		t.Fatalf("SchemaExtensionsClient.Delete(): %v", err)
+	}
+	if status < 200 || status >= 300 {
+		t.Fatalf("SchemaExtensionsClient.Delete(): invalid status: %d", status)
+	}
+}

--- a/msgraph/valuetypes.go
+++ b/msgraph/valuetypes.go
@@ -52,14 +52,15 @@ const (
 type ExtensionSchemaTargetType string
 
 const (
-	ExtensionSchemaTargetTypeContact      ExtensionSchemaTargetType = "Contact"
-	ExtensionSchemaTargetTypeDevice       ExtensionSchemaTargetType = "Device"
-	ExtensionSchemaTargetTypeEvent        ExtensionSchemaTargetType = "Event"
-	ExtensionSchemaTargetTypePost         ExtensionSchemaTargetType = "Post"
-	ExtensionSchemaTargetTypeGroup        ExtensionSchemaTargetType = "Group"
-	ExtensionSchemaTargetTypeMessage      ExtensionSchemaTargetType = "Message"
-	ExtensionSchemaTargetTypeOrganization ExtensionSchemaTargetType = "Organization"
-	ExtensionSchemaTargetTypeUser         ExtensionSchemaTargetType = "User"
+	ExtensionSchemaTargetTypeAdministrativeUnit ExtensionSchemaTargetType = "AdministrativeUnit"
+	ExtensionSchemaTargetTypeContact            ExtensionSchemaTargetType = "Contact"
+	ExtensionSchemaTargetTypeDevice             ExtensionSchemaTargetType = "Device"
+	ExtensionSchemaTargetTypeEvent              ExtensionSchemaTargetType = "Event"
+	ExtensionSchemaTargetTypePost               ExtensionSchemaTargetType = "Post"
+	ExtensionSchemaTargetTypeGroup              ExtensionSchemaTargetType = "Group"
+	ExtensionSchemaTargetTypeMessage            ExtensionSchemaTargetType = "Message"
+	ExtensionSchemaTargetTypeOrganization       ExtensionSchemaTargetType = "Organization"
+	ExtensionSchemaTargetTypeUser               ExtensionSchemaTargetType = "User"
 )
 
 type ExtensionSchemaPropertyDataType string

--- a/msgraph/valuetypes.go
+++ b/msgraph/valuetypes.go
@@ -49,6 +49,29 @@ const (
 	BodyTypeHtml BodyType = "html"
 )
 
+type ExtensionSchemaTargetType string
+
+const (
+	ExtensionSchemaTargetTypeContact      ExtensionSchemaTargetType = "Contact"
+	ExtensionSchemaTargetTypeDevice       ExtensionSchemaTargetType = "Device"
+	ExtensionSchemaTargetTypeEvent        ExtensionSchemaTargetType = "Event"
+	ExtensionSchemaTargetTypePost         ExtensionSchemaTargetType = "Post"
+	ExtensionSchemaTargetTypeGroup        ExtensionSchemaTargetType = "Group"
+	ExtensionSchemaTargetTypeMessage      ExtensionSchemaTargetType = "Message"
+	ExtensionSchemaTargetTypeOrganization ExtensionSchemaTargetType = "Organization"
+	ExtensionSchemaTargetTypeUser         ExtensionSchemaTargetType = "User"
+)
+
+type ExtensionSchemaPropertyDataType string
+
+const (
+	ExtensionSchemaPropertyDataBinary   ExtensionSchemaPropertyDataType = "Binary"
+	ExtensionSchemaPropertyDataBoolean  ExtensionSchemaPropertyDataType = "Boolean"
+	ExtensionSchemaPropertyDataDateTime ExtensionSchemaPropertyDataType = "DateTime"
+	ExtensionSchemaPropertyDataInteger  ExtensionSchemaPropertyDataType = "Integer"
+	ExtensionSchemaPropertyDataString   ExtensionSchemaPropertyDataType = "String"
+)
+
 type GroupType string
 
 const (


### PR DESCRIPTION
This PR creates the models, data types and functions to perform CRUD operations on schema Extensions.

https://docs.microsoft.com/en-us/graph/api/resources/schemaextension?view=graph-rest-1.0