### PR TITLE
Handle consistency related error that occurs possibly due to app ID collision in another tenant

### DIFF
--- a/msgraph/serviceprincipals.go
+++ b/msgraph/serviceprincipals.go
@@ -64,8 +64,13 @@ func (c *ServicePrincipalsClient) Create(ctx context.Context, servicePrincipal S
 	}
 
 	appNotReplicated := func(resp *http.Response, o *odata.OData) bool {
-		if resp != nil && resp.StatusCode == http.StatusBadRequest && o != nil && o.Error != nil {
-			return o.Error.Match(odata.ErrorServicePrincipalInvalidAppId)
+		if resp != nil && o != nil && o.Error != nil {
+			if resp.StatusCode == http.StatusBadRequest {
+				return o.Error.Match(odata.ErrorServicePrincipalInvalidAppId)
+			}
+			if resp.StatusCode == http.StatusForbidden {
+				return o.Error.Match(odata.ErrorServicePrincipalAppInOtherTenant)
+			}
 		}
 		return false
 	}

--- a/odata/odata.go
+++ b/odata/odata.go
@@ -13,6 +13,7 @@ const (
 	ErrorConflictingObjectPresentInDirectory    = "A conflicting object with one or more of the specified property values is present in the directory"
 	ErrorResourceDoesNotExist                   = "Resource '.+' does not exist or one of its queried reference-property objects are not present"
 	ErrorRemovedObjectReferencesDoNotExist      = "One or more removed object references do not exist"
+	ErrorServicePrincipalAppInOtherTenant       = "When using this permission, the backing application of the service principal being created must in the local tenant"
 	ErrorServicePrincipalInvalidAppId           = "The appId '.+' of the service principal does not reference a valid application object"
 	ErrorUnknownUnsupportedQuery                = "UnknownError: Unsupported Query"
 )


### PR DESCRIPTION
This occurs when the backing application for the service principal has not fully replicated. We'd usually see an `ErrorServicePrincipalInvalidAppId` here but sometimes this new error occurs within a 403 response.

Related: https://github.com/hashicorp/terraform-provider-azuread/issues/581