### PR TITLE
Improvements to Group and ServicePrincipal models

### DIFF
--- a/environments/published.go
+++ b/environments/published.go
@@ -1,6 +1,6 @@
 package environments
 
-type ApiAppId string
+type ApiAppId = string
 
 // PublishedApis is a map containing Application IDs for well known APIs published by Microsoft.
 // They can be used to acquire access tokens, but are primarily described here for easy inclusion in

--- a/msgraph/models.go
+++ b/msgraph/models.go
@@ -854,19 +854,22 @@ type ServicePrincipal struct {
 	AppRoleAssignmentRequired           *bool                         `json:"appRoleAssignmentRequired,omitempty"`
 	AppRoles                            *[]AppRole                    `json:"appRoles,omitempty"`
 	DeletedDateTime                     *time.Time                    `json:"deletedDateTime,omitempty"`
+	Description                         *StringNullWhenEmpty          `json:"description,omitempty"`
 	DisplayName                         *string                       `json:"displayName,omitempty"`
 	Homepage                            *string                       `json:"homepage,omitempty"`
 	Info                                *InformationalUrl             `json:"info,omitempty"`
 	KeyCredentials                      *[]KeyCredential              `json:"keyCredentials,omitempty"`
-	LoginUrl                            *string                       `json:"loginUrl,omitempty"`
+	LoginUrl                            *StringNullWhenEmpty          `json:"loginUrl,omitempty"`
 	LogoutUrl                           *string                       `json:"logoutUrl,omitempty"`
+	Notes                               *StringNullWhenEmpty          `json:"notes,omitempty"`
 	NotificationEmailAddresses          *[]string                     `json:"notificationEmailAddresses,omitempty"`
 	PasswordCredentials                 *[]PasswordCredential         `json:"passwordCredentials,omitempty"`
 	PasswordSingleSignOnSettings        *PasswordSingleSignOnSettings `json:"passwordSingleSignOnSettings,omitempty"`
-	PreferredSingleSignOnMode           *string                       `json:"preferredSingleSignOnMode,omitempty"`
+	PreferredSingleSignOnMode           *PreferredSingleSignOnMode    `json:"preferredSingleSignOnMode,omitempty"`
 	PreferredTokenSigningKeyEndDateTime *time.Time                    `json:"preferredTokenSigningKeyEndDateTime,omitempty"`
 	PublishedPermissionScopes           *[]PermissionScope            `json:"publishedPermissionScopes,omitempty"`
 	ReplyUrls                           *[]string                     `json:"replyUrls,omitempty"`
+	SamlMetadataUrl                     *StringNullWhenEmpty          `json:"samlMetadataUrl,omitempty"`
 	SamlSingleSignOnSettings            *SamlSingleSignOnSettings     `json:"samlSingleSignOnSettings,omitempty"`
 	ServicePrincipalNames               *[]string                     `json:"servicePrincipalNames,omitempty"`
 	ServicePrincipalType                *string                       `json:"servicePrincipalType,omitempty"`

--- a/msgraph/valuetypes.go
+++ b/msgraph/valuetypes.go
@@ -164,6 +164,16 @@ const (
 	PermissionScopeTypeUser  PermissionScopeType = "User"
 )
 
+type PreferredSingleSignOnMode = StringNullWhenEmpty
+
+const (
+	PreferredSingleSignOnModeNone         PreferredSingleSignOnMode = ""
+	PreferredSingleSignOnModeNotSupported PreferredSingleSignOnMode = "notSupported"
+	PreferredSingleSignOnModeOidc         PreferredSingleSignOnMode = "oidc"
+	PreferredSingleSignOnModePassword     PreferredSingleSignOnMode = "password"
+	PreferredSingleSignOnModeSaml         PreferredSingleSignOnMode = "saml"
+)
+
 type ResourceAccessType = string
 
 const (


### PR DESCRIPTION
- `environments.ApiAppId` is now a type alias
- Add the `Description` field to the ServicePrincipal model
- Add the `Notes` field to the ServicePrincipal model
- Add the `SamlMetadataUrl` field to the ServicePrincipal model
- `msgraph.ServicePrincipal{}.LoginUrl` is now a `StringNullWhenEmpty`
- `msgraph.ServicePrincipal{}.PreferredSingleSignOnMode` is now a pointer to a type alias (formerly a string pointer)
