### PR TITLE
Add support for user's manager

### DIFF
--- a/msgraph/users.go
+++ b/msgraph/users.go
@@ -373,12 +373,14 @@ func (c *UsersClient) GetManager(ctx context.Context, id string) (*User, int, er
 	if err != nil {
 		return nil, status, err
 	}
+
 	defer resp.Body.Close()
 	respBody, _ := io.ReadAll(resp.Body)
 	var manager User
 	if err := json.Unmarshal(respBody, &manager); err != nil {
 		return nil, status, err
 	}
+
 	return &manager, status, nil
 }
 

--- a/msgraph/users.go
+++ b/msgraph/users.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"net/http"
 
 	"github.com/manicminer/hamilton/odata"
@@ -352,6 +353,54 @@ func (c *UsersClient) Sendmail(ctx context.Context, id string, message MailMessa
 		ValidStatusCodes: []int{http.StatusOK, http.StatusAccepted},
 		Uri: Uri{
 			Entity:      fmt.Sprintf("/users/%s/sendMail", id),
+			HasTenantId: true,
+		},
+	})
+	if err != nil {
+		return status, fmt.Errorf("UsersClient.BaseClient.Post(): %v", err)
+	}
+
+	return status, nil
+}
+
+// Get retrieves an  user or organizational contact assigned as the user's manager.
+func (c *UsersClient) GetManager(ctx context.Context, id string) (*User, int, error) {
+	resp, status, _, err := c.BaseClient.Get(ctx, GetHttpRequestInput{
+		ValidStatusCodes: []int{http.StatusOK},
+		Uri: Uri{
+			Entity: fmt.Sprintf("/users/%s/manager", id),
+		},
+	})
+	if err != nil {
+		return nil, status, err
+	}
+	defer resp.Body.Close()
+	respBody, _ := ioutil.ReadAll(resp.Body)
+	var manager User
+	if err := json.Unmarshal(respBody, &manager); err != nil {
+		return nil, status, err
+	}
+	return &manager, status, nil
+}
+
+// AssignManager assigns a user's manager.
+func (c *UsersClient) AssignManager(ctx context.Context, id string, manager User) (int, error) {
+	var status int
+
+	body, err := json.Marshal(struct {
+		Manager odata.Id `json:"@odata.id"`
+	}{
+		Manager: *manager.ODataId,
+	})
+	if err != nil {
+		return status, fmt.Errorf("json.Marshal(): %v", err)
+	}
+
+	_, status, _, err = c.BaseClient.Put(ctx, PutHttpRequestInput{
+		Body:             body,
+		ValidStatusCodes: []int{http.StatusNoContent},
+		Uri: Uri{
+			Entity:      fmt.Sprintf("/users/%s/manager/$ref", id),
 			HasTenantId: true,
 		},
 	})

--- a/msgraph/users.go
+++ b/msgraph/users.go
@@ -363,7 +363,7 @@ func (c *UsersClient) Sendmail(ctx context.Context, id string, message MailMessa
 	return status, nil
 }
 
-// Get retrieves an  user or organizational contact assigned as the user's manager.
+// GetManager retrieves an user or organizational contact assigned as the user's manager.
 func (c *UsersClient) GetManager(ctx context.Context, id string) (*User, int, error) {
 	resp, status, _, err := c.BaseClient.Get(ctx, GetHttpRequestInput{
 		ValidStatusCodes: []int{http.StatusOK},

--- a/msgraph/users.go
+++ b/msgraph/users.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 
 	"github.com/manicminer/hamilton/odata"
@@ -375,7 +374,7 @@ func (c *UsersClient) GetManager(ctx context.Context, id string) (*User, int, er
 		return nil, status, err
 	}
 	defer resp.Body.Close()
-	respBody, _ := ioutil.ReadAll(resp.Body)
+	respBody, _ := io.ReadAll(resp.Body)
 	var manager User
 	if err := json.Unmarshal(respBody, &manager); err != nil {
 		return nil, status, err


### PR DESCRIPTION
Add basic support for retrieving and assigning user's manager; was tested.

Reference to the documentation
* https://docs.microsoft.com/en-us/graph/api/user-list-manager?view=graph-rest-1.0&tabs=http
* https://docs.microsoft.com/en-us/graph/api/user-post-manager?view=graph-rest-1.0&tabs=http