### PR TITLE
Expand odata.Query support to more client methods

### DIFF
--- a/msgraph/applications.go
+++ b/msgraph/applications.go
@@ -82,12 +82,13 @@ func (c *ApplicationsClient) Create(ctx context.Context, application Application
 }
 
 // Get retrieves an Application manifest.
-func (c *ApplicationsClient) Get(ctx context.Context, id string) (*Application, int, error) {
+func (c *ApplicationsClient) Get(ctx context.Context, id string, query odata.Query) (*Application, int, error) {
 	resp, status, _, err := c.BaseClient.Get(ctx, GetHttpRequestInput{
 		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
 		ValidStatusCodes:       []int{http.StatusOK},
 		Uri: Uri{
 			Entity:      fmt.Sprintf("/applications/%s", id),
+			Params:      query.Values(),
 			HasTenantId: true,
 		},
 	})
@@ -108,12 +109,13 @@ func (c *ApplicationsClient) Get(ctx context.Context, id string) (*Application, 
 
 // GetDeleted retrieves a deleted Application manifest.
 // id is the object ID of the application.
-func (c *ApplicationsClient) GetDeleted(ctx context.Context, id string) (*Application, int, error) {
+func (c *ApplicationsClient) GetDeleted(ctx context.Context, id string, query odata.Query) (*Application, int, error) {
 	resp, status, _, err := c.BaseClient.Get(ctx, GetHttpRequestInput{
 		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
 		ValidStatusCodes:       []int{http.StatusOK},
 		Uri: Uri{
 			Entity:      fmt.Sprintf("/directory/deletedItems/%s", id),
+			Params:      query.Values(),
 			HasTenantId: true,
 		},
 	})
@@ -458,12 +460,13 @@ func (c *ApplicationsClient) RemoveOwners(ctx context.Context, applicationId str
 	return status, nil
 }
 
-func (c *ApplicationsClient) ListExtensions(ctx context.Context, id string) (*[]ApplicationExtension, int, error) {
+func (c *ApplicationsClient) ListExtensions(ctx context.Context, id string, query odata.Query) (*[]ApplicationExtension, int, error) {
 	resp, status, _, err := c.BaseClient.Get(ctx, GetHttpRequestInput{
 		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
 		ValidStatusCodes:       []int{http.StatusOK},
 		Uri: Uri{
 			Entity:      fmt.Sprintf("/applications/%s/extensionProperties", id),
+			Params:      query.Values(),
 			HasTenantId: true,
 		},
 	})

--- a/msgraph/applications_test.go
+++ b/msgraph/applications_test.go
@@ -112,7 +112,7 @@ func testApplicationsClient_List(t *testing.T, c ApplicationsClientTest) (applic
 }
 
 func testApplicationsClient_Get(t *testing.T, c ApplicationsClientTest, id string) (application *msgraph.Application) {
-	application, status, err := c.client.Get(c.connection.Context, id)
+	application, status, err := c.client.Get(c.connection.Context, id, odata.Query{})
 	if err != nil {
 		t.Fatalf("ApplicationsClient.Get(): %v", err)
 	}
@@ -143,7 +143,7 @@ func testApplicationsClient_CreateExtension(t *testing.T, c ApplicationsClientTe
 }
 
 func testApplicationsClient_ListExtension(t *testing.T, c ApplicationsClientTest, id string) {
-	extension, status, err := c.client.ListExtensions(c.connection.Context, id)
+	extension, status, err := c.client.ListExtensions(c.connection.Context, id, odata.Query{})
 	if err != nil {
 		t.Fatalf("ApplicationsClient.ListExtensions(): %v", err)
 	}
@@ -166,7 +166,7 @@ func testApplicationsClient_DeleteExtension(t *testing.T, c ApplicationsClientTe
 }
 
 func testApplicationsClient_GetDeleted(t *testing.T, c ApplicationsClientTest, id string) (application *msgraph.Application) {
-	application, status, err := c.client.GetDeleted(c.connection.Context, id)
+	application, status, err := c.client.GetDeleted(c.connection.Context, id, odata.Query{})
 	if err != nil {
 		t.Fatalf("ApplicationsClient.GetDeleted(): %v", err)
 	}

--- a/msgraph/conditionalaccesspolicy.go
+++ b/msgraph/conditionalaccesspolicy.go
@@ -82,12 +82,13 @@ func (c *ConditionalAccessPolicyClient) Create(ctx context.Context, conditionalA
 }
 
 // Get retrieves a ConditionalAccessPolicy.
-func (c *ConditionalAccessPolicyClient) Get(ctx context.Context, id string) (*ConditionalAccessPolicy, int, error) {
+func (c *ConditionalAccessPolicyClient) Get(ctx context.Context, id string, query odata.Query) (*ConditionalAccessPolicy, int, error) {
 	resp, status, _, err := c.BaseClient.Get(ctx, GetHttpRequestInput{
 		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
 		ValidStatusCodes:       []int{http.StatusOK},
 		Uri: Uri{
 			Entity:      fmt.Sprintf("/identity/conditionalAccess/policies/%s", id),
+			Params:      query.Values(),
 			HasTenantId: true,
 		},
 	})

--- a/msgraph/conditionalaccesspolicy_test.go
+++ b/msgraph/conditionalaccesspolicy_test.go
@@ -100,7 +100,7 @@ func testConditionalAccessPolicysClient_Create(t *testing.T, c ConditionalAccess
 }
 
 func testConditionalAccessPolicysClient_Get(t *testing.T, c ConditionalAccessPolicyTest, id string) (policy *msgraph.ConditionalAccessPolicy) {
-	policy, status, err := c.policyClient.Get(c.connection.Context, id)
+	policy, status, err := c.policyClient.Get(c.connection.Context, id, odata.Query{})
 	if err != nil {
 		t.Fatalf("ConditionalAccessPolicyClient.Get(): %v", err)
 	}

--- a/msgraph/directory_audit_reports.go
+++ b/msgraph/directory_audit_reports.go
@@ -51,12 +51,13 @@ func (c *DirectoryAuditReportsClient) List(ctx context.Context, query odata.Quer
 }
 
 // Get retrieves a Directory audit report.
-func (c *DirectoryAuditReportsClient) Get(ctx context.Context, id string) (*DirectoryAudit, int, error) {
+func (c *DirectoryAuditReportsClient) Get(ctx context.Context, id string, query odata.Query) (*DirectoryAudit, int, error) {
 	resp, status, _, err := c.BaseClient.Get(ctx, GetHttpRequestInput{
 		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
 		ValidStatusCodes:       []int{http.StatusOK},
 		Uri: Uri{
 			Entity:      fmt.Sprintf("/auditLogs/directoryAudits/%s", id),
+			Params:      query.Values(),
 			HasTenantId: true,
 		},
 	})

--- a/msgraph/directory_audit_reports_test.go
+++ b/msgraph/directory_audit_reports_test.go
@@ -43,7 +43,7 @@ func testDirectoryAuditReports_List(t *testing.T, c DirectoryAuditReportsClientT
 }
 
 func testDirectoryAuditReports_Get(t *testing.T, c DirectoryAuditReportsClientTest, id string) (dirLog *msgraph.DirectoryAudit) {
-	dirLog, status, err := c.client.Get(c.connection.Context, id)
+	dirLog, status, err := c.client.Get(c.connection.Context, id, odata.Query{})
 	if err != nil {
 		t.Fatalf("DirectoryAuditReportsClient.Get(): %v", err)
 	}

--- a/msgraph/domains.go
+++ b/msgraph/domains.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+
+	"github.com/manicminer/hamilton/odata"
 )
 
 // DomainsClient performs operations on Domains.
@@ -21,12 +23,13 @@ func NewDomainsClient(tenantId string) *DomainsClient {
 }
 
 // List returns a list of Domains.
-func (c *DomainsClient) List(ctx context.Context) (*[]Domain, int, error) {
+func (c *DomainsClient) List(ctx context.Context, query odata.Query) (*[]Domain, int, error) {
 	var status int
 	resp, status, _, err := c.BaseClient.Get(ctx, GetHttpRequestInput{
 		ValidStatusCodes: []int{http.StatusOK},
 		Uri: Uri{
 			Entity:      "/domains",
+			Params:      query.Values(),
 			HasTenantId: true,
 		},
 	})
@@ -53,13 +56,14 @@ func (c *DomainsClient) List(ctx context.Context) (*[]Domain, int, error) {
 }
 
 // Get retrieves a Domain.
-func (c *DomainsClient) Get(ctx context.Context, id string) (*Domain, int, error) {
+func (c *DomainsClient) Get(ctx context.Context, id string, query odata.Query) (*Domain, int, error) {
 	var status int
 	resp, status, _, err := c.BaseClient.Get(ctx, GetHttpRequestInput{
 		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
 		ValidStatusCodes:       []int{http.StatusOK},
 		Uri: Uri{
 			Entity:      fmt.Sprintf("/domains/%s", id),
+			Params:      query.Values(),
 			HasTenantId: true,
 		},
 	})

--- a/msgraph/domains_test.go
+++ b/msgraph/domains_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/manicminer/hamilton/auth"
 	"github.com/manicminer/hamilton/internal/test"
 	"github.com/manicminer/hamilton/msgraph"
+	"github.com/manicminer/hamilton/odata"
 )
 
 type DomainsClientTest struct {
@@ -27,7 +28,7 @@ func TestDomainsClient(t *testing.T) {
 }
 
 func testDomainsClient_List(t *testing.T, c DomainsClientTest) (domains *[]msgraph.Domain) {
-	domains, _, err := c.client.List(c.connection.Context)
+	domains, _, err := c.client.List(c.connection.Context, odata.Query{})
 	if err != nil {
 		t.Fatalf("DomainsClient.List(): %v", err)
 	}
@@ -38,7 +39,7 @@ func testDomainsClient_List(t *testing.T, c DomainsClientTest) (domains *[]msgra
 }
 
 func testDomainsClient_Get(t *testing.T, c DomainsClientTest, id string) (domain *msgraph.Domain) {
-	domain, status, err := c.client.Get(c.connection.Context, id)
+	domain, status, err := c.client.Get(c.connection.Context, id, odata.Query{})
 	if err != nil {
 		t.Fatalf("DomainsClient.Get(): %v", err)
 	}

--- a/msgraph/groups.go
+++ b/msgraph/groups.go
@@ -81,12 +81,13 @@ func (c *GroupsClient) Create(ctx context.Context, group Group) (*Group, int, er
 }
 
 // Get retrieves a Group.
-func (c *GroupsClient) Get(ctx context.Context, id string) (*Group, int, error) {
+func (c *GroupsClient) Get(ctx context.Context, id string, query odata.Query) (*Group, int, error) {
 	resp, status, _, err := c.BaseClient.Get(ctx, GetHttpRequestInput{
 		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
 		ValidStatusCodes:       []int{http.StatusOK},
 		Uri: Uri{
 			Entity:      fmt.Sprintf("/groups/%s", id),
+			Params:      query.Values(),
 			HasTenantId: true,
 		},
 	})
@@ -106,12 +107,13 @@ func (c *GroupsClient) Get(ctx context.Context, id string) (*Group, int, error) 
 }
 
 // GetDeleted retrieves a deleted O365 Group.
-func (c *GroupsClient) GetDeleted(ctx context.Context, id string) (*Group, int, error) {
+func (c *GroupsClient) GetDeleted(ctx context.Context, id string, query odata.Query) (*Group, int, error) {
 	resp, status, _, err := c.BaseClient.Get(ctx, GetHttpRequestInput{
 		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
 		ValidStatusCodes:       []int{http.StatusOK},
 		Uri: Uri{
 			Entity:      fmt.Sprintf("/directory/deletedItems/%s", id),
+			Params:      query.Values(),
 			HasTenantId: true,
 		},
 	})

--- a/msgraph/groups_test.go
+++ b/msgraph/groups_test.go
@@ -139,7 +139,7 @@ func testGroupsClient_List(t *testing.T, c GroupsClientTest) (groups *[]msgraph.
 }
 
 func testGroupsClient_Get(t *testing.T, c GroupsClientTest, id string) (group *msgraph.Group) {
-	group, status, err := c.client.Get(c.connection.Context, id)
+	group, status, err := c.client.Get(c.connection.Context, id, odata.Query{})
 	if err != nil {
 		t.Fatalf("GroupsClient.Get(): %v", err)
 	}
@@ -275,7 +275,7 @@ func testGroupsClient_RemoveMembers(t *testing.T, c GroupsClientTest, groupId st
 }
 
 func testGroupsClient_GetDeleted(t *testing.T, c GroupsClientTest, id string) (group *msgraph.Group) {
-	group, status, err := c.client.GetDeleted(c.connection.Context, id)
+	group, status, err := c.client.GetDeleted(c.connection.Context, id, odata.Query{})
 	if err != nil {
 		t.Fatalf("GroupsClient.GetDeleted(): %v", err)
 	}

--- a/msgraph/me.go
+++ b/msgraph/me.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+
+	"github.com/manicminer/hamilton/odata"
 )
 
 // MeClient performs operations on the authenticated user.
@@ -21,12 +23,13 @@ func NewMeClient(tenantId string) *MeClient {
 }
 
 // Get retrieves information about the authenticated user.
-func (c *MeClient) Get(ctx context.Context) (*Me, int, error) {
+func (c *MeClient) Get(ctx context.Context, query odata.Query) (*Me, int, error) {
 	var status int
 	resp, status, _, err := c.BaseClient.Get(ctx, GetHttpRequestInput{
 		ValidStatusCodes: []int{http.StatusOK},
 		Uri: Uri{
 			Entity:      "/me",
+			Params:      query.Values(),
 			HasTenantId: false,
 		},
 	})
@@ -46,12 +49,13 @@ func (c *MeClient) Get(ctx context.Context) (*Me, int, error) {
 }
 
 // GetProfile retrieves the profile of the authenticated user.
-func (c *MeClient) GetProfile(ctx context.Context) (*Me, int, error) {
+func (c *MeClient) GetProfile(ctx context.Context, query odata.Query) (*Me, int, error) {
 	var status int
 	resp, status, _, err := c.BaseClient.Get(ctx, GetHttpRequestInput{
 		ValidStatusCodes: []int{http.StatusOK},
 		Uri: Uri{
 			Entity:      "/me/profile",
+			Params:      query.Values(),
 			HasTenantId: false,
 		},
 	})

--- a/msgraph/namedlocations.go
+++ b/msgraph/namedlocations.go
@@ -172,12 +172,13 @@ func (c *NamedLocationsClient) CreateCountry(ctx context.Context, countryNamedLo
 }
 
 // GetIP retrieves an IP Named Location.
-func (c *NamedLocationsClient) GetIP(ctx context.Context, id string) (*IPNamedLocation, int, error) {
+func (c *NamedLocationsClient) GetIP(ctx context.Context, id string, query odata.Query) (*IPNamedLocation, int, error) {
 	resp, status, _, err := c.BaseClient.Get(ctx, GetHttpRequestInput{
 		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
 		ValidStatusCodes:       []int{http.StatusOK},
 		Uri: Uri{
 			Entity:      fmt.Sprintf("/identity/conditionalAccess/namedLocations/%s", id),
+			Params:      query.Values(),
 			HasTenantId: true,
 		},
 	})
@@ -197,12 +198,13 @@ func (c *NamedLocationsClient) GetIP(ctx context.Context, id string) (*IPNamedLo
 }
 
 // Get retrieves a Named Location which can be type asserted back to IP or Country Named Location.
-func (c *NamedLocationsClient) Get(ctx context.Context, id string) (*NamedLocation, int, error) {
+func (c *NamedLocationsClient) Get(ctx context.Context, id string, query odata.Query) (*NamedLocation, int, error) {
 	resp, status, _, err := c.BaseClient.Get(ctx, GetHttpRequestInput{
 		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
 		ValidStatusCodes:       []int{http.StatusOK},
 		Uri: Uri{
 			Entity:      fmt.Sprintf("/identity/conditionalAccess/namedLocations/%s", id),
+			Params:      query.Values(),
 			HasTenantId: true,
 		},
 	})
@@ -248,12 +250,13 @@ func (c *NamedLocationsClient) Get(ctx context.Context, id string) (*NamedLocati
 }
 
 // GetCountry retrieves an Country Named Location.
-func (c *NamedLocationsClient) GetCountry(ctx context.Context, id string) (*CountryNamedLocation, int, error) {
+func (c *NamedLocationsClient) GetCountry(ctx context.Context, id string, query odata.Query) (*CountryNamedLocation, int, error) {
 	resp, status, _, err := c.BaseClient.Get(ctx, GetHttpRequestInput{
 		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
 		ValidStatusCodes:       []int{http.StatusOK},
 		Uri: Uri{
 			Entity:      fmt.Sprintf("/identity/conditionalAccess/namedLocations/%s", id),
+			Params:      query.Values(),
 			HasTenantId: true,
 		},
 	})

--- a/msgraph/namedlocations_test.go
+++ b/msgraph/namedlocations_test.go
@@ -106,7 +106,7 @@ func testNamedLocationsClient_CreateCountry(t *testing.T, c NamedLocationsClient
 }
 
 func testNamedLocationsClient_GetIP(t *testing.T, c NamedLocationsClientTest, id string) (ipNamedLocation *msgraph.IPNamedLocation) {
-	ipNamedLocation, status, err := c.client.GetIP(c.connection.Context, id)
+	ipNamedLocation, status, err := c.client.GetIP(c.connection.Context, id, odata.Query{})
 	if err != nil {
 		t.Fatalf("IPNamedLocationsClient.GetIP(): %v", err)
 	}
@@ -120,7 +120,7 @@ func testNamedLocationsClient_GetIP(t *testing.T, c NamedLocationsClientTest, id
 }
 
 func testNamedLocationsClient_GetCountry(t *testing.T, c NamedLocationsClientTest, id string) (countryNamedLocation *msgraph.CountryNamedLocation) {
-	countryNamedLocation, status, err := c.client.GetCountry(c.connection.Context, id)
+	countryNamedLocation, status, err := c.client.GetCountry(c.connection.Context, id, odata.Query{})
 	if err != nil {
 		t.Fatalf("NamedLocationsClient.GetCountry(): %v", err)
 	}
@@ -134,7 +134,7 @@ func testNamedLocationsClient_GetCountry(t *testing.T, c NamedLocationsClientTes
 }
 
 func testNamedLocationsClient_Get(t *testing.T, c NamedLocationsClientTest, id string) (namedLocation *msgraph.NamedLocation) {
-	namedLocation, status, err := c.client.Get(c.connection.Context, id)
+	namedLocation, status, err := c.client.Get(c.connection.Context, id, odata.Query{})
 	if err != nil {
 		t.Fatalf("NamedLocationsClient.Get(): %v", err)
 	}

--- a/msgraph/schema_extensions.go
+++ b/msgraph/schema_extensions.go
@@ -51,12 +51,13 @@ func (c *SchemaExtensionsClient) List(ctx context.Context, query odata.Query) (*
 }
 
 // Get retrieves a Schema Extension.
-func (c *SchemaExtensionsClient) Get(ctx context.Context, id string) (*SchemaExtension, int, error) {
+func (c *SchemaExtensionsClient) Get(ctx context.Context, id string, query odata.Query) (*SchemaExtension, int, error) {
 	resp, status, _, err := c.BaseClient.Get(ctx, GetHttpRequestInput{
 		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
 		ValidStatusCodes:       []int{http.StatusOK},
 		Uri: Uri{
 			Entity:      fmt.Sprintf("/schemaExtensions/%s", id),
+			Params:      query.Values(),
 			HasTenantId: true,
 		},
 	})

--- a/msgraph/schema_extensions_test.go
+++ b/msgraph/schema_extensions_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/manicminer/hamilton/internal/test"
 	"github.com/manicminer/hamilton/internal/utils"
 	"github.com/manicminer/hamilton/msgraph"
+	"github.com/manicminer/hamilton/odata"
 )
 
 type SchemaExtensionsClientTest struct {
@@ -72,7 +73,7 @@ func testSchemaExtensionsClient_Create(t *testing.T, c SchemaExtensionsClientTes
 }
 
 func testSchemaExtensionsClient_Get(t *testing.T, c SchemaExtensionsClientTest, id string) (schema *msgraph.SchemaExtension) {
-	schema, status, err := c.client.Get(c.connection.Context, id)
+	schema, status, err := c.client.Get(c.connection.Context, id, odata.Query{})
 	if err != nil {
 		t.Fatalf("SchemaExtensionsClient.Get(): %v", err)
 	}

--- a/msgraph/serviceprincipals.go
+++ b/msgraph/serviceprincipals.go
@@ -86,12 +86,13 @@ func (c *ServicePrincipalsClient) Create(ctx context.Context, servicePrincipal S
 }
 
 // Get retrieves a Service Principal.
-func (c *ServicePrincipalsClient) Get(ctx context.Context, id string) (*ServicePrincipal, int, error) {
+func (c *ServicePrincipalsClient) Get(ctx context.Context, id string, query odata.Query) (*ServicePrincipal, int, error) {
 	resp, status, _, err := c.BaseClient.Get(ctx, GetHttpRequestInput{
 		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
 		ValidStatusCodes:       []int{http.StatusOK},
 		Uri: Uri{
 			Entity:      fmt.Sprintf("/servicePrincipals/%s", id),
+			Params:      query.Values(),
 			HasTenantId: true,
 		},
 	})
@@ -430,12 +431,13 @@ func (c *ServicePrincipalsClient) ListOwnedObjects(ctx context.Context, id strin
 }
 
 // ListAppRoleAssignments retrieves a list of appRoleAssignment that users, groups, or client service principals have been granted for the given resource service principal.
-func (c *ServicePrincipalsClient) ListAppRoleAssignments(ctx context.Context, resourceId string) (*[]AppRoleAssignment, int, error) {
+func (c *ServicePrincipalsClient) ListAppRoleAssignments(ctx context.Context, resourceId string, query odata.Query) (*[]AppRoleAssignment, int, error) {
 	resp, status, _, err := c.BaseClient.Get(ctx, GetHttpRequestInput{
 		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
 		ValidStatusCodes:       []int{http.StatusOK},
 		Uri: Uri{
 			Entity:      fmt.Sprintf("/servicePrincipals/%s/appRoleAssignedTo", resourceId),
+			Params:      query.Values(),
 			HasTenantId: true,
 		},
 	})

--- a/msgraph/serviceprincipals_test.go
+++ b/msgraph/serviceprincipals_test.go
@@ -237,7 +237,7 @@ func testServicePrincipalsClient_List(t *testing.T, c ServicePrincipalsClientTes
 }
 
 func testServicePrincipalsClient_Get(t *testing.T, c ServicePrincipalsClientTest, id string) (servicePrincipal *msgraph.ServicePrincipal) {
-	servicePrincipal, status, err := c.client.Get(c.connection.Context, id)
+	servicePrincipal, status, err := c.client.Get(c.connection.Context, id, odata.Query{})
 	if err != nil {
 		t.Fatalf("ServicePrincipalsClient.Get(): %v", err)
 	}
@@ -402,7 +402,7 @@ func testServicePrincipalsClient_AssignAppRole(t *testing.T, c ServicePrincipals
 }
 
 func testServicePrincipalsClient_ListAppRoleAssignments(t *testing.T, c ServicePrincipalsClientTest, resourceId string) (appRoleAssignments *[]msgraph.AppRoleAssignment) {
-	appRoleAssignments, _, err := c.client.ListAppRoleAssignments(c.connection.Context, resourceId)
+	appRoleAssignments, _, err := c.client.ListAppRoleAssignments(c.connection.Context, resourceId, odata.Query{})
 	if err != nil {
 		t.Fatalf("ServicePrincipalsClient.ListAppRoleAssignments(): %v", err)
 	}

--- a/msgraph/sign_in_reports.go
+++ b/msgraph/sign_in_reports.go
@@ -51,12 +51,13 @@ func (c *SignInReportsClient) List(ctx context.Context, query odata.Query) (*[]S
 }
 
 // Get retrieves a Sign-in Report.
-func (c *SignInReportsClient) Get(ctx context.Context, id string) (*SignInReport, int, error) {
+func (c *SignInReportsClient) Get(ctx context.Context, id string, query odata.Query) (*SignInReport, int, error) {
 	resp, status, _, err := c.BaseClient.Get(ctx, GetHttpRequestInput{
 		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
 		ValidStatusCodes:       []int{http.StatusOK},
 		Uri: Uri{
 			Entity:      fmt.Sprintf("/auditLogs/signIns/%s", id),
+			Params:      query.Values(),
 			HasTenantId: true,
 		},
 	})

--- a/msgraph/sign_in_reports_test.go
+++ b/msgraph/sign_in_reports_test.go
@@ -43,7 +43,7 @@ func testSignInReports_List(t *testing.T, c SignInReportsClientTest) (signInLogs
 }
 
 func testSignInReports_Get(t *testing.T, c SignInReportsClientTest, id string) (signInLog *msgraph.SignInReport) {
-	signInLog, status, err := c.client.Get(c.connection.Context, id)
+	signInLog, status, err := c.client.Get(c.connection.Context, id, odata.Query{})
 	if err != nil {
 		t.Fatalf("SignInReportsClient.Get(): %v", err)
 	}

--- a/msgraph/users.go
+++ b/msgraph/users.go
@@ -81,12 +81,13 @@ func (c *UsersClient) Create(ctx context.Context, user User) (*User, int, error)
 }
 
 // Get retrieves a User.
-func (c *UsersClient) Get(ctx context.Context, id string) (*User, int, error) {
+func (c *UsersClient) Get(ctx context.Context, id string, query odata.Query) (*User, int, error) {
 	resp, status, _, err := c.BaseClient.Get(ctx, GetHttpRequestInput{
 		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
 		ValidStatusCodes:       []int{http.StatusOK},
 		Uri: Uri{
 			Entity:      fmt.Sprintf("/users/%s", id),
+			Params:      query.Values(),
 			HasTenantId: true,
 		},
 	})
@@ -106,12 +107,13 @@ func (c *UsersClient) Get(ctx context.Context, id string) (*User, int, error) {
 }
 
 // GetDeleted retrieves a deleted User.
-func (c *UsersClient) GetDeleted(ctx context.Context, id string) (*User, int, error) {
+func (c *UsersClient) GetDeleted(ctx context.Context, id string, query odata.Query) (*User, int, error) {
 	resp, status, _, err := c.BaseClient.Get(ctx, GetHttpRequestInput{
 		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
 		ValidStatusCodes:       []int{http.StatusOK},
 		Uri: Uri{
 			Entity:      fmt.Sprintf("/directory/deletedItems/%s", id),
+			Params:      query.Values(),
 			HasTenantId: true,
 		},
 	})

--- a/msgraph/users_test.go
+++ b/msgraph/users_test.go
@@ -118,7 +118,7 @@ func testUsersClient_List(t *testing.T, c UsersClientTest) (users *[]msgraph.Use
 }
 
 func testUsersClient_Get(t *testing.T, c UsersClientTest, id string) (user *msgraph.User) {
-	user, status, err := c.client.Get(c.connection.Context, id)
+	user, status, err := c.client.Get(c.connection.Context, id, odata.Query{})
 	if err != nil {
 		t.Fatalf("UsersClient.Get(): %v", err)
 	}
@@ -132,7 +132,7 @@ func testUsersClient_Get(t *testing.T, c UsersClientTest, id string) (user *msgr
 }
 
 func testUsersClient_GetDeleted(t *testing.T, c UsersClientTest, id string) (user *msgraph.User) {
-	user, status, err := c.client.GetDeleted(c.connection.Context, id)
+	user, status, err := c.client.GetDeleted(c.connection.Context, id, odata.Query{})
 	if err != nil {
 		t.Fatalf("UsersClient.GetDeleted(): %v", err)
 	}


### PR DESCRIPTION
Note: Breaking change that affects the following method signatures

- `ApplicationsClient{}.Get()`
- `ApplicationsClient{}.GetDeleted()`
- `ApplicationsClient{}.ListExtensions()`
- `ConditionalAccessPolicyClient{}.Get()`
- `DirectoryAuditReportsClient{}.Get()`
- `DomainsClient{}.List()`
- `DomainsClient{}.Get()`
- `GroupsClient{}.Get()`
- `GroupsClient{}.GetDeleted()`
- `MeClient{}.Get()`
- `MeClient{}.GetProfile()`
- `NamedLocationsClient{}.Get()`
- `NamedLocationsClient{}.GetCountry()`
- `NamedLocationsClient{}.GetIP()`
- `SchemaExtensionsClient{}.Get()`
- `ServicePrincipalsClient{}.Get()`
- `ServicePrincipalsClient{}.ListAppRoleAssignments()`
- `SignInReportsClient{}.Get()`
- `UsersClient{}.Get()`
- `UsersClient{}.GetDeleted()`