### PR TITLE
Remove MSI sanity check

### DIFF
--- a/auth/msi.go
+++ b/auth/msi.go
@@ -105,24 +105,6 @@ func NewMsiConfig(ctx context.Context, resource, msiEndpoint, clientId string) (
 		endpoint = msiEndpoint
 	}
 
-	// validate the metadata endpoint
-	e, err := url.Parse(endpoint)
-	if err != nil {
-		return nil, fmt.Errorf("NewMsiConfig: invalid MSI endpoint configured: %q", endpoint)
-	}
-
-	// determine the generic metadata URL and check if we can reach it
-	e.Path = "/metadata"
-	e.RawQuery = url.Values{
-		"api-version": []string{msiDefaultApiVersion},
-		"format":      []string{"text"},
-	}.Encode()
-
-	_, err = azureMetadata(ctx, e.String())
-	if err != nil {
-		return nil, fmt.Errorf("NewMsiConfig: could not validate MSI endpoint: %v", err)
-	}
-
 	return &MsiConfig{
 		ClientID:      clientId,
 		Resource:      resource,


### PR DESCRIPTION
Remove MSI sanity check, since it's opinionated and works not in various envs such as CloudShell. The value added is comparitively small, since a similar error will occur slightly further along anyway when the first API call is attempted.

🧪 Tested on a linux VM and in Cloud Shell

Closes: #116
Related: https://github.com/hashicorp/terraform-provider-azuread/issues/633