### PR TITLE
Support custom schema extensions for users and groups

### DIFF
--- a/internal/cmd/test-cleanup/main.go
+++ b/internal/cmd/test-cleanup/main.go
@@ -56,5 +56,6 @@ func main() {
 	cleanupApplications()
 	cleanupGroups()
 	cleanupUsers()
+	cleanupSchemaExtensions()
 	log.Println("Finished test cleanup")
 }

--- a/internal/cmd/test-cleanup/schemaextensions.go
+++ b/internal/cmd/test-cleanup/schemaextensions.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/manicminer/hamilton/msgraph"
+	"github.com/manicminer/hamilton/odata"
+)
+
+func cleanupSchemaExtensions() {
+	schemaExtensionsClient := msgraph.NewSchemaExtensionsClient(tenantId)
+	schemaExtensionsClient.BaseClient.Authorizer = authorizer
+
+	schemaExtensions, _, err := schemaExtensionsClient.List(ctx, odata.Query{Filter: fmt.Sprintf("status eq '%s'", msgraph.SchemaExtensionStatusInDevelopment)})
+	if err != nil {
+		log.Println(err)
+		return
+	}
+	if schemaExtensions == nil {
+		log.Println("bad API response, nil SchemaExtensions result received")
+		return
+	}
+	for _, schemaExtension := range *schemaExtensions {
+		if schemaExtension.ID == nil {
+			log.Println("Schema Extensions returned with nil ID")
+			continue
+		}
+
+		log.Printf("Deleting schema extension %q\n", *schemaExtension.ID)
+		_, err := schemaExtensionsClient.Delete(ctx, *schemaExtension.ID)
+		if err != nil {
+			log.Printf("Error when deleting schema extension %q: %v\n", *schemaExtension.ID, err)
+		}
+	}
+}

--- a/msgraph/groups.go
+++ b/msgraph/groups.go
@@ -106,6 +106,49 @@ func (c *GroupsClient) Get(ctx context.Context, id string, query odata.Query) (*
 	return &group, status, nil
 }
 
+// GetWithSchemaExtensions retrieves a Group, including the values for any specified schema extensions
+func (c *GroupsClient) GetWithSchemaExtensions(ctx context.Context, id string, query odata.Query, schemaExtensions *[]SchemaExtensionData) (*Group, int, error) {
+	var sel []string
+	if len(query.Select) > 0 {
+		sel = query.Select
+		query.Select = []string{}
+	}
+
+	group, status, err := c.Get(ctx, id, query)
+	if err != nil {
+		return group, status, err
+	}
+
+	if len(sel) > 0 {
+		query.Select = sel
+	}
+
+	var resp *http.Response
+	resp, status, _, err = c.BaseClient.Get(ctx, GetHttpRequestInput{
+		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
+		ValidStatusCodes:       []int{http.StatusOK},
+		Uri: Uri{
+			Entity:      fmt.Sprintf("/groups/%s", id),
+			Params:      query.Values(),
+			HasTenantId: true,
+		},
+	})
+	if err != nil {
+		return nil, status, fmt.Errorf("GroupsClient.BaseClient.Get(): %v", err)
+	}
+	defer resp.Body.Close()
+	respBody, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, status, fmt.Errorf("ioutil.ReadAll(): %v", err)
+	}
+
+	group.SchemaExtensions = schemaExtensions
+	if err := json.Unmarshal(respBody, group); err != nil {
+		return nil, status, fmt.Errorf("json.Unmarshal(): %v", err)
+	}
+	return group, status, nil
+}
+
 // GetDeleted retrieves a deleted O365 Group.
 func (c *GroupsClient) GetDeleted(ctx context.Context, id string, query odata.Query) (*Group, int, error) {
 	resp, status, _, err := c.BaseClient.Get(ctx, GetHttpRequestInput{

--- a/msgraph/models.go
+++ b/msgraph/models.go
@@ -841,12 +841,12 @@ type SchemaExtension struct {
 	Status      SchemaExtensionStatus        `json:"status,omitempty"`
 }
 
-type SchemaExtensionMap struct {
+type SchemaExtensionData struct {
 	ID         string
 	Properties SchemaExtensionProperties
 }
 
-func (se SchemaExtensionMap) MarshalJSON() ([]byte, error) {
+func (se SchemaExtensionData) MarshalJSON() ([]byte, error) {
 	in := map[string]interface{}{
 		se.ID: se.Properties,
 	}
@@ -1027,7 +1027,7 @@ type User struct {
 
 	PasswordProfile *UserPasswordProfile `json:"passwordProfile,omitempty"`
 
-	SchemaExtensions *[]SchemaExtensionMap `json:"-"`
+	SchemaExtensions *[]SchemaExtensionData `json:"-"`
 }
 
 func (u User) MarshalJSON() ([]byte, error) {

--- a/msgraph/models.go
+++ b/msgraph/models.go
@@ -838,7 +838,7 @@ type SchemaExtension struct {
 	Owner       *string                      `json:"owner,omitempty"`
 	Properties  *[]ExtensionSchemaProperty   `json:"properties,omitempty"`
 	TargetTypes *[]ExtensionSchemaTargetType `json:"targetTypes,omitempty"`
-	Status      *string                      `json:"status,omitempty"`
+	Status      SchemaExtensionStatus        `json:"status,omitempty"`
 }
 
 // ServicePrincipal describes a Service Principal object.

--- a/msgraph/models.go
+++ b/msgraph/models.go
@@ -101,7 +101,7 @@ func (a *Application) UnmarshalJSON(data []byte) error {
 	}{
 		application: (*application)(a),
 	}
-	if err := json.Unmarshal(data, &app); err != nil {
+	if err := json.Unmarshal(data, app); err != nil {
 		return err
 	}
 	if app.GroupMembershipClaims != nil {

--- a/msgraph/schema_extensions_test.go
+++ b/msgraph/schema_extensions_test.go
@@ -119,7 +119,7 @@ func testSchemaExtensionsUser_Get(t *testing.T, u UsersClientTest, id string, sc
 	for _, s := range schemaExtensions {
 		sel = append(sel, s.ID)
 	}
-	user, status, err := u.client.Get(u.connection.Context, id, odata.Query{Select: sel}, &schemaExtensions)
+	user, status, err := u.client.GetWithSchemaExtensions(u.connection.Context, id, odata.Query{Select: sel}, &schemaExtensions)
 	if err != nil {
 		t.Fatalf("UsersClient.Get(): %v", err)
 	}

--- a/msgraph/schema_extensions_test.go
+++ b/msgraph/schema_extensions_test.go
@@ -1,8 +1,10 @@
 package msgraph_test
 
 import (
+	"encoding/json"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/manicminer/hamilton/auth"
 	"github.com/manicminer/hamilton/internal/test"
@@ -14,14 +16,35 @@ import (
 type SchemaExtensionsClientTest struct {
 	connection   *test.Connection
 	client       *msgraph.SchemaExtensionsClient
-	randomstring string
+	randomString string
+}
+
+type ExtensionProperties struct {
+	Property1 *string `json:"property1,omitempty"`
+	Property2 *bool   `json:"property2,omitempty"`
+}
+
+func (e *ExtensionProperties) UnmarshalJSON(data []byte) error {
+	type ep ExtensionProperties
+	e2 := (*ep)(e)
+	return json.Unmarshal(data, e2)
 }
 
 func TestSchemaExtensionsClient(t *testing.T) {
+	rs := test.RandomString()
 	c := SchemaExtensionsClientTest{
 		connection:   test.NewConnection(auth.MsGraph, auth.TokenVersion2),
-		randomstring: test.RandomString(),
+		randomString: rs,
 	}
+	c.client = msgraph.NewSchemaExtensionsClient(c.connection.AuthConfig.TenantID)
+	c.client.BaseClient.Authorizer = c.connection.Authorizer
+
+	u := UsersClientTest{
+		connection:   test.NewConnection(auth.MsGraph, auth.TokenVersion2),
+		randomString: rs,
+	}
+	u.client = msgraph.NewUsersClient(u.connection.AuthConfig.TenantID)
+	u.client.BaseClient.Authorizer = u.connection.Authorizer
 
 	property1 := msgraph.ExtensionSchemaProperty{
 		Name: utils.StringPtr("property1"),
@@ -36,13 +59,12 @@ func TestSchemaExtensionsClient(t *testing.T) {
 	targetTypes := []msgraph.ExtensionSchemaTargetType{msgraph.ExtensionSchemaTargetTypeUser}
 	schemaExtension := msgraph.SchemaExtension{
 		Description: utils.StringPtr("This is a description"),
-		ID:          utils.StringPtr(fmt.Sprintf("schemaid%s", c.randomstring)),
+		ID:          utils.StringPtr("testschema"),
 		TargetTypes: &targetTypes,
 		Properties:  &[]msgraph.ExtensionSchemaProperty{property1},
+		Status:      msgraph.SchemaExtensionStatusInDevelopment,
 	}
 
-	c.client = msgraph.NewSchemaExtensionsClient(c.connection.AuthConfig.TenantID)
-	c.client.BaseClient.Authorizer = c.connection.Authorizer
 	schema := testSchemaExtensionsClient_Create(t, c, schemaExtension)
 	testSchemaExtensionsClient_Get(t, c, *schema.ID)
 
@@ -52,7 +74,68 @@ func TestSchemaExtensionsClient(t *testing.T) {
 	}
 
 	testSchemaExtensionsClient_Update(t, c, updateExtension)
+
+	time.Sleep(10 * time.Second)
+
+	user := testUsersClient_Create(t, u, msgraph.User{
+		AccountEnabled:    utils.BoolPtr(true),
+		DisplayName:       utils.StringPtr("test-user"),
+		MailNickname:      utils.StringPtr(fmt.Sprintf("test-user-%s", u.randomString)),
+		UserPrincipalName: utils.StringPtr(fmt.Sprintf("test-user-%s@%s", u.randomString, u.connection.DomainName)),
+		PasswordProfile: &msgraph.UserPasswordProfile{
+			Password: utils.StringPtr(fmt.Sprintf("IrPa55w0rd%s", c.randomString)),
+		},
+		SchemaExtensions: &[]msgraph.SchemaExtensionMap{
+			{
+				ID: *schema.ID,
+				Properties: &ExtensionProperties{
+					Property1: utils.StringPtr("my string value"),
+					Property2: utils.BoolPtr(true),
+				},
+			},
+		},
+	})
+
+	user = testSchemaExtensionsUser_Get(t, u, *user.ID, []msgraph.SchemaExtensionMap{
+		{
+			ID:         *schema.ID,
+			Properties: &ExtensionProperties{},
+		},
+	})
+	schemaExtensions := *user.SchemaExtensions
+	if val := schemaExtensions[0].Properties.(*ExtensionProperties).Property1; val == nil || *val != "my string value" {
+		t.Fatalf("Unexpected value for Property1 returned: %+v", val)
+	}
+	if val := schemaExtensions[0].Properties.(*ExtensionProperties).Property2; val == nil || !*val {
+		t.Fatalf("Unexpected value for Property2 returned: %+v", val)
+	}
+	testUsersClient_Delete(t, u, *user.ID)
+
 	testSchemaExtensionsClient_Delete(t, c, *schema.ID)
+}
+
+func testSchemaExtensionsUser_Get(t *testing.T, u UsersClientTest, id string, schemaExtensions []msgraph.SchemaExtensionMap) (user *msgraph.User) {
+	sel := []string{"id", "displayName"}
+	for _, s := range schemaExtensions {
+		sel = append(sel, s.ID)
+	}
+	user, status, err := u.client.Get(u.connection.Context, id, odata.Query{Select: sel}, &schemaExtensions)
+	if err != nil {
+		t.Fatalf("UsersClient.Get(): %v", err)
+	}
+	if status < 200 || status >= 300 {
+		t.Fatalf("UsersClient.Get(): invalid status: %d", status)
+	}
+	if user == nil {
+		t.Fatal("UsersClient.Get(): user was nil")
+	}
+	if user.SchemaExtensions == nil {
+		t.Fatal("UsersClient.Get(): user.SchemaExtensions was nil")
+	}
+	if len(*user.SchemaExtensions) != len(schemaExtensions) {
+		t.Fatalf("UsersClient.Get(): unexpected length of user.SchemaExtensions, was %d, expected %d", len(*user.SchemaExtensions), len(schemaExtensions))
+	}
+	return
 }
 
 func testSchemaExtensionsClient_Create(t *testing.T, c SchemaExtensionsClientTest, s msgraph.SchemaExtension) (schema *msgraph.SchemaExtension) {

--- a/msgraph/users.go
+++ b/msgraph/users.go
@@ -81,7 +81,7 @@ func (c *UsersClient) Create(ctx context.Context, user User) (*User, int, error)
 }
 
 // Get retrieves a User.
-func (c *UsersClient) Get(ctx context.Context, id string, query odata.Query) (*User, int, error) {
+func (c *UsersClient) Get(ctx context.Context, id string, query odata.Query, schemaExtensions *[]SchemaExtensionMap) (*User, int, error) {
 	resp, status, _, err := c.BaseClient.Get(ctx, GetHttpRequestInput{
 		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
 		ValidStatusCodes:       []int{http.StatusOK},
@@ -99,7 +99,7 @@ func (c *UsersClient) Get(ctx context.Context, id string, query odata.Query) (*U
 	if err != nil {
 		return nil, status, fmt.Errorf("ioutil.ReadAll(): %v", err)
 	}
-	var user User
+	user := User{SchemaExtensions: schemaExtensions}
 	if err := json.Unmarshal(respBody, &user); err != nil {
 		return nil, status, fmt.Errorf("json.Unmarshal(): %v", err)
 	}

--- a/msgraph/users.go
+++ b/msgraph/users.go
@@ -81,7 +81,7 @@ func (c *UsersClient) Create(ctx context.Context, user User) (*User, int, error)
 }
 
 // Get retrieves a User.
-func (c *UsersClient) Get(ctx context.Context, id string, query odata.Query, schemaExtensions *[]SchemaExtensionMap) (*User, int, error) {
+func (c *UsersClient) Get(ctx context.Context, id string, query odata.Query) (*User, int, error) {
 	resp, status, _, err := c.BaseClient.Get(ctx, GetHttpRequestInput{
 		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
 		ValidStatusCodes:       []int{http.StatusOK},
@@ -99,11 +99,54 @@ func (c *UsersClient) Get(ctx context.Context, id string, query odata.Query, sch
 	if err != nil {
 		return nil, status, fmt.Errorf("ioutil.ReadAll(): %v", err)
 	}
-	user := User{SchemaExtensions: schemaExtensions}
+	var user User
 	if err := json.Unmarshal(respBody, &user); err != nil {
 		return nil, status, fmt.Errorf("json.Unmarshal(): %v", err)
 	}
 	return &user, status, nil
+}
+
+// GetWithSchemaExtensions retrieves a User, including the values for any specified schema extensions
+func (c *UsersClient) GetWithSchemaExtensions(ctx context.Context, id string, query odata.Query, schemaExtensions *[]SchemaExtensionMap) (*User, int, error) {
+	var sel []string
+	if len(query.Select) > 0 {
+		sel = query.Select
+		query.Select = []string{}
+	}
+
+	user, status, err := c.Get(ctx, id, query)
+	if err != nil {
+		return user, status, err
+	}
+
+	if len(sel) > 0 {
+		query.Select = sel
+	}
+
+	var resp *http.Response
+	resp, status, _, err = c.BaseClient.Get(ctx, GetHttpRequestInput{
+		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
+		ValidStatusCodes:       []int{http.StatusOK},
+		Uri: Uri{
+			Entity:      fmt.Sprintf("/users/%s", id),
+			Params:      query.Values(),
+			HasTenantId: true,
+		},
+	})
+	if err != nil {
+		return nil, status, fmt.Errorf("UsersClient.BaseClient.Get(): %v", err)
+	}
+	defer resp.Body.Close()
+	respBody, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, status, fmt.Errorf("ioutil.ReadAll(): %v", err)
+	}
+
+	user.SchemaExtensions = schemaExtensions
+	if err := json.Unmarshal(respBody, user); err != nil {
+		return nil, status, fmt.Errorf("json.Unmarshal(): %v", err)
+	}
+	return user, status, nil
 }
 
 // GetDeleted retrieves a deleted User.

--- a/msgraph/users.go
+++ b/msgraph/users.go
@@ -107,7 +107,7 @@ func (c *UsersClient) Get(ctx context.Context, id string, query odata.Query) (*U
 }
 
 // GetWithSchemaExtensions retrieves a User, including the values for any specified schema extensions
-func (c *UsersClient) GetWithSchemaExtensions(ctx context.Context, id string, query odata.Query, schemaExtensions *[]SchemaExtensionMap) (*User, int, error) {
+func (c *UsersClient) GetWithSchemaExtensions(ctx context.Context, id string, query odata.Query, schemaExtensions *[]SchemaExtensionData) (*User, int, error) {
 	var sel []string
 	if len(query.Select) > 0 {
 		sel = query.Select

--- a/msgraph/users_test.go
+++ b/msgraph/users_test.go
@@ -118,7 +118,7 @@ func testUsersClient_List(t *testing.T, c UsersClientTest) (users *[]msgraph.Use
 }
 
 func testUsersClient_Get(t *testing.T, c UsersClientTest, id string) (user *msgraph.User) {
-	user, status, err := c.client.Get(c.connection.Context, id, odata.Query{}, nil)
+	user, status, err := c.client.Get(c.connection.Context, id, odata.Query{})
 	if err != nil {
 		t.Fatalf("UsersClient.Get(): %v", err)
 	}

--- a/msgraph/users_test.go
+++ b/msgraph/users_test.go
@@ -118,7 +118,7 @@ func testUsersClient_List(t *testing.T, c UsersClientTest) (users *[]msgraph.Use
 }
 
 func testUsersClient_Get(t *testing.T, c UsersClientTest, id string) (user *msgraph.User) {
-	user, status, err := c.client.Get(c.connection.Context, id, odata.Query{})
+	user, status, err := c.client.Get(c.connection.Context, id, odata.Query{}, nil)
 	if err != nil {
 		t.Fatalf("UsersClient.Get(): %v", err)
 	}

--- a/msgraph/utils.go
+++ b/msgraph/utils.go
@@ -1,0 +1,18 @@
+package msgraph
+
+import "encoding/json"
+
+func MarshalDocs(docs [][]byte) ([]byte, error) {
+	out := make(map[string]interface{})
+	for _, d := range docs {
+		var o map[string]interface{}
+		err := json.Unmarshal(d, &o)
+		if err != nil {
+			return d, err
+		}
+		for k, v := range o {
+			out[k] = v
+		}
+	}
+	return json.Marshal(out)
+}

--- a/msgraph/valuetypes.go
+++ b/msgraph/valuetypes.go
@@ -189,6 +189,10 @@ const (
 	SchemaExtensionStatusDeprecated    SchemaExtensionStatus = "Deprecated"
 )
 
+type SchemaExtensionProperties interface {
+	UnmarshalJSON([]byte) error
+}
+
 type SignInAudience = string
 
 const (

--- a/msgraph/valuetypes.go
+++ b/msgraph/valuetypes.go
@@ -181,6 +181,14 @@ const (
 	ResourceAccessTypeScope ResourceAccessType = "Scope"
 )
 
+type SchemaExtensionStatus = string
+
+const (
+	SchemaExtensionStatusInDevelopment SchemaExtensionStatus = "InDevelopment"
+	SchemaExtensionStatusAvailable     SchemaExtensionStatus = "Available"
+	SchemaExtensionStatusDeprecated    SchemaExtensionStatus = "Deprecated"
+)
+
 type SignInAudience = string
 
 const (

--- a/msgraph/valuetypes.go
+++ b/msgraph/valuetypes.go
@@ -193,6 +193,14 @@ type SchemaExtensionProperties interface {
 	UnmarshalJSON([]byte) error
 }
 
+type SchemaExtensionMap map[string]interface{}
+
+func (m *SchemaExtensionMap) UnmarshalJSON(data []byte) error {
+	type sem SchemaExtensionMap
+	m2 := (*sem)(m)
+	return json.Unmarshal(data, m2)
+}
+
 type SignInAudience = string
 
 const (


### PR DESCRIPTION
This introduces support for schema extension data for Groups and Users

Marshaling of schema extension data is handled automatically by the Group and User structs, enabling use of the existing `Update()` methods on the respective clients.

Unmarshaling is handled by either the provided `msgraph.SchemaExtensionMap` type, or a custom type supplied by the caller. Such a custom type must have an explicit `UnmarshalJSON()` method to satisfy the `SchemaExtensionProperties` interface. Both approaches are tested in the `TestSchemaExtensionsClient()` test.