### PR TITLE
Improve CachedAuthorizer

### DIFF
--- a/auth/azcli.go
+++ b/auth/azcli.go
@@ -86,7 +86,7 @@ func NewAzureCliConfig(api Api, tenantId string) (*AzureCliConfig, error) {
 // TokenSource provides a source for obtaining access tokens using AzureCliAuthorizer.
 func (c *AzureCliConfig) TokenSource(ctx context.Context) Authorizer {
 	// Cache access tokens internally to avoid unnecessary `az` invocations
-	return CachedAuthorizer(AzureCliAuthorizer{
+	return NewCachedAuthorizer(&AzureCliAuthorizer{
 		TenantID: c.TenantID,
 		ctx:      ctx,
 		conf:     c,

--- a/auth/clientcredentials.go
+++ b/auth/clientcredentials.go
@@ -79,9 +79,9 @@ type ClientCredentialsConfig struct {
 func (c *ClientCredentialsConfig) TokenSource(ctx context.Context, authType ClientCredentialsType) (source Authorizer) {
 	switch authType {
 	case ClientCredentialsAssertionType:
-		source = CachedAuthorizer(clientAssertionAuthorizer{ctx, c})
+		source = NewCachedAuthorizer(&clientAssertionAuthorizer{ctx, c})
 	case ClientCredentialsSecretType:
-		source = CachedAuthorizer(clientSecretAuthorizer{ctx, c})
+		source = NewCachedAuthorizer(&clientSecretAuthorizer{ctx, c})
 	}
 	return
 }

--- a/auth/msi.go
+++ b/auth/msi.go
@@ -115,7 +115,7 @@ func NewMsiConfig(ctx context.Context, resource string, msiEndpoint string) (*Ms
 
 // TokenSource provides a source for obtaining access tokens using MsiAuthorizer.
 func (c *MsiConfig) TokenSource(ctx context.Context) Authorizer {
-	return CachedAuthorizer(&MsiAuthorizer{ctx: ctx, conf: c})
+	return NewCachedAuthorizer(&MsiAuthorizer{ctx: ctx, conf: c})
 }
 
 func azureMetadata(ctx context.Context, url string) (body []byte, err error) {


### PR DESCRIPTION
- Export the Source authorizer to consumers can assert it
- Ensure the Source is a struct pointer for consistency
- Breaking: existing exported func `CachedAuthorizer` is renamed to `NewCachedAuthorizer`