### PR TITLE
Support more APIs, auth refactoring, multi-tenant auth, implement autorest.Authorizer, remove Azure Germany

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"net/http"
+	"net/http/httputil"
 	"os"
 
 	"github.com/manicminer/hamilton/auth"
@@ -44,21 +46,45 @@ var (
 func main() {
 	ctx := context.Background()
 
+	environment := environments.Global
+
 	authConfig := &auth.Config{
-		Environment:            environments.Global,
+		Environment:            environment,
 		TenantID:               tenantId,
 		ClientID:               clientId,
 		ClientSecret:           clientSecret,
 		EnableClientSecretAuth: true,
 	}
 
-	authorizer, err := authConfig.NewAuthorizer(ctx, auth.MsGraph)
+	authorizer, err := authConfig.NewAuthorizer(ctx, environment.MsGraph)
 	if err != nil {
 		log.Fatal(err)
 	}
 
+	requestLogger := func(req *http.Request) (*http.Request, error) {
+		if req != nil {
+			dmp, err := httputil.DumpRequestOut(req, true)
+			if err == nil {
+				log.Printf("REQUEST: %s", dmp)
+			}
+		}
+		return req, nil
+	}
+
+	responseLogger := func(req *http.Request, resp *http.Response) (*http.Response, error) {
+		if resp != nil {
+			dmp, err := httputil.DumpResponse(resp, true)
+			if err == nil {
+				log.Printf("RESPONSE: %s", dmp)
+			}
+		}
+		return resp, nil
+	}
+
 	client := msgraph.NewUsersClient(tenantId)
 	client.BaseClient.Authorizer = authorizer
+	client.BaseClient.RequestMiddlewares = &[]msgraph.RequestMiddleware{requestLogger}
+	client.BaseClient.ResponseMiddlewares = &[]msgraph.ResponseMiddleware{responseLogger}
 
 	users, _, err := client.List(ctx, odata.Query{})
 	if err != nil {

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ See [pkg.go.dev](https://pkg.go.dev/github.com/manicminer/hamilton).
 - Automatic retries for failed requests and handling of eventual consistency on writes due to propagation delays
 - Automatic paging of results
 - Native model structs for marshaling and unmarshaling
-- Support for national clouds including US Government (L4 and L5), China and Germany
+- Support for national clouds including US Government (L4 and L5) and China
 - Support for both the v1.0 and beta API endpoints
 - Ability to inject middleware functions for logging etc
 - OData parsing in API responses and support for OData queries such as filters, sorting, searching, expand and select

--- a/aadgraph/applicationrefs_test.go
+++ b/aadgraph/applicationrefs_test.go
@@ -16,9 +16,10 @@ type ApplicationRefsClientTest struct {
 
 func TestApplicationRefsClient(t *testing.T) {
 	c := ApplicationRefsClientTest{
-		connection:   test.NewConnection(auth.AadGraph, auth.TokenVersion1),
+		connection:   test.NewConnection(auth.TokenVersion1),
 		randomString: test.RandomString(),
 	}
+	c.connection.Authorize(c.connection.AuthConfig.Environment.MsGraph)
 	c.client = aadgraph.NewApplicationRefsClient(c.connection.AuthConfig.TenantID)
 	c.client.BaseClient.Authorizer = c.connection.Authorizer
 

--- a/aadgraph/applicationrefs_test.go
+++ b/aadgraph/applicationrefs_test.go
@@ -1,6 +1,7 @@
 package aadgraph_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/manicminer/hamilton/aadgraph"
@@ -15,11 +16,18 @@ type ApplicationRefsClientTest struct {
 }
 
 func TestApplicationRefsClient(t *testing.T) {
+	ctx := context.Background()
+	var cancel context.CancelFunc
+	if deadline, ok := t.Deadline(); ok {
+		ctx, cancel = context.WithDeadline(context.Background(), deadline)
+		defer cancel()
+	}
+
 	c := ApplicationRefsClientTest{
 		connection:   test.NewConnection(auth.TokenVersion1),
 		randomString: test.RandomString(),
 	}
-	c.connection.Authorize(c.connection.AuthConfig.Environment.MsGraph)
+	c.connection.Authorize(ctx, c.connection.AuthConfig.Environment.MsGraph)
 	c.client = aadgraph.NewApplicationRefsClient(c.connection.AuthConfig.TenantID)
 	c.client.BaseClient.Authorizer = c.connection.Authorizer
 

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -94,8 +94,8 @@ func (c *Config) NewAuthorizer(ctx context.Context, api Api) (Authorizer, error)
 }
 
 // NewAutorestAuthorizerWrapper returns an Authorizer that sources tokens from a supplied autorest.BearerAuthorizer
-func NewAutorestAuthorizerWrapper(bearerAuthorizer *autorest.BearerAuthorizer) (Authorizer, error) {
-	return &AutorestAuthorizerWrapper{authorizer: bearerAuthorizer}, nil
+func NewAutorestAuthorizerWrapper(autorestAuthorizer autorest.Authorizer) (Authorizer, error) {
+	return &AutorestAuthorizerWrapper{authorizer: autorestAuthorizer}, nil
 }
 
 // NewAzureCliAuthorizer returns an Authorizer which authenticates using the Azure CLI.

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -98,7 +98,7 @@ func NewAzureCliAuthorizer(ctx context.Context, api environments.Api, tenantId s
 
 // NewMsiAuthorizer returns an authorizer which uses managed service identity to for authentication.
 func NewMsiAuthorizer(ctx context.Context, api environments.Api, msiEndpoint, clientId string) (Authorizer, error) {
-	conf, err := NewMsiConfig(resource(api), msiEndpoint, clientId)
+	conf, err := NewMsiConfig(api.Resource(), msiEndpoint, clientId)
 	if err != nil {
 		return nil, err
 	}
@@ -132,8 +132,8 @@ func NewClientCertificateAuthorizer(ctx context.Context, environment environment
 		ClientID:           clientId,
 		PrivateKey:         x509.MarshalPKCS1PrivateKey(priv),
 		Certificate:        cert.Raw,
-		Resource:           resource(api),
-		Scopes:             scopes(api),
+		Resource:           api.Resource(),
+		Scopes:             []string{api.DefaultScope()},
 		TokenVersion:       tokenVersion,
 	}
 
@@ -148,8 +148,8 @@ func NewClientSecretAuthorizer(ctx context.Context, environment environments.Env
 		AuxiliaryTenantIDs: auxTenantIds,
 		ClientID:           clientId,
 		ClientSecret:       clientSecret,
-		Resource:           resource(api),
-		Scopes:             scopes(api),
+		Resource:           api.Resource(),
+		Scopes:             []string{api.DefaultScope()},
 		TokenVersion:       tokenVersion,
 	}
 
@@ -166,12 +166,4 @@ func TokenEndpoint(endpoint environments.AzureADEndpoint, tenant string, version
 	}
 	e = fmt.Sprintf("%s/token", e)
 	return
-}
-
-func scopes(api environments.Api) (s []string) {
-	return []string{fmt.Sprintf("%s/.default", api.Endpoint)}
-}
-
-func resource(api environments.Api) (r string) {
-	return fmt.Sprintf("%s/", api.Endpoint)
 }

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -25,6 +25,10 @@ type Api int
 const (
 	MsGraph Api = iota
 	AadGraph
+	ResourceManager
+	Batch
+	DataLake
+	OSSRDBMS
 )
 
 // NewAuthorizer returns a suitable Authorizer depending on what is defined in the Config
@@ -90,7 +94,7 @@ func (c *Config) NewAuthorizer(ctx context.Context, api Api) (Authorizer, error)
 
 // NewAutorestAuthorizerWrapper returns an Authorizer that sources tokens from a supplied autorest.BearerAuthorizer
 func NewAutorestAuthorizerWrapper(bearerAuthorizer *autorest.BearerAuthorizer) (Authorizer, error) {
-	return AutorestAuthorizerWrapper{bearerAuthorizer: bearerAuthorizer}, nil
+	return &AutorestAuthorizerWrapper{bearerAuthorizer: bearerAuthorizer}, nil
 }
 
 // NewAzureCliAuthorizer returns an Authorizer which authenticates using the Azure CLI.
@@ -175,6 +179,8 @@ func scopes(env environments.Environment, api Api) (s []string) {
 	case MsGraph:
 		s = []string{fmt.Sprintf("%s/.default", env.MsGraph.Endpoint)}
 	case AadGraph:
+		s = []string{fmt.Sprintf("%s/.default", env.AadGraph.Endpoint)}
+	case ResourceManager:
 		s = []string{fmt.Sprintf("%s/.default", env.AadGraph.Endpoint)}
 	}
 	return

--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -45,7 +45,7 @@ func testClientCertificateAuthorizer(ctx context.Context, t *testing.T, tokenVer
 
 	pfx := utils.Base64DecodeCertificate(clientCertificate)
 
-	auth, err := auth.NewClientCertificateAuthorizer(ctx, env, auth.MsGraph, tokenVersion, tenantId, []string{}, clientId, pfx, clientCertificatePath, clientCertPassword)
+	auth, err := auth.NewClientCertificateAuthorizer(ctx, env, env.MsGraph, tokenVersion, tenantId, []string{}, clientId, pfx, clientCertificatePath, clientCertPassword)
 	if err != nil {
 		t.Fatalf("NewClientCertificateAuthorizer(): %v", err)
 	}
@@ -83,7 +83,7 @@ func testClientSecretAuthorizer(ctx context.Context, t *testing.T, tokenVersion 
 		t.Fatal(err)
 	}
 
-	auth, err := auth.NewClientSecretAuthorizer(ctx, env, auth.MsGraph, tokenVersion, tenantId, []string{}, clientId, clientSecret)
+	auth, err := auth.NewClientSecretAuthorizer(ctx, env, env.MsGraph, tokenVersion, tenantId, []string{}, clientId, clientSecret)
 	if err != nil {
 		t.Fatalf("NewClientSecretAuthorizer(): %v", err)
 	}
@@ -111,7 +111,12 @@ func TestAzureCliAuthorizer(t *testing.T) {
 }
 
 func testAzureCliAuthorizer(ctx context.Context, t *testing.T) (token *oauth2.Token) {
-	auth, err := auth.NewAzureCliAuthorizer(ctx, auth.MsGraph, tenantId)
+	env, err := environments.EnvironmentFromString(environment)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	auth, err := auth.NewAzureCliAuthorizer(ctx, env.MsGraph, tenantId)
 	if err != nil {
 		t.Fatalf("NewAzureCliAuthorizer(): %v", err)
 	}
@@ -148,7 +153,7 @@ func TestMsiAuthorizer(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	auth, err := auth.NewMsiAuthorizer(ctx, env, auth.MsGraph, msiEndpoint, clientId)
+	auth, err := auth.NewMsiAuthorizer(ctx, env.MsGraph, msiEndpoint, clientId)
 	if err != nil {
 		t.Fatalf("NewMsiAuthorizer(): %v", err)
 	}

--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -45,7 +45,7 @@ func testClientCertificateAuthorizer(ctx context.Context, t *testing.T, tokenVer
 
 	pfx := utils.Base64DecodeCertificate(clientCertificate)
 
-	auth, err := auth.NewClientCertificateAuthorizer(ctx, env, auth.MsGraph, tokenVersion, tenantId, clientId, pfx, clientCertificatePath, clientCertPassword)
+	auth, err := auth.NewClientCertificateAuthorizer(ctx, env, auth.MsGraph, tokenVersion, tenantId, []string{}, clientId, pfx, clientCertificatePath, clientCertPassword)
 	if err != nil {
 		t.Fatalf("NewClientCertificateAuthorizer(): %v", err)
 	}
@@ -83,7 +83,7 @@ func testClientSecretAuthorizer(ctx context.Context, t *testing.T, tokenVersion 
 		t.Fatal(err)
 	}
 
-	auth, err := auth.NewClientSecretAuthorizer(ctx, env, auth.MsGraph, tokenVersion, tenantId, clientId, clientSecret)
+	auth, err := auth.NewClientSecretAuthorizer(ctx, env, auth.MsGraph, tokenVersion, tenantId, []string{}, clientId, clientSecret)
 	if err != nil {
 		t.Fatalf("NewClientSecretAuthorizer(): %v", err)
 	}

--- a/auth/autorest.go
+++ b/auth/autorest.go
@@ -14,7 +14,7 @@ type AutorestAuthorizerWrapper struct {
 }
 
 // Token returns an access token using an autorest.BearerAuthorizer struct
-func (a AutorestAuthorizerWrapper) Token() (*oauth2.Token, error) {
+func (a *AutorestAuthorizerWrapper) Token() (*oauth2.Token, error) {
 	tokenProvider := a.bearerAuthorizer.TokenProvider()
 	if refresher, ok := tokenProvider.(adal.Refresher); ok {
 		if err := refresher.EnsureFresh(); err != nil {

--- a/auth/autorest.go
+++ b/auth/autorest.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/Azure/go-autorest/autorest"
@@ -8,27 +9,59 @@ import (
 	"golang.org/x/oauth2"
 )
 
-// AutorestAuthorizerWrapper is an Authorizer which sources tokens from an autorest.BearerAuthorizer
+// AutorestAuthorizerWrapper is an Authorizer which sources tokens from an autorest.Authorizer
+// Currently supports only:
+// - autorest.BearerAuthorizer
+// - autorest.MultiTenantBearerAuthorizer
 type AutorestAuthorizerWrapper struct {
-	bearerAuthorizer *autorest.BearerAuthorizer
+	authorizer interface{}
+}
+
+func (a *AutorestAuthorizerWrapper) tokenProviders() (tokenProviders []adal.OAuthTokenProvider, err error) {
+	if authorizer, ok := a.authorizer.(*autorest.BearerAuthorizer); ok && authorizer != nil {
+		tokenProviders = append(tokenProviders, authorizer.TokenProvider())
+	} else if authorizer, ok := a.authorizer.(*autorest.MultiTenantBearerAuthorizer); ok && authorizer != nil {
+		if multiTokenProvider := authorizer.TokenProvider(); multiTokenProvider != nil {
+			if m, ok := multiTokenProvider.(*adal.MultiTenantServicePrincipalToken); ok && m != nil {
+				tokenProviders = append(tokenProviders, m.PrimaryToken)
+				for _, aux := range m.AuxiliaryTokens {
+					tokenProviders = append(tokenProviders, aux)
+				}
+			}
+		}
+	}
+
+	for _, tokenProvider := range tokenProviders {
+		if refresher, ok := tokenProvider.(adal.Refresher); ok {
+			if err = refresher.EnsureFresh(); err != nil {
+				return
+			}
+		} else if refresher, ok := tokenProvider.(adal.RefresherWithContext); ok {
+			if err = refresher.EnsureFreshWithContext(context.Background()); err != nil {
+				return
+			}
+		}
+	}
+
+	return
 }
 
 // Token returns an access token using an autorest.BearerAuthorizer struct
 func (a *AutorestAuthorizerWrapper) Token() (*oauth2.Token, error) {
-	tokenProvider := a.bearerAuthorizer.TokenProvider()
-	if refresher, ok := tokenProvider.(adal.Refresher); ok {
-		if err := refresher.EnsureFresh(); err != nil {
-			return nil, err
-		}
+	tokenProviders, err := a.tokenProviders()
+	if err != nil {
+		return nil, err
+	}
+	if len(tokenProviders) == 0 {
+		return nil, fmt.Errorf("no token providers returned")
 	}
 
 	var adalToken adal.Token
-	if spToken, ok := tokenProvider.(*adal.ServicePrincipalToken); ok {
+	if spToken, ok := tokenProviders[0].(*adal.ServicePrincipalToken); ok && spToken != nil {
 		adalToken = spToken.Token()
 	}
-
 	if adalToken.AccessToken == "" {
-		return nil, fmt.Errorf("could not obtain access token via supplied autorest.BearerAuthorizer")
+		return nil, fmt.Errorf("could not obtain access token from token provider")
 	}
 
 	return &oauth2.Token{
@@ -37,4 +70,35 @@ func (a *AutorestAuthorizerWrapper) Token() (*oauth2.Token, error) {
 		RefreshToken: adalToken.RefreshToken,
 		Expiry:       adalToken.Expires(),
 	}, nil
+}
+
+// AuxiliaryTokens returns additional tokens for auxiliary tenant IDs, sourced from an
+// autorest.MultiTenantBearerAuthorizer, for use in multi-tenant scenarios
+func (a *AutorestAuthorizerWrapper) AuxiliaryTokens() ([]*oauth2.Token, error) {
+	tokenProviders, err := a.tokenProviders()
+	if err != nil {
+		return nil, err
+	}
+
+	var auxTokens []*oauth2.Token
+	for i := 1; i < len(tokenProviders); i++ {
+		var adalToken adal.Token
+
+		if spToken, ok := tokenProviders[i].(*adal.ServicePrincipalToken); ok && spToken != nil {
+			adalToken = spToken.Token()
+		}
+
+		if adalToken.AccessToken == "" {
+			return nil, fmt.Errorf("could not obtain access token from token providers")
+		}
+
+		auxTokens = append(auxTokens, &oauth2.Token{
+			AccessToken:  adalToken.AccessToken,
+			TokenType:    adalToken.Type,
+			RefreshToken: adalToken.RefreshToken,
+			Expiry:       adalToken.Expires(),
+		})
+	}
+
+	return auxTokens, nil
 }

--- a/auth/azcli.go
+++ b/auth/azcli.go
@@ -71,6 +71,11 @@ func (a *AzureCliAuthorizer) Token() (*oauth2.Token, error) {
 	}, nil
 }
 
+// AuxiliaryTokens returns additional tokens for auxiliary tenant IDs, for use in multi-tenant scenarios
+func (a *AzureCliAuthorizer) AuxiliaryTokens() ([]*oauth2.Token, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
 // AzureCliConfig configures an AzureCliAuthorizer.
 type AzureCliConfig struct {
 	Api      Api

--- a/auth/azcli.go
+++ b/auth/azcli.go
@@ -10,10 +10,11 @@ import (
 	"os/exec"
 	"regexp"
 	"strings"
-	"time"
 
 	"github.com/hashicorp/go-version"
 	"golang.org/x/oauth2"
+
+	"github.com/manicminer/hamilton/environments"
 )
 
 const (
@@ -21,69 +22,19 @@ const (
 	azureCliNextMajorVersion = "3.0.0"
 )
 
-// AzureCliAuthorizer is an Authorizer which supports the Azure CLI.
-type AzureCliAuthorizer struct {
-	// TenantID is optional and forces selection of the specified tenant. Must be a valid UUID.
-	TenantID string
-
-	ctx  context.Context
-	conf *AzureCliConfig
-}
-
-// Token returns an access token using the Azure CLI as an authentication mechanism.
-func (a *AzureCliAuthorizer) Token() (*oauth2.Token, error) {
-	if a.conf == nil {
-		return nil, fmt.Errorf("could not request token: conf is nil")
-	}
-
-	var token struct {
-		AccessToken string `json:"accessToken"`
-		ExpiresOn   string `json:"expiresOn"`
-		Tenant      string `json:"tenant"`
-		TokenType   string `json:"tokenType"`
-	}
-
-	var resourceType string
-	switch a.conf.Api {
-	case MsGraph:
-		resourceType = "ms-graph"
-	case AadGraph:
-		resourceType = "aad-graph"
-	}
-
-	azArgs := []string{"account", "get-access-token", fmt.Sprintf("--resource-type=%s", resourceType)}
-
-	// Try to detect if we're running in Cloud Shell
-	if cloudShell := os.Getenv("AZUREPS_HOST_ENVIRONMENT"); !strings.HasPrefix(cloudShell, "cloud-shell/") {
-		// Seemingly not, so we'll append the tenant ID to the az args
-		azArgs = append(azArgs, "--tenant", a.conf.TenantID)
-	}
-
-	err := jsonUnmarshalAzCmd(&token, azArgs...)
-	if err != nil {
-		return nil, err
-	}
-
-	return &oauth2.Token{
-		AccessToken: token.AccessToken,
-		TokenType:   token.TokenType,
-		Expiry:      time.Time{},
-	}, nil
-}
-
-// AuxiliaryTokens returns additional tokens for auxiliary tenant IDs, for use in multi-tenant scenarios
-func (a *AzureCliAuthorizer) AuxiliaryTokens() ([]*oauth2.Token, error) {
-	return nil, fmt.Errorf("not implemented")
-}
-
 // AzureCliConfig configures an AzureCliAuthorizer.
 type AzureCliConfig struct {
-	Api      Api
+	Endpoint environments.ApiEndpoint
+
+	// TenantID is the required tenant ID for the primary token
 	TenantID string
+
+	// AuxiliaryTenantIDs is an optional list of tenant IDs for which to obtain additional tokens
+	AuxiliaryTenantIDs []string
 }
 
 // NewAzureCliConfig validates the supplied tenant ID and returns a new AzureCliConfig.
-func NewAzureCliConfig(api Api, tenantId string) (*AzureCliConfig, error) {
+func NewAzureCliConfig(api environments.Api, tenantId string) (*AzureCliConfig, error) {
 	var err error
 
 	// check az-cli version
@@ -100,7 +51,7 @@ func NewAzureCliConfig(api Api, tenantId string) (*AzureCliConfig, error) {
 		return nil, errors.New("invalid tenantId or unable to determine tenantId")
 	}
 
-	return &AzureCliConfig{Api: api, TenantID: tenantId}, nil
+	return &AzureCliConfig{Endpoint: api.Endpoint, TenantID: tenantId}, nil
 }
 
 // TokenSource provides a source for obtaining access tokens using AzureCliAuthorizer.
@@ -111,6 +62,76 @@ func (c *AzureCliConfig) TokenSource(ctx context.Context) Authorizer {
 		ctx:      ctx,
 		conf:     c,
 	})
+}
+
+type azureCliToken struct {
+	AccessToken string `json:"accessToken"`
+	ExpiresOn   string `json:"expiresOn"`
+	Tenant      string `json:"tenant"`
+	TokenType   string `json:"tokenType"`
+}
+
+// AzureCliAuthorizer is an Authorizer which supports the Azure CLI.
+type AzureCliAuthorizer struct {
+	// TenantID is optional and forces selection of the specified tenant. Must be a valid UUID.
+	TenantID string
+
+	ctx  context.Context
+	conf *AzureCliConfig
+}
+
+// Token returns an access token using the Azure CLI as an authentication mechanism.
+func (a *AzureCliAuthorizer) Token() (*oauth2.Token, error) {
+	if a.conf == nil {
+		return nil, fmt.Errorf("could not request token: conf is nil")
+	}
+
+	azArgs := []string{"account", "get-access-token", fmt.Sprintf("--resource=%s", a.conf.Endpoint)}
+
+	// Try to detect if we're running in Cloud Shell
+	if cloudShell := os.Getenv("AZUREPS_HOST_ENVIRONMENT"); !strings.HasPrefix(cloudShell, "cloud-shell/") {
+		// Seemingly not, so we'll append the tenant ID to the az args
+		azArgs = append(azArgs, "--tenant", a.conf.TenantID)
+	}
+
+	var token azureCliToken
+	err := jsonUnmarshalAzCmd(&token, azArgs...)
+	if err != nil {
+		return nil, err
+	}
+
+	return &oauth2.Token{
+		AccessToken: token.AccessToken,
+		TokenType:   token.TokenType,
+	}, nil
+}
+
+// AuxiliaryTokens returns additional tokens for auxiliary tenant IDs, for use in multi-tenant scenarios
+func (a *AzureCliAuthorizer) AuxiliaryTokens() ([]*oauth2.Token, error) {
+	if a.conf == nil {
+		return nil, fmt.Errorf("could not request token: conf is nil")
+	}
+
+	// Try to detect if we're running in Cloud Shell
+	if cloudShell := os.Getenv("AZUREPS_HOST_ENVIRONMENT"); strings.HasPrefix(cloudShell, "cloud-shell/") {
+		return nil, fmt.Errorf("auxiliary tokens not supported in Cloud Shell")
+	}
+
+	tokens := make([]*oauth2.Token, 0)
+	for _, tenantId := range a.conf.AuxiliaryTenantIDs {
+		var token azureCliToken
+		err := jsonUnmarshalAzCmd(&token, "account", "get-access-token", fmt.Sprintf("--resource=%s", a.conf.Endpoint), "--tenant", tenantId)
+		if err != nil {
+			return nil, err
+		}
+
+		tokens = append(tokens, &oauth2.Token{
+			AccessToken: token.AccessToken,
+			TokenType:   token.TokenType,
+		})
+	}
+
+	return tokens, nil
 }
 
 // checkAzVersion tries to determine the version of Azure CLI in the path and checks for a compatible version

--- a/auth/cache.go
+++ b/auth/cache.go
@@ -3,6 +3,7 @@ package auth
 import (
 	"fmt"
 	"net/http"
+	"strings"
 	"sync"
 
 	"github.com/Azure/go-autorest/autorest"
@@ -14,8 +15,9 @@ type CachedAuthorizer struct {
 	// Source contains the underlying Authorizer for obtaining tokens
 	Source Authorizer
 
-	mutex sync.RWMutex
-	token *oauth2.Token
+	mutex     sync.RWMutex
+	token     *oauth2.Token
+	auxTokens []*oauth2.Token
 }
 
 // Token returns the current token if it's still valid, else will acquire a new token
@@ -27,27 +29,72 @@ func (c *CachedAuthorizer) Token() (*oauth2.Token, error) {
 	if !valid {
 		c.mutex.Lock()
 		defer c.mutex.Unlock()
-		token, err := c.Source.Token()
+		var err error
+		c.token, err = c.Source.Token()
 		if err != nil {
 			return nil, err
 		}
-		c.token = token
 	}
 
 	return c.token, nil
 }
 
+// AuxiliaryTokens returns additional tokens for auxiliary tenant IDs, for use in multi-tenant scenarios
+func (c *CachedAuthorizer) AuxiliaryTokens() ([]*oauth2.Token, error) {
+	c.mutex.RLock()
+	var valid bool
+	for _, token := range c.auxTokens {
+		valid = token != nil && token.Valid()
+		if !valid {
+			break
+		}
+	}
+	c.mutex.RUnlock()
+
+	if !valid {
+		c.mutex.Lock()
+		defer c.mutex.Unlock()
+		var err error
+		c.auxTokens, err = c.Source.AuxiliaryTokens()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return c.auxTokens, nil
+}
+
 func (c *CachedAuthorizer) WithAuthorization() autorest.PrepareDecorator {
 	return func(p autorest.Preparer) autorest.Preparer {
 		return autorest.PreparerFunc(func(req *http.Request) (*http.Request, error) {
-			req, err := p.Prepare(req)
+			var err error
+			req, err = p.Prepare(req)
 			if err == nil {
 				token, err := c.Token()
 				if err != nil {
 					return nil, err
 				}
-				return autorest.Prepare(req, autorest.WithHeader("Authorization", fmt.Sprintf("Bearer %s", token.AccessToken)))
+
+				req, err = autorest.Prepare(req, autorest.WithHeader("Authorization", fmt.Sprintf("Bearer %s", token.AccessToken)))
+				if err != nil {
+					return req, err
+				}
+
+				auxTokens, err := c.AuxiliaryTokens()
+				if err != nil {
+					return req, err
+				}
+
+				auxTokenList := make([]string, 0)
+				for _, a := range auxTokens {
+					if a != nil && a.AccessToken != "" {
+						auxTokenList = append(auxTokenList, fmt.Sprintf("%s %s", a.TokenType, a.AccessToken))
+					}
+				}
+
+				return autorest.Prepare(req, autorest.WithHeader("x-ms-authorization-auxiliary", strings.Join(auxTokenList, ", ")))
 			}
+
 			return req, err
 		})
 	}

--- a/auth/config.go
+++ b/auth/config.go
@@ -21,6 +21,9 @@ type Config struct {
 	// Azure Active Directory tenant to connect to, should be a valid UUID
 	TenantID string
 
+	// Auxiliary tenant IDs for which to obtain tokens in a multi-tenant scenario
+	AuxiliaryTenantIDs []string
+
 	// Client ID for the application used to authenticate the connection
 	ClientID string
 

--- a/auth/msi.go
+++ b/auth/msi.go
@@ -82,6 +82,11 @@ func (a *MsiAuthorizer) Token() (*oauth2.Token, error) {
 	return token, nil
 }
 
+// AuxiliaryTokens returns additional tokens for auxiliary tenant IDs, for use in multi-tenant scenarios
+func (a *MsiAuthorizer) AuxiliaryTokens() ([]*oauth2.Token, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
 // MsiConfig configures an MsiAuthorizer.
 type MsiConfig struct {
 	// ClientID is optionally used to determine which application to assume when a resource has multiple managed identities

--- a/auth/msi.go
+++ b/auth/msi.go
@@ -104,7 +104,7 @@ type MsiConfig struct {
 
 // NewMsiConfig returns a new MsiConfig with a configured metadata endpoint and resource.
 // clientId and objectId can be left blank when a single managed identity is available
-func NewMsiConfig(ctx context.Context, resource, msiEndpoint, clientId string) (*MsiConfig, error) {
+func NewMsiConfig(resource, msiEndpoint, clientId string) (*MsiConfig, error) {
 	endpoint := msiDefaultEndpoint
 	if msiEndpoint != "" {
 		endpoint = msiEndpoint

--- a/auth/msi.go
+++ b/auth/msi.go
@@ -84,7 +84,7 @@ func (a *MsiAuthorizer) Token() (*oauth2.Token, error) {
 
 // AuxiliaryTokens returns additional tokens for auxiliary tenant IDs, for use in multi-tenant scenarios
 func (a *MsiAuthorizer) AuxiliaryTokens() ([]*oauth2.Token, error) {
-	return nil, fmt.Errorf("not implemented")
+	return nil, fmt.Errorf("auxiliary tokens are not supported with MSI authentication")
 }
 
 // MsiConfig configures an MsiAuthorizer.

--- a/environments/apis.go
+++ b/environments/apis.go
@@ -1,5 +1,9 @@
 package environments
 
+import (
+	"fmt"
+)
+
 // API represent an API configuration for Microsoft Graph or Azure Active Directory Graph.
 type Api struct {
 	// The Application ID for the API.
@@ -7,6 +11,14 @@ type Api struct {
 
 	// The endpoint for the API, including scheme.
 	Endpoint ApiEndpoint
+}
+
+func (a *Api) DefaultScope() string {
+	return fmt.Sprintf("%s/.default", a.Endpoint)
+}
+
+func (a *Api) Resource() string {
+	return fmt.Sprintf("%s/", a.Endpoint)
 }
 
 var (

--- a/environments/apis.go
+++ b/environments/apis.go
@@ -1,68 +1,229 @@
 package environments
 
-type ApiEndpoint string
+// API represent an API configuration for Microsoft Graph or Azure Active Directory Graph.
+type Api struct {
+	// The Application ID for the API.
+	AppId ApiAppId
 
-const (
-	MsGraphGlobalEndpoint  ApiEndpoint = "https://graph.microsoft.com"
-	MsGraphGermanyEndpoint ApiEndpoint = "https://graph.microsoft.de"
-	MsGraphChinaEndpoint   ApiEndpoint = "https://microsoftgraph.chinacloudapi.cn"
-	MsGraphUSGovL4Endpoint ApiEndpoint = "https://graph.microsoft.us"
-	MsGraphUSGovL5Endpoint ApiEndpoint = "https://dod-graph.microsoft.us"
-	MsGraphCanaryEndpoint  ApiEndpoint = "https://canary.graph.microsoft.com"
+	// The endpoint for the API, including scheme.
+	Endpoint ApiEndpoint
+}
 
-	AadGraphGlobalEndpoint  ApiEndpoint = "https://graph.windows.net"
-	AadGraphGermanyEndpoint ApiEndpoint = "https://graph.cloudapi.de"
-	AadGraphChinaEndpoint   ApiEndpoint = "https://graph.chinacloudapi.cn"
-	AadGraphUSGovEndpoint   ApiEndpoint = "https://graph.microsoftazure.us"
+var (
+	MsGraphGlobal = Api{
+		AppId:    PublishedApis["MicrosoftGraph"],
+		Endpoint: MsGraphGlobalEndpoint,
+	}
 
-	ResourceManagerPublicEndpoint  ApiEndpoint = "https://management.azure.com"
-	ResourceManagerGermanyEndpoint ApiEndpoint = "https://management.microsoftazure.de"
-	ResourceManagerChinaEndpoint   ApiEndpoint = "https://management.chinacloudapi.cn"
-	ResourceManagerUSGovEndpoint   ApiEndpoint = "https://management.usgovcloudapi.net"
+	MsGraphGermany = Api{
+		AppId:    PublishedApis["MicrosoftGraph"],
+		Endpoint: MsGraphGermanyEndpoint,
+	}
 
-	BatchManagementPublicEndpoint  ApiEndpoint = "https://batch.core.windows.net"
-	BatchManagementGermanyEndpoint ApiEndpoint = "https://batch.cloudapi.de"
-	BatchManagementChinaEndpoint   ApiEndpoint = "https://batch.chinacloudapi.cn"
-	BatchManagementUSGovEndpoint   ApiEndpoint = "https://batch.core.usgovcloudapi.net"
+	MsGraphChina = Api{
+		AppId:    PublishedApis["MicrosoftGraph"],
+		Endpoint: MsGraphChinaEndpoint,
+	}
 
-	DataLakePublicEndpoint ApiEndpoint = "https://datalake.azure.net"
+	MsGraphUSGovL4 = Api{
+		AppId:    PublishedApis["MicrosoftGraph"],
+		Endpoint: MsGraphUSGovL4Endpoint,
+	}
 
-	GalleryPublicEndpoint  ApiEndpoint = "https://gallery.azure.com"
-	GalleryGermanyEndpoint ApiEndpoint = "https://gallery.cloudapi.de"
-	GalleryChinaEndpoint   ApiEndpoint = "https://gallery.chinacloudapi.cn"
-	GalleryUSGovEndpoint   ApiEndpoint = "https://gallery.usgovcloudapi.net"
+	MsGraphUSGovL5 = Api{
+		AppId:    PublishedApis["MicrosoftGraph"],
+		Endpoint: MsGraphUSGovL5Endpoint,
+	}
 
-	KeyVaultPublicEndpoint  ApiEndpoint = "https://vault.azure.net"
-	KeyVaultGermanyEndpoint ApiEndpoint = "https://vault.azure.net"
-	KeyVaultChinaEndpoint   ApiEndpoint = "https://vault.azure.cn"
-	KeyVaultUSGovEndpoint   ApiEndpoint = "https://vault.microsoftazure.de"
+	MsGraphCanary = Api{
+		AppId:    PublishedApis["MicrosoftGraph"],
+		Endpoint: MsGraphCanaryEndpoint,
+	}
 
-	OperationalInsightsPublicEndpoint ApiEndpoint = "https://api.loganalytics.io"
-	OperationalInsightsUSGovEndpoint  ApiEndpoint = "https://api.loganalytics.us"
+	AadGraphGlobal = Api{
+		AppId:    PublishedApis["AzureActiveDirectoryGraph"],
+		Endpoint: AadGraphGlobalEndpoint,
+	}
 
-	OSSRDBMSPublicEndpoint  ApiEndpoint = "https://ossrdbms-aad.database.windows.net"
-	OSSRDBMSGermanyEndpoint ApiEndpoint = "https://ossrdbms-aad.database.cloudapi.de"
-	OSSRDBMSChinaEndpoint   ApiEndpoint = "https://ossrdbms-aad.database.chinacloudapi.cn"
-	OSSRDBMSUSGovEndpoint   ApiEndpoint = "https://ossrdbms-aad.database.usgovcloudapi.net"
+	AadGraphGermany = Api{
+		AppId:    PublishedApis["AzureActiveDirectoryGraph"],
+		Endpoint: AadGraphGermanyEndpoint,
+	}
 
-	ServiceBusPublicEndpoint  ApiEndpoint = "https://servicebus.windows.net"
-	ServiceBusGermanyEndpoint ApiEndpoint = "https://servicebus.cloudapi.de"
-	ServiceBusChinaEndpoint   ApiEndpoint = "https://servicebus.chinacloudapi.cn"
-	ServiceBusUSGovEndpoint   ApiEndpoint = "https://servicebus.usgovcloudapi.net"
+	AadGraphChina = Api{
+		AppId:    PublishedApis["AzureActiveDirectoryGraph"],
+		Endpoint: AadGraphChinaEndpoint,
+	}
 
-	ServiceManagementPublicEndpoint  ApiEndpoint = "https://management.core.windows.net"
-	ServiceManagementGermanyEndpoint ApiEndpoint = "https://management.core.cloudapi.de"
-	ServiceManagementChinaEndpoint   ApiEndpoint = "https://management.core.chinacloudapi.cn"
-	ServiceManagementUSGovEndpoint   ApiEndpoint = "https://management.core.usgovcloudapi.net"
+	AadGraphUSGov = Api{
+		AppId:    PublishedApis["AzureActiveDirectoryGraph"],
+		Endpoint: AadGraphUSGovEndpoint,
+	}
 
-	SQLDatabasePublicEndpoint  ApiEndpoint = "https://database.windows.net"
-	SQLDatabaseGermanyEndpoint ApiEndpoint = "https://database.cloudapi.de"
-	SQLDatabaseChinaEndpoint   ApiEndpoint = "https://database.chinacloudapi.cn"
-	SQLDatabaseUSGovEndpoint   ApiEndpoint = "https://database.usgovcloudapi.net"
+	ResourceManagerPublic = Api{
+		AppId:    PublishedApis["AzureServiceManagement"],
+		Endpoint: ResourceManagerPublicEndpoint,
+	}
 
-	StoragePublicEndpoint ApiEndpoint = "https://storage.azure.com"
+	ResourceManagerGermany = Api{
+		AppId:    PublishedApis["AzureServiceManagement"],
+		Endpoint: ResourceManagerGermanyEndpoint,
+	}
 
-	SynapsePublicEndpoint ApiEndpoint = "https://dev.azuresynapse.net"
+	ResourceManagerChina = Api{
+		AppId:    PublishedApis["AzureServiceManagement"],
+		Endpoint: ResourceManagerChinaEndpoint,
+	}
+
+	ResourceManagerUSGov = Api{
+		AppId:    PublishedApis["AzureServiceManagement"],
+		Endpoint: ResourceManagerUSGovEndpoint,
+	}
+
+	BatchManagementPublic = Api{
+		AppId:    PublishedApis["AzureBatch"],
+		Endpoint: BatchManagementPublicEndpoint,
+	}
+
+	BatchManagementGermany = Api{
+		AppId:    PublishedApis["AzureBatch"],
+		Endpoint: BatchManagementGermanyEndpoint,
+	}
+
+	BatchManagementChina = Api{
+		AppId:    PublishedApis["AzureBatch"],
+		Endpoint: BatchManagementChinaEndpoint,
+	}
+
+	BatchManagementUSGov = Api{
+		AppId:    PublishedApis["AzureBatch"],
+		Endpoint: BatchManagementUSGovEndpoint,
+	}
+
+	DataLakePublic = Api{
+		AppId:    PublishedApis["AzureDataLake"],
+		Endpoint: DataLakePublicEndpoint,
+	}
+
+	KeyVaultPublic = Api{
+		AppId:    PublishedApis["AzureBatch"],
+		Endpoint: KeyVaultPublicEndpoint,
+	}
+
+	KeyVaultGermany = Api{
+		AppId:    PublishedApis["AzureBatch"],
+		Endpoint: KeyVaultGermanyEndpoint,
+	}
+
+	KeyVaultChina = Api{
+		AppId:    PublishedApis["AzureBatch"],
+		Endpoint: KeyVaultChinaEndpoint,
+	}
+
+	KeyVaultUSGov = Api{
+		AppId:    PublishedApis["AzureBatch"],
+		Endpoint: KeyVaultUSGovEndpoint,
+	}
+
+	OperationalInsightsPublic = Api{
+		AppId:    PublishedApis["LogAnalytics"],
+		Endpoint: OperationalInsightsPublicEndpoint,
+	}
+
+	OperationalInsightsUSGov = Api{
+		AppId:    PublishedApis["LogAnalytics"],
+		Endpoint: OperationalInsightsUSGovEndpoint,
+	}
+
+	OSSRDBMSPublic = Api{
+		AppId:    PublishedApis["OssRdbms"],
+		Endpoint: OSSRDBMSPublicEndpoint,
+	}
+
+	OSSRDBMSGermany = Api{
+		AppId:    PublishedApis["OssRdbms"],
+		Endpoint: OSSRDBMSGermanyEndpoint,
+	}
+
+	OSSRDBMSChina = Api{
+		AppId:    PublishedApis["OssRdbms"],
+		Endpoint: OSSRDBMSChinaEndpoint,
+	}
+
+	OSSRDBMSUSGov = Api{
+		AppId:    PublishedApis["OssRdbms"],
+		Endpoint: OSSRDBMSUSGovEndpoint,
+	}
+
+	ServiceBusPublic = Api{
+		AppId:    PublishedApis["AzureServiceBus"],
+		Endpoint: ServiceBusPublicEndpoint,
+	}
+
+	ServiceBusGermany = Api{
+		AppId:    PublishedApis["AzureServiceBus"],
+		Endpoint: ServiceBusGermanyEndpoint,
+	}
+
+	ServiceBusChina = Api{
+		AppId:    PublishedApis["AzureServiceBus"],
+		Endpoint: ServiceBusChinaEndpoint,
+	}
+
+	ServiceBusUSGov = Api{
+		AppId:    PublishedApis["AzureServiceBus"],
+		Endpoint: ServiceBusUSGovEndpoint,
+	}
+
+	ServiceManagementPublic = Api{
+		AppId:    PublishedApis["AzureServiceManagement"],
+		Endpoint: ServiceManagementPublicEndpoint,
+	}
+
+	ServiceManagementGermany = Api{
+		AppId:    PublishedApis["AzureServiceManagement"],
+		Endpoint: ServiceManagementGermanyEndpoint,
+	}
+
+	ServiceManagementChina = Api{
+		AppId:    PublishedApis["AzureServiceManagement"],
+		Endpoint: ServiceManagementChinaEndpoint,
+	}
+
+	ServiceManagementUSGov = Api{
+		AppId:    PublishedApis["AzureServiceManagement"],
+		Endpoint: ServiceManagementUSGovEndpoint,
+	}
+
+	SQLDatabasePublic = Api{
+		AppId:    PublishedApis["AzureSqlDatabase"],
+		Endpoint: SQLDatabasePublicEndpoint,
+	}
+
+	SQLDatabaseGermany = Api{
+		AppId:    PublishedApis["AzureSqlDatabase"],
+		Endpoint: SQLDatabaseGermanyEndpoint,
+	}
+
+	SQLDatabaseChina = Api{
+		AppId:    PublishedApis["AzureSqlDatabase"],
+		Endpoint: SQLDatabaseChinaEndpoint,
+	}
+
+	SQLDatabaseUSGov = Api{
+		AppId:    PublishedApis["AzureSqlDatabase"],
+		Endpoint: SQLDatabaseUSGovEndpoint,
+	}
+
+	StoragePublic = Api{
+		AppId:    PublishedApis["AzureStorage"],
+		Endpoint: StoragePublicEndpoint,
+	}
+
+	SynapsePublic = Api{
+		AppId:    PublishedApis["AzureSynapseGateway"],
+		Endpoint: SynapsePublicEndpoint,
+	}
 )
 
 type ApiCliName string
@@ -74,102 +235,4 @@ const (
 	BatchCliName           ApiCliName = "batch"
 	DataLakeCliName        ApiCliName = "data-lake"
 	OSSRDBMSCliName        ApiCliName = "oss-rdbms"
-)
-
-// API represent an API configuration for Microsoft Graph or Azure Active Directory Graph.
-type Api struct {
-	// The Application ID for the API.
-	AppId ApiAppId
-
-	// The Azure CLI codename for the API. Used with `az account get-access-token`.
-	CliName ApiCliName
-
-	// The endpoint for the API, including scheme.
-	Endpoint ApiEndpoint
-}
-
-var (
-	MsGraphGlobal = Api{
-		AppId:    PublishedApis["MicrosoftGraph"],
-		CliName:  MsGraphCliName,
-		Endpoint: MsGraphGlobalEndpoint,
-	}
-
-	MsGraphGermany = Api{
-		AppId:    PublishedApis["MicrosoftGraph"],
-		CliName:  MsGraphCliName,
-		Endpoint: MsGraphGermanyEndpoint,
-	}
-
-	MsGraphChina = Api{
-		AppId:    PublishedApis["MicrosoftGraph"],
-		CliName:  MsGraphCliName,
-		Endpoint: MsGraphChinaEndpoint,
-	}
-
-	MsGraphUSGovL4 = Api{
-		AppId:    PublishedApis["MicrosoftGraph"],
-		CliName:  MsGraphCliName,
-		Endpoint: MsGraphUSGovL4Endpoint,
-	}
-
-	MsGraphUSGovL5 = Api{
-		AppId:    PublishedApis["MicrosoftGraph"],
-		CliName:  MsGraphCliName,
-		Endpoint: MsGraphUSGovL5Endpoint,
-	}
-
-	MsGraphCanary = Api{
-		AppId:    PublishedApis["MicrosoftGraph"],
-		CliName:  MsGraphCliName,
-		Endpoint: MsGraphCanaryEndpoint,
-	}
-
-	AadGraphGlobal = Api{
-		AppId:    PublishedApis["AzureActiveDirectoryGraph"],
-		CliName:  AadGraphCliName,
-		Endpoint: AadGraphGlobalEndpoint,
-	}
-
-	AadGraphGermany = Api{
-		AppId:    PublishedApis["AzureActiveDirectoryGraph"],
-		CliName:  AadGraphCliName,
-		Endpoint: AadGraphGermanyEndpoint,
-	}
-
-	AadGraphChina = Api{
-		AppId:    PublishedApis["AzureActiveDirectoryGraph"],
-		CliName:  AadGraphCliName,
-		Endpoint: AadGraphChinaEndpoint,
-	}
-
-	AadGraphUSGov = Api{
-		AppId:    PublishedApis["AzureActiveDirectoryGraph"],
-		CliName:  AadGraphCliName,
-		Endpoint: AadGraphUSGovEndpoint,
-	}
-
-	ResourceManagerPublic = Api{
-		AppId:    PublishedApis["AzureServiceManagement"],
-		CliName:  ResourceManagerCliName,
-		Endpoint: ResourceManagerPublicEndpoint,
-	}
-
-	ResourceManagerGermany = Api{
-		AppId:    PublishedApis["AzureServiceManagement"],
-		CliName:  ResourceManagerCliName,
-		Endpoint: ResourceManagerGermanyEndpoint,
-	}
-
-	ResourceManagerChina = Api{
-		AppId:    PublishedApis["AzureServiceManagement"],
-		CliName:  ResourceManagerCliName,
-		Endpoint: ResourceManagerChinaEndpoint,
-	}
-
-	ResourceManagerUSGov = Api{
-		AppId:    PublishedApis["AzureServiceManagement"],
-		CliName:  ResourceManagerCliName,
-		Endpoint: ResourceManagerUSGovEndpoint,
-	}
 )

--- a/environments/apis.go
+++ b/environments/apis.go
@@ -15,11 +15,6 @@ var (
 		Endpoint: MsGraphGlobalEndpoint,
 	}
 
-	MsGraphGermany = Api{
-		AppId:    PublishedApis["MicrosoftGraph"],
-		Endpoint: MsGraphGermanyEndpoint,
-	}
-
 	MsGraphChina = Api{
 		AppId:    PublishedApis["MicrosoftGraph"],
 		Endpoint: MsGraphChinaEndpoint,
@@ -45,11 +40,6 @@ var (
 		Endpoint: AadGraphGlobalEndpoint,
 	}
 
-	AadGraphGermany = Api{
-		AppId:    PublishedApis["AzureActiveDirectoryGraph"],
-		Endpoint: AadGraphGermanyEndpoint,
-	}
-
 	AadGraphChina = Api{
 		AppId:    PublishedApis["AzureActiveDirectoryGraph"],
 		Endpoint: AadGraphChinaEndpoint,
@@ -65,11 +55,6 @@ var (
 		Endpoint: ResourceManagerPublicEndpoint,
 	}
 
-	ResourceManagerGermany = Api{
-		AppId:    PublishedApis["AzureServiceManagement"],
-		Endpoint: ResourceManagerGermanyEndpoint,
-	}
-
 	ResourceManagerChina = Api{
 		AppId:    PublishedApis["AzureServiceManagement"],
 		Endpoint: ResourceManagerChinaEndpoint,
@@ -83,11 +68,6 @@ var (
 	BatchManagementPublic = Api{
 		AppId:    PublishedApis["AzureBatch"],
 		Endpoint: BatchManagementPublicEndpoint,
-	}
-
-	BatchManagementGermany = Api{
-		AppId:    PublishedApis["AzureBatch"],
-		Endpoint: BatchManagementGermanyEndpoint,
 	}
 
 	BatchManagementChina = Api{
@@ -108,11 +88,6 @@ var (
 	KeyVaultPublic = Api{
 		AppId:    PublishedApis["AzureBatch"],
 		Endpoint: KeyVaultPublicEndpoint,
-	}
-
-	KeyVaultGermany = Api{
-		AppId:    PublishedApis["AzureBatch"],
-		Endpoint: KeyVaultGermanyEndpoint,
 	}
 
 	KeyVaultChina = Api{
@@ -140,11 +115,6 @@ var (
 		Endpoint: OSSRDBMSPublicEndpoint,
 	}
 
-	OSSRDBMSGermany = Api{
-		AppId:    PublishedApis["OssRdbms"],
-		Endpoint: OSSRDBMSGermanyEndpoint,
-	}
-
 	OSSRDBMSChina = Api{
 		AppId:    PublishedApis["OssRdbms"],
 		Endpoint: OSSRDBMSChinaEndpoint,
@@ -158,11 +128,6 @@ var (
 	ServiceBusPublic = Api{
 		AppId:    PublishedApis["AzureServiceBus"],
 		Endpoint: ServiceBusPublicEndpoint,
-	}
-
-	ServiceBusGermany = Api{
-		AppId:    PublishedApis["AzureServiceBus"],
-		Endpoint: ServiceBusGermanyEndpoint,
 	}
 
 	ServiceBusChina = Api{
@@ -180,11 +145,6 @@ var (
 		Endpoint: ServiceManagementPublicEndpoint,
 	}
 
-	ServiceManagementGermany = Api{
-		AppId:    PublishedApis["AzureServiceManagement"],
-		Endpoint: ServiceManagementGermanyEndpoint,
-	}
-
 	ServiceManagementChina = Api{
 		AppId:    PublishedApis["AzureServiceManagement"],
 		Endpoint: ServiceManagementChinaEndpoint,
@@ -198,11 +158,6 @@ var (
 	SQLDatabasePublic = Api{
 		AppId:    PublishedApis["AzureSqlDatabase"],
 		Endpoint: SQLDatabasePublicEndpoint,
-	}
-
-	SQLDatabaseGermany = Api{
-		AppId:    PublishedApis["AzureSqlDatabase"],
-		Endpoint: SQLDatabaseGermanyEndpoint,
 	}
 
 	SQLDatabaseChina = Api{

--- a/environments/apis.go
+++ b/environments/apis.go
@@ -3,23 +3,77 @@ package environments
 type ApiEndpoint string
 
 const (
+	MsGraphGlobalEndpoint  ApiEndpoint = "https://graph.microsoft.com"
+	MsGraphGermanyEndpoint ApiEndpoint = "https://graph.microsoft.de"
+	MsGraphChinaEndpoint   ApiEndpoint = "https://microsoftgraph.chinacloudapi.cn"
+	MsGraphUSGovL4Endpoint ApiEndpoint = "https://graph.microsoft.us"
+	MsGraphUSGovL5Endpoint ApiEndpoint = "https://dod-graph.microsoft.us"
+	MsGraphCanaryEndpoint  ApiEndpoint = "https://canary.graph.microsoft.com"
+
 	AadGraphGlobalEndpoint  ApiEndpoint = "https://graph.windows.net"
 	AadGraphGermanyEndpoint ApiEndpoint = "https://graph.cloudapi.de"
 	AadGraphChinaEndpoint   ApiEndpoint = "https://graph.chinacloudapi.cn"
 	AadGraphUSGovEndpoint   ApiEndpoint = "https://graph.microsoftazure.us"
-	MsGraphGlobalEndpoint   ApiEndpoint = "https://graph.microsoft.com"
-	MsGraphGermanyEndpoint  ApiEndpoint = "https://graph.microsoft.de"
-	MsGraphChinaEndpoint    ApiEndpoint = "https://microsoftgraph.chinacloudapi.cn"
-	MsGraphUSGovL4Endpoint  ApiEndpoint = "https://graph.microsoft.us"
-	MsGraphUSGovL5Endpoint  ApiEndpoint = "https://dod-graph.microsoft.us"
-	MsGraphCanaryEndpoint   ApiEndpoint = "https://canary.graph.microsoft.com"
+
+	ResourceManagerPublicEndpoint  ApiEndpoint = "https://management.azure.com"
+	ResourceManagerGermanyEndpoint ApiEndpoint = "https://management.microsoftazure.de"
+	ResourceManagerChinaEndpoint   ApiEndpoint = "https://management.chinacloudapi.cn"
+	ResourceManagerUSGovEndpoint   ApiEndpoint = "https://management.usgovcloudapi.net"
+
+	BatchManagementPublicEndpoint  ApiEndpoint = "https://batch.core.windows.net"
+	BatchManagementGermanyEndpoint ApiEndpoint = "https://batch.cloudapi.de"
+	BatchManagementChinaEndpoint   ApiEndpoint = "https://batch.chinacloudapi.cn"
+	BatchManagementUSGovEndpoint   ApiEndpoint = "https://batch.core.usgovcloudapi.net"
+
+	DataLakePublicEndpoint ApiEndpoint = "https://datalake.azure.net"
+
+	GalleryPublicEndpoint  ApiEndpoint = "https://gallery.azure.com"
+	GalleryGermanyEndpoint ApiEndpoint = "https://gallery.cloudapi.de"
+	GalleryChinaEndpoint   ApiEndpoint = "https://gallery.chinacloudapi.cn"
+	GalleryUSGovEndpoint   ApiEndpoint = "https://gallery.usgovcloudapi.net"
+
+	KeyVaultPublicEndpoint  ApiEndpoint = "https://vault.azure.net"
+	KeyVaultGermanyEndpoint ApiEndpoint = "https://vault.azure.net"
+	KeyVaultChinaEndpoint   ApiEndpoint = "https://vault.azure.cn"
+	KeyVaultUSGovEndpoint   ApiEndpoint = "https://vault.microsoftazure.de"
+
+	OperationalInsightsPublicEndpoint ApiEndpoint = "https://api.loganalytics.io"
+	OperationalInsightsUSGovEndpoint  ApiEndpoint = "https://api.loganalytics.us"
+
+	OSSRDBMSPublicEndpoint  ApiEndpoint = "https://ossrdbms-aad.database.windows.net"
+	OSSRDBMSGermanyEndpoint ApiEndpoint = "https://ossrdbms-aad.database.cloudapi.de"
+	OSSRDBMSChinaEndpoint   ApiEndpoint = "https://ossrdbms-aad.database.chinacloudapi.cn"
+	OSSRDBMSUSGovEndpoint   ApiEndpoint = "https://ossrdbms-aad.database.usgovcloudapi.net"
+
+	ServiceBusPublicEndpoint  ApiEndpoint = "https://servicebus.windows.net"
+	ServiceBusGermanyEndpoint ApiEndpoint = "https://servicebus.cloudapi.de"
+	ServiceBusChinaEndpoint   ApiEndpoint = "https://servicebus.chinacloudapi.cn"
+	ServiceBusUSGovEndpoint   ApiEndpoint = "https://servicebus.usgovcloudapi.net"
+
+	ServiceManagementPublicEndpoint  ApiEndpoint = "https://management.core.windows.net"
+	ServiceManagementGermanyEndpoint ApiEndpoint = "https://management.core.cloudapi.de"
+	ServiceManagementChinaEndpoint   ApiEndpoint = "https://management.core.chinacloudapi.cn"
+	ServiceManagementUSGovEndpoint   ApiEndpoint = "https://management.core.usgovcloudapi.net"
+
+	SQLDatabasePublicEndpoint  ApiEndpoint = "https://database.windows.net"
+	SQLDatabaseGermanyEndpoint ApiEndpoint = "https://database.cloudapi.de"
+	SQLDatabaseChinaEndpoint   ApiEndpoint = "https://database.chinacloudapi.cn"
+	SQLDatabaseUSGovEndpoint   ApiEndpoint = "https://database.usgovcloudapi.net"
+
+	StoragePublicEndpoint ApiEndpoint = "https://storage.azure.com"
+
+	SynapsePublicEndpoint ApiEndpoint = "https://dev.azuresynapse.net"
 )
 
 type ApiCliName string
 
 const (
-	AadGraphCliName ApiCliName = "aad-graph"
-	MsGraphCliName  ApiCliName = "ms-graph"
+	MsGraphCliName         ApiCliName = "ms-graph"
+	AadGraphCliName        ApiCliName = "aad-graph"
+	ResourceManagerCliName ApiCliName = "arm"
+	BatchCliName           ApiCliName = "batch"
+	DataLakeCliName        ApiCliName = "data-lake"
+	OSSRDBMSCliName        ApiCliName = "oss-rdbms"
 )
 
 // API represent an API configuration for Microsoft Graph or Azure Active Directory Graph.
@@ -93,5 +147,29 @@ var (
 		AppId:    PublishedApis["AzureActiveDirectoryGraph"],
 		CliName:  AadGraphCliName,
 		Endpoint: AadGraphUSGovEndpoint,
+	}
+
+	ResourceManagerPublic = Api{
+		AppId:    PublishedApis["AzureServiceManagement"],
+		CliName:  ResourceManagerCliName,
+		Endpoint: ResourceManagerPublicEndpoint,
+	}
+
+	ResourceManagerGermany = Api{
+		AppId:    PublishedApis["AzureServiceManagement"],
+		CliName:  ResourceManagerCliName,
+		Endpoint: ResourceManagerGermanyEndpoint,
+	}
+
+	ResourceManagerChina = Api{
+		AppId:    PublishedApis["AzureServiceManagement"],
+		CliName:  ResourceManagerCliName,
+		Endpoint: ResourceManagerChinaEndpoint,
+	}
+
+	ResourceManagerUSGov = Api{
+		AppId:    PublishedApis["AzureServiceManagement"],
+		CliName:  ResourceManagerCliName,
+		Endpoint: ResourceManagerUSGovEndpoint,
 	}
 )

--- a/environments/endpoints.go
+++ b/environments/endpoints.go
@@ -3,66 +3,56 @@ package environments
 type AzureADEndpoint string
 
 const (
-	AzureADGlobal  AzureADEndpoint = "https://login.microsoftonline.com"
-	AzureADUSGov   AzureADEndpoint = "https://login.microsoftonline.us"
-	AzureADGermany AzureADEndpoint = "https://login.microsoftonline.de"
-	AzureADChina   AzureADEndpoint = "https://login.chinacloudapi.cn"
+	AzureADGlobal AzureADEndpoint = "https://login.microsoftonline.com"
+	AzureADUSGov  AzureADEndpoint = "https://login.microsoftonline.us"
+	AzureADChina  AzureADEndpoint = "https://login.chinacloudapi.cn"
 )
 
 type ApiEndpoint string
 
 const (
 	MsGraphGlobalEndpoint  ApiEndpoint = "https://graph.microsoft.com"
-	MsGraphGermanyEndpoint ApiEndpoint = "https://graph.microsoft.de"
 	MsGraphChinaEndpoint   ApiEndpoint = "https://microsoftgraph.chinacloudapi.cn"
 	MsGraphUSGovL4Endpoint ApiEndpoint = "https://graph.microsoft.us"
 	MsGraphUSGovL5Endpoint ApiEndpoint = "https://dod-graph.microsoft.us"
 	MsGraphCanaryEndpoint  ApiEndpoint = "https://canary.graph.microsoft.com"
 
-	AadGraphGlobalEndpoint  ApiEndpoint = "https://graph.windows.net"
-	AadGraphGermanyEndpoint ApiEndpoint = "https://graph.cloudapi.de"
-	AadGraphChinaEndpoint   ApiEndpoint = "https://graph.chinacloudapi.cn"
-	AadGraphUSGovEndpoint   ApiEndpoint = "https://graph.microsoftazure.us"
+	AadGraphGlobalEndpoint ApiEndpoint = "https://graph.windows.net"
+	AadGraphChinaEndpoint  ApiEndpoint = "https://graph.chinacloudapi.cn"
+	AadGraphUSGovEndpoint  ApiEndpoint = "https://graph.microsoftazure.us"
 
-	ResourceManagerPublicEndpoint  ApiEndpoint = "https://management.azure.com"
-	ResourceManagerGermanyEndpoint ApiEndpoint = "https://management.microsoftazure.de"
-	ResourceManagerChinaEndpoint   ApiEndpoint = "https://management.chinacloudapi.cn"
-	ResourceManagerUSGovEndpoint   ApiEndpoint = "https://management.usgovcloudapi.net"
+	ResourceManagerPublicEndpoint ApiEndpoint = "https://management.azure.com"
+	ResourceManagerChinaEndpoint  ApiEndpoint = "https://management.chinacloudapi.cn"
+	ResourceManagerUSGovEndpoint  ApiEndpoint = "https://management.usgovcloudapi.net"
 
-	BatchManagementPublicEndpoint  ApiEndpoint = "https://batch.core.windows.net"
-	BatchManagementGermanyEndpoint ApiEndpoint = "https://batch.cloudapi.de"
-	BatchManagementChinaEndpoint   ApiEndpoint = "https://batch.chinacloudapi.cn"
-	BatchManagementUSGovEndpoint   ApiEndpoint = "https://batch.core.usgovcloudapi.net"
+	BatchManagementPublicEndpoint ApiEndpoint = "https://batch.core.windows.net"
+	BatchManagementChinaEndpoint  ApiEndpoint = "https://batch.chinacloudapi.cn"
+	BatchManagementUSGovEndpoint  ApiEndpoint = "https://batch.core.usgovcloudapi.net"
 
 	DataLakePublicEndpoint ApiEndpoint = "https://datalake.azure.net"
 
-	KeyVaultPublicEndpoint  ApiEndpoint = "https://vault.azure.net"
-	KeyVaultGermanyEndpoint ApiEndpoint = "https://vault.azure.net"
-	KeyVaultChinaEndpoint   ApiEndpoint = "https://vault.azure.cn"
-	KeyVaultUSGovEndpoint   ApiEndpoint = "https://vault.microsoftazure.de"
+	KeyVaultPublicEndpoint ApiEndpoint = "https://vault.azure.net"
+	KeyVaultChinaEndpoint  ApiEndpoint = "https://vault.azure.cn"
+	KeyVaultUSGovEndpoint  ApiEndpoint = "https://vault.microsoftazure.de"
 
 	OperationalInsightsPublicEndpoint ApiEndpoint = "https://api.loganalytics.io"
 	OperationalInsightsUSGovEndpoint  ApiEndpoint = "https://api.loganalytics.us"
 
-	OSSRDBMSPublicEndpoint  ApiEndpoint = "https://ossrdbms-aad.database.windows.net"
-	OSSRDBMSGermanyEndpoint ApiEndpoint = "https://ossrdbms-aad.database.cloudapi.de"
-	OSSRDBMSChinaEndpoint   ApiEndpoint = "https://ossrdbms-aad.database.chinacloudapi.cn"
-	OSSRDBMSUSGovEndpoint   ApiEndpoint = "https://ossrdbms-aad.database.usgovcloudapi.net"
+	OSSRDBMSPublicEndpoint ApiEndpoint = "https://ossrdbms-aad.database.windows.net"
+	OSSRDBMSChinaEndpoint  ApiEndpoint = "https://ossrdbms-aad.database.chinacloudapi.cn"
+	OSSRDBMSUSGovEndpoint  ApiEndpoint = "https://ossrdbms-aad.database.usgovcloudapi.net"
 
-	ServiceBusPublicEndpoint  ApiEndpoint = "https://servicebus.windows.net"
-	ServiceBusGermanyEndpoint ApiEndpoint = "https://servicebus.cloudapi.de"
-	ServiceBusChinaEndpoint   ApiEndpoint = "https://servicebus.chinacloudapi.cn"
-	ServiceBusUSGovEndpoint   ApiEndpoint = "https://servicebus.usgovcloudapi.net"
+	ServiceBusPublicEndpoint ApiEndpoint = "https://servicebus.windows.net"
+	ServiceBusChinaEndpoint  ApiEndpoint = "https://servicebus.chinacloudapi.cn"
+	ServiceBusUSGovEndpoint  ApiEndpoint = "https://servicebus.usgovcloudapi.net"
 
-	ServiceManagementPublicEndpoint  ApiEndpoint = "https://management.core.windows.net"
-	ServiceManagementGermanyEndpoint ApiEndpoint = "https://management.core.cloudapi.de"
-	ServiceManagementChinaEndpoint   ApiEndpoint = "https://management.core.chinacloudapi.cn"
-	ServiceManagementUSGovEndpoint   ApiEndpoint = "https://management.core.usgovcloudapi.net"
+	ServiceManagementPublicEndpoint ApiEndpoint = "https://management.core.windows.net"
+	ServiceManagementChinaEndpoint  ApiEndpoint = "https://management.core.chinacloudapi.cn"
+	ServiceManagementUSGovEndpoint  ApiEndpoint = "https://management.core.usgovcloudapi.net"
 
-	SQLDatabasePublicEndpoint  ApiEndpoint = "https://database.windows.net"
-	SQLDatabaseGermanyEndpoint ApiEndpoint = "https://database.cloudapi.de"
-	SQLDatabaseChinaEndpoint   ApiEndpoint = "https://database.chinacloudapi.cn"
-	SQLDatabaseUSGovEndpoint   ApiEndpoint = "https://database.usgovcloudapi.net"
+	SQLDatabasePublicEndpoint ApiEndpoint = "https://database.windows.net"
+	SQLDatabaseChinaEndpoint  ApiEndpoint = "https://database.chinacloudapi.cn"
+	SQLDatabaseUSGovEndpoint  ApiEndpoint = "https://database.usgovcloudapi.net"
 
 	StoragePublicEndpoint ApiEndpoint = "https://storage.azure.com"
 

--- a/environments/endpoints.go
+++ b/environments/endpoints.go
@@ -8,3 +8,63 @@ const (
 	AzureADGermany AzureADEndpoint = "https://login.microsoftonline.de"
 	AzureADChina   AzureADEndpoint = "https://login.chinacloudapi.cn"
 )
+
+type ApiEndpoint string
+
+const (
+	MsGraphGlobalEndpoint  ApiEndpoint = "https://graph.microsoft.com"
+	MsGraphGermanyEndpoint ApiEndpoint = "https://graph.microsoft.de"
+	MsGraphChinaEndpoint   ApiEndpoint = "https://microsoftgraph.chinacloudapi.cn"
+	MsGraphUSGovL4Endpoint ApiEndpoint = "https://graph.microsoft.us"
+	MsGraphUSGovL5Endpoint ApiEndpoint = "https://dod-graph.microsoft.us"
+	MsGraphCanaryEndpoint  ApiEndpoint = "https://canary.graph.microsoft.com"
+
+	AadGraphGlobalEndpoint  ApiEndpoint = "https://graph.windows.net"
+	AadGraphGermanyEndpoint ApiEndpoint = "https://graph.cloudapi.de"
+	AadGraphChinaEndpoint   ApiEndpoint = "https://graph.chinacloudapi.cn"
+	AadGraphUSGovEndpoint   ApiEndpoint = "https://graph.microsoftazure.us"
+
+	ResourceManagerPublicEndpoint  ApiEndpoint = "https://management.azure.com"
+	ResourceManagerGermanyEndpoint ApiEndpoint = "https://management.microsoftazure.de"
+	ResourceManagerChinaEndpoint   ApiEndpoint = "https://management.chinacloudapi.cn"
+	ResourceManagerUSGovEndpoint   ApiEndpoint = "https://management.usgovcloudapi.net"
+
+	BatchManagementPublicEndpoint  ApiEndpoint = "https://batch.core.windows.net"
+	BatchManagementGermanyEndpoint ApiEndpoint = "https://batch.cloudapi.de"
+	BatchManagementChinaEndpoint   ApiEndpoint = "https://batch.chinacloudapi.cn"
+	BatchManagementUSGovEndpoint   ApiEndpoint = "https://batch.core.usgovcloudapi.net"
+
+	DataLakePublicEndpoint ApiEndpoint = "https://datalake.azure.net"
+
+	KeyVaultPublicEndpoint  ApiEndpoint = "https://vault.azure.net"
+	KeyVaultGermanyEndpoint ApiEndpoint = "https://vault.azure.net"
+	KeyVaultChinaEndpoint   ApiEndpoint = "https://vault.azure.cn"
+	KeyVaultUSGovEndpoint   ApiEndpoint = "https://vault.microsoftazure.de"
+
+	OperationalInsightsPublicEndpoint ApiEndpoint = "https://api.loganalytics.io"
+	OperationalInsightsUSGovEndpoint  ApiEndpoint = "https://api.loganalytics.us"
+
+	OSSRDBMSPublicEndpoint  ApiEndpoint = "https://ossrdbms-aad.database.windows.net"
+	OSSRDBMSGermanyEndpoint ApiEndpoint = "https://ossrdbms-aad.database.cloudapi.de"
+	OSSRDBMSChinaEndpoint   ApiEndpoint = "https://ossrdbms-aad.database.chinacloudapi.cn"
+	OSSRDBMSUSGovEndpoint   ApiEndpoint = "https://ossrdbms-aad.database.usgovcloudapi.net"
+
+	ServiceBusPublicEndpoint  ApiEndpoint = "https://servicebus.windows.net"
+	ServiceBusGermanyEndpoint ApiEndpoint = "https://servicebus.cloudapi.de"
+	ServiceBusChinaEndpoint   ApiEndpoint = "https://servicebus.chinacloudapi.cn"
+	ServiceBusUSGovEndpoint   ApiEndpoint = "https://servicebus.usgovcloudapi.net"
+
+	ServiceManagementPublicEndpoint  ApiEndpoint = "https://management.core.windows.net"
+	ServiceManagementGermanyEndpoint ApiEndpoint = "https://management.core.cloudapi.de"
+	ServiceManagementChinaEndpoint   ApiEndpoint = "https://management.core.chinacloudapi.cn"
+	ServiceManagementUSGovEndpoint   ApiEndpoint = "https://management.core.usgovcloudapi.net"
+
+	SQLDatabasePublicEndpoint  ApiEndpoint = "https://database.windows.net"
+	SQLDatabaseGermanyEndpoint ApiEndpoint = "https://database.cloudapi.de"
+	SQLDatabaseChinaEndpoint   ApiEndpoint = "https://database.chinacloudapi.cn"
+	SQLDatabaseUSGovEndpoint   ApiEndpoint = "https://database.usgovcloudapi.net"
+
+	StoragePublicEndpoint ApiEndpoint = "https://storage.azure.com"
+
+	SynapsePublicEndpoint ApiEndpoint = "https://dev.azuresynapse.net"
+)

--- a/environments/environments.go
+++ b/environments/environments.go
@@ -15,6 +15,9 @@ type Environment struct {
 
 	// The Azure Active Directory Graph configuration for an environment.
 	AadGraph Api
+
+	// The Azure Resource Manager configuration for an environment.
+	ResourceManager Api
 }
 
 var (
@@ -22,30 +25,35 @@ var (
 		AzureADEndpoint: AzureADGlobal,
 		MsGraph:         MsGraphGlobal,
 		AadGraph:        AadGraphGlobal,
+		ResourceManager: ResourceManagerPublic,
 	}
 
 	Germany = Environment{
 		AzureADEndpoint: AzureADGermany,
 		MsGraph:         MsGraphGermany,
 		AadGraph:        AadGraphGermany,
+		ResourceManager: ResourceManagerGermany,
 	}
 
 	China = Environment{
 		AzureADEndpoint: AzureADChina,
 		MsGraph:         MsGraphChina,
 		AadGraph:        AadGraphChina,
+		ResourceManager: ResourceManagerChina,
 	}
 
 	USGovernmentL4 = Environment{
 		AzureADEndpoint: AzureADUSGov,
 		MsGraph:         MsGraphUSGovL4,
 		AadGraph:        AadGraphUSGov,
+		ResourceManager: ResourceManagerUSGov,
 	}
 
 	USGovernmentL5 = Environment{
 		AzureADEndpoint: AzureADUSGov,
 		MsGraph:         MsGraphUSGovL5,
 		AadGraph:        AadGraphUSGov,
+		ResourceManager: ResourceManagerUSGov,
 	}
 
 	Canary = Environment{

--- a/environments/environments.go
+++ b/environments/environments.go
@@ -44,19 +44,6 @@ var (
 		Synapse:             SynapsePublic,
 	}
 
-	Germany = Environment{
-		AzureADEndpoint:   AzureADGermany,
-		MsGraph:           MsGraphGermany,
-		AadGraph:          AadGraphGermany,
-		ResourceManager:   ResourceManagerGermany,
-		BatchManagement:   BatchManagementGermany,
-		KeyVault:          KeyVaultGermany,
-		OSSRDBMS:          OSSRDBMSGermany,
-		ServiceBus:        ServiceBusGermany,
-		ServiceManagement: ServiceManagementGermany,
-		SQLDatabase:       SQLDatabaseGermany,
-	}
-
 	China = Environment{
 		AzureADEndpoint:   AzureADChina,
 		MsGraph:           MsGraphChina,
@@ -116,8 +103,6 @@ func EnvironmentFromString(env string) (Environment, error) {
 		return Canary, nil
 	case "china":
 		return China, nil
-	case "germany":
-		return Germany, nil
 	}
 
 	return Environment{}, fmt.Errorf("invalid environment specified: %s", env)

--- a/environments/environments.go
+++ b/environments/environments.go
@@ -10,50 +10,92 @@ type Environment struct {
 	// The Azure AD endpoint for acquiring access tokens.
 	AzureADEndpoint AzureADEndpoint
 
-	// The Microsoft Graph configuration for an environment.
-	MsGraph Api
-
-	// The Azure Active Directory Graph configuration for an environment.
-	AadGraph Api
-
-	// The Azure Resource Manager configuration for an environment.
-	ResourceManager Api
+	// Management plane API definitions
+	MsGraph             Api
+	AadGraph            Api
+	ResourceManager     Api
+	BatchManagement     Api
+	DataLake            Api
+	KeyVault            Api
+	OperationalInsights Api
+	OSSRDBMS            Api
+	ServiceBus          Api
+	ServiceManagement   Api
+	SQLDatabase         Api
+	Storage             Api
+	Synapse             Api
 }
 
 var (
 	Global = Environment{
-		AzureADEndpoint: AzureADGlobal,
-		MsGraph:         MsGraphGlobal,
-		AadGraph:        AadGraphGlobal,
-		ResourceManager: ResourceManagerPublic,
+		AzureADEndpoint:     AzureADGlobal,
+		MsGraph:             MsGraphGlobal,
+		AadGraph:            AadGraphGlobal,
+		ResourceManager:     ResourceManagerPublic,
+		BatchManagement:     BatchManagementPublic,
+		DataLake:            DataLakePublic,
+		KeyVault:            KeyVaultPublic,
+		OperationalInsights: OperationalInsightsPublic,
+		OSSRDBMS:            OSSRDBMSPublic,
+		ServiceBus:          ServiceBusPublic,
+		ServiceManagement:   ServiceManagementPublic,
+		SQLDatabase:         SQLDatabasePublic,
+		Storage:             StoragePublic,
+		Synapse:             SynapsePublic,
 	}
 
 	Germany = Environment{
-		AzureADEndpoint: AzureADGermany,
-		MsGraph:         MsGraphGermany,
-		AadGraph:        AadGraphGermany,
-		ResourceManager: ResourceManagerGermany,
+		AzureADEndpoint:   AzureADGermany,
+		MsGraph:           MsGraphGermany,
+		AadGraph:          AadGraphGermany,
+		ResourceManager:   ResourceManagerGermany,
+		BatchManagement:   BatchManagementGermany,
+		KeyVault:          KeyVaultGermany,
+		OSSRDBMS:          OSSRDBMSGermany,
+		ServiceBus:        ServiceBusGermany,
+		ServiceManagement: ServiceManagementGermany,
+		SQLDatabase:       SQLDatabaseGermany,
 	}
 
 	China = Environment{
-		AzureADEndpoint: AzureADChina,
-		MsGraph:         MsGraphChina,
-		AadGraph:        AadGraphChina,
-		ResourceManager: ResourceManagerChina,
+		AzureADEndpoint:   AzureADChina,
+		MsGraph:           MsGraphChina,
+		AadGraph:          AadGraphChina,
+		ResourceManager:   ResourceManagerChina,
+		BatchManagement:   BatchManagementChina,
+		KeyVault:          KeyVaultChina,
+		OSSRDBMS:          OSSRDBMSChina,
+		ServiceBus:        ServiceBusChina,
+		ServiceManagement: ServiceManagementChina,
+		SQLDatabase:       SQLDatabaseChina,
 	}
 
 	USGovernmentL4 = Environment{
-		AzureADEndpoint: AzureADUSGov,
-		MsGraph:         MsGraphUSGovL4,
-		AadGraph:        AadGraphUSGov,
-		ResourceManager: ResourceManagerUSGov,
+		AzureADEndpoint:     AzureADUSGov,
+		MsGraph:             MsGraphUSGovL4,
+		AadGraph:            AadGraphUSGov,
+		ResourceManager:     ResourceManagerUSGov,
+		BatchManagement:     BatchManagementUSGov,
+		KeyVault:            KeyVaultUSGov,
+		OperationalInsights: OperationalInsightsUSGov,
+		OSSRDBMS:            OSSRDBMSUSGov,
+		ServiceBus:          ServiceBusUSGov,
+		ServiceManagement:   ServiceManagementUSGov,
+		SQLDatabase:         SQLDatabaseUSGov,
 	}
 
 	USGovernmentL5 = Environment{
-		AzureADEndpoint: AzureADUSGov,
-		MsGraph:         MsGraphUSGovL5,
-		AadGraph:        AadGraphUSGov,
-		ResourceManager: ResourceManagerUSGov,
+		AzureADEndpoint:     AzureADUSGov,
+		MsGraph:             MsGraphUSGovL5,
+		AadGraph:            AadGraphUSGov,
+		ResourceManager:     ResourceManagerUSGov,
+		BatchManagement:     BatchManagementUSGov,
+		KeyVault:            KeyVaultUSGov,
+		OperationalInsights: OperationalInsightsUSGov,
+		OSSRDBMS:            OSSRDBMSUSGov,
+		ServiceBus:          ServiceBusUSGov,
+		ServiceManagement:   ServiceManagementUSGov,
+		SQLDatabase:         SQLDatabaseUSGov,
 	}
 
 	Canary = Environment{

--- a/example/example.go
+++ b/example/example.go
@@ -23,15 +23,17 @@ var (
 func main() {
 	ctx := context.Background()
 
+	environment := environments.Global
+
 	authConfig := &auth.Config{
-		Environment:            environments.Global,
+		Environment:            environment,
 		TenantID:               tenantId,
 		ClientID:               clientId,
 		ClientSecret:           clientSecret,
 		EnableClientSecretAuth: true,
 	}
 
-	authorizer, err := authConfig.NewAuthorizer(ctx, auth.MsGraph)
+	authorizer, err := authConfig.NewAuthorizer(ctx, environment.MsGraph)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/internal/cmd/test-cleanup/conditionalaccesspolicies.go
+++ b/internal/cmd/test-cleanup/conditionalaccesspolicies.go
@@ -9,7 +9,7 @@ import (
 )
 
 func cleanupConditionalAccessPolicies() {
-	conditionalAccessPoliciesClient := msgraph.NewConditionalAccessPolicyClient(tenantId)
+	conditionalAccessPoliciesClient := msgraph.NewConditionalAccessPoliciesClient(tenantId)
 	conditionalAccessPoliciesClient.BaseClient.Authorizer = authorizer
 
 	conditionalAccessPoliciess, _, err := conditionalAccessPoliciesClient.List(ctx, odata.Query{Filter: fmt.Sprintf("startsWith(displayName, '%s')", displayNamePrefix)})

--- a/internal/cmd/test-cleanup/main.go
+++ b/internal/cmd/test-cleanup/main.go
@@ -42,7 +42,7 @@ func init() {
 	}
 
 	var err error
-	authorizer, err = authConfig.NewAuthorizer(ctx, auth.MsGraph)
+	authorizer, err = authConfig.NewAuthorizer(ctx, environments.Global.MsGraph)
 	if err != nil {
 		log.Fatalln(err)
 	}

--- a/internal/test/testing.go
+++ b/internal/test/testing.go
@@ -8,11 +8,10 @@ import (
 
 	"golang.org/x/oauth2"
 
-	"github.com/manicminer/hamilton/msgraph"
-
 	"github.com/manicminer/hamilton/auth"
 	"github.com/manicminer/hamilton/environments"
 	"github.com/manicminer/hamilton/internal/utils"
+	"github.com/manicminer/hamilton/msgraph"
 )
 
 var (

--- a/internal/test/testing.go
+++ b/internal/test/testing.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log"
 	"os"
+	"strconv"
 	"testing"
 
 	"golang.org/x/oauth2"
@@ -14,6 +15,13 @@ import (
 	"github.com/manicminer/hamilton/msgraph"
 )
 
+func envDefault(envVarName, defaultValue string) string {
+	if v := os.Getenv(envVarName); v != "" {
+		return v
+	}
+	return defaultValue
+}
+
 var (
 	tenantId              = os.Getenv("TENANT_ID")
 	tenantDomain          = os.Getenv("TENANT_DOMAIN")
@@ -23,6 +31,7 @@ var (
 	clientCertPassword    = os.Getenv("CLIENT_CERTIFICATE_PASSWORD")
 	clientSecret          = os.Getenv("CLIENT_SECRET")
 	environment           = os.Getenv("AZURE_ENVIRONMENT")
+	retryMax              = envDefault("RETRY_MAX", "9")
 )
 
 type Connection struct {
@@ -109,7 +118,7 @@ type Test struct {
 
 func NewTest(t *testing.T) (c *Test) {
 	ctx := context.Background()
-	var cancel context.CancelFunc
+	var cancel context.CancelFunc = func() {}
 
 	if deadline, ok := t.Deadline(); ok {
 		ctx, cancel = context.WithDeadline(context.Background(), deadline)
@@ -135,121 +144,155 @@ func NewTest(t *testing.T) (c *Test) {
 		t.Fatalf("could not parse claims: %v", err)
 	}
 
+	retry, err := strconv.Atoi(retryMax)
+	if err != nil {
+		t.Fatalf("invalid retry count %q: %v", retryMax, err)
+	}
+
 	c.AccessPackageAssignmentPolicyClient = msgraph.NewAccessPackageAssignmentPolicyClient(c.Connection.AuthConfig.TenantID)
 	c.AccessPackageAssignmentPolicyClient.BaseClient.Authorizer = c.Connection.Authorizer
 	c.AccessPackageAssignmentPolicyClient.BaseClient.Endpoint = c.Connection.AuthConfig.Environment.MsGraph.Endpoint
+	c.AccessPackageAssignmentPolicyClient.BaseClient.RetryableClient.RetryMax = retry
 
 	c.AccessPackageCatalogClient = msgraph.NewAccessPackageCatalogClient(c.Connection.AuthConfig.TenantID)
 	c.AccessPackageCatalogClient.BaseClient.Authorizer = c.Connection.Authorizer
 	c.AccessPackageCatalogClient.BaseClient.Endpoint = c.Connection.AuthConfig.Environment.MsGraph.Endpoint
+	c.AccessPackageCatalogClient.BaseClient.RetryableClient.RetryMax = retry
 
 	c.AccessPackageClient = msgraph.NewAccessPackageClient(c.Connection.AuthConfig.TenantID)
 	c.AccessPackageClient.BaseClient.Authorizer = c.Connection.Authorizer
 	c.AccessPackageClient.BaseClient.Endpoint = c.Connection.AuthConfig.Environment.MsGraph.Endpoint
+	c.AccessPackageClient.BaseClient.RetryableClient.RetryMax = retry
 
 	c.AccessPackageResourceClient = msgraph.NewAccessPackageResourceClient(c.Connection.AuthConfig.TenantID)
 	c.AccessPackageResourceClient.BaseClient.Authorizer = c.Connection.Authorizer
 	c.AccessPackageResourceClient.BaseClient.Endpoint = c.Connection.AuthConfig.Environment.MsGraph.Endpoint
+	c.AccessPackageResourceClient.BaseClient.RetryableClient.RetryMax = retry
 
 	c.AccessPackageResourceRequestClient = msgraph.NewAccessPackageResourceRequestClient(c.Connection.AuthConfig.TenantID)
 	c.AccessPackageResourceRequestClient.BaseClient.Authorizer = c.Connection.Authorizer
 	c.AccessPackageResourceRequestClient.BaseClient.Endpoint = c.Connection.AuthConfig.Environment.MsGraph.Endpoint
+	c.AccessPackageAssignmentPolicyClient.BaseClient.RetryableClient.RetryMax = retry
 
 	c.AccessPackageResourceRoleScopeClient = msgraph.NewAccessPackageResourceRoleScopeClient(c.Connection.AuthConfig.TenantID)
 	c.AccessPackageResourceRoleScopeClient.BaseClient.Authorizer = c.Connection.Authorizer
 	c.AccessPackageResourceRoleScopeClient.BaseClient.Endpoint = c.Connection.AuthConfig.Environment.MsGraph.Endpoint
+	c.AccessPackageResourceRoleScopeClient.BaseClient.RetryableClient.RetryMax = retry
 
 	c.ApplicationTemplatesClient = msgraph.NewApplicationTemplatesClient(c.Connection.AuthConfig.TenantID)
 	c.ApplicationTemplatesClient.BaseClient.Authorizer = c.Connection.Authorizer
 	c.ApplicationTemplatesClient.BaseClient.Endpoint = c.Connection.AuthConfig.Environment.MsGraph.Endpoint
+	c.ApplicationTemplatesClient.BaseClient.RetryableClient.RetryMax = retry
 
 	c.ApplicationsClient = msgraph.NewApplicationsClient(c.Connection.AuthConfig.TenantID)
 	c.ApplicationsClient.BaseClient.Authorizer = c.Connection.Authorizer
 	c.ApplicationsClient.BaseClient.Endpoint = c.Connection.AuthConfig.Environment.MsGraph.Endpoint
+	c.ApplicationsClient.BaseClient.RetryableClient.RetryMax = retry
 
 	c.AppRoleAssignedToClient = msgraph.NewAppRoleAssignedToClient(c.Connection.AuthConfig.TenantID)
 	c.AppRoleAssignedToClient.BaseClient.Authorizer = c.Connection.Authorizer
 	c.AppRoleAssignedToClient.BaseClient.Endpoint = c.Connection.AuthConfig.Environment.MsGraph.Endpoint
+	c.AppRoleAssignedToClient.BaseClient.RetryableClient.RetryMax = retry
 
 	c.AuthenticationMethodsClient = msgraph.NewAuthenticationMethodsClient(c.Connection.AuthConfig.TenantID)
 	c.AuthenticationMethodsClient.BaseClient.Authorizer = c.Connection.Authorizer
 	c.AuthenticationMethodsClient.BaseClient.Endpoint = c.Connection.AuthConfig.Environment.MsGraph.Endpoint
+	c.AuthenticationMethodsClient.BaseClient.RetryableClient.RetryMax = retry
 
 	c.ConditionalAccessPoliciesClient = msgraph.NewConditionalAccessPoliciesClient(c.Connection.AuthConfig.TenantID)
 	c.ConditionalAccessPoliciesClient.BaseClient.Authorizer = c.Connection.Authorizer
 	c.ConditionalAccessPoliciesClient.BaseClient.Endpoint = c.Connection.AuthConfig.Environment.MsGraph.Endpoint
+	c.ConditionalAccessPoliciesClient.BaseClient.RetryableClient.RetryMax = retry
 
 	c.DirectoryAuditReportsClient = msgraph.NewDirectoryAuditReportsClient(c.Connection.AuthConfig.TenantID)
 	c.DirectoryAuditReportsClient.BaseClient.Authorizer = c.Connection.Authorizer
 	c.DirectoryAuditReportsClient.BaseClient.Endpoint = c.Connection.AuthConfig.Environment.MsGraph.Endpoint
+	c.DirectoryAuditReportsClient.BaseClient.RetryableClient.RetryMax = retry
 
 	c.DirectoryObjectsClient = msgraph.NewDirectoryObjectsClient(c.Connection.AuthConfig.TenantID)
 	c.DirectoryObjectsClient.BaseClient.Authorizer = c.Connection.Authorizer
 	c.DirectoryObjectsClient.BaseClient.Endpoint = c.Connection.AuthConfig.Environment.MsGraph.Endpoint
+	c.DirectoryObjectsClient.BaseClient.RetryableClient.RetryMax = retry
 
 	c.DirectoryRoleTemplatesClient = msgraph.NewDirectoryRoleTemplatesClient(c.Connection.AuthConfig.TenantID)
 	c.DirectoryRoleTemplatesClient.BaseClient.Authorizer = c.Connection.Authorizer
 	c.DirectoryRoleTemplatesClient.BaseClient.Endpoint = c.Connection.AuthConfig.Environment.MsGraph.Endpoint
+	c.DirectoryRoleTemplatesClient.BaseClient.RetryableClient.RetryMax = retry
 
 	c.DirectoryRolesClient = msgraph.NewDirectoryRolesClient(c.Connection.AuthConfig.TenantID)
 	c.DirectoryRolesClient.BaseClient.Authorizer = c.Connection.Authorizer
 	c.DirectoryRolesClient.BaseClient.Endpoint = c.Connection.AuthConfig.Environment.MsGraph.Endpoint
+	c.DirectoryRolesClient.BaseClient.RetryableClient.RetryMax = retry
 
 	c.DomainsClient = msgraph.NewDomainsClient(c.Connection.AuthConfig.TenantID)
 	c.DomainsClient.BaseClient.Authorizer = c.Connection.Authorizer
 	c.DomainsClient.BaseClient.Endpoint = c.Connection.AuthConfig.Environment.MsGraph.Endpoint
+	c.DomainsClient.BaseClient.RetryableClient.RetryMax = retry
 
 	c.GroupsAppRoleAssignmentsClient = msgraph.NewGroupsAppRoleAssignmentsClient(c.Connection.AuthConfig.TenantID)
 	c.GroupsAppRoleAssignmentsClient.BaseClient.Authorizer = c.Connection.Authorizer
 	c.GroupsAppRoleAssignmentsClient.BaseClient.Endpoint = c.Connection.AuthConfig.Environment.MsGraph.Endpoint
+	c.GroupsAppRoleAssignmentsClient.BaseClient.RetryableClient.RetryMax = retry
 
 	c.GroupsClient = msgraph.NewGroupsClient(c.Connection.AuthConfig.TenantID)
 	c.GroupsClient.BaseClient.Authorizer = c.Connection.Authorizer
 	c.GroupsClient.BaseClient.Endpoint = c.Connection.AuthConfig.Environment.MsGraph.Endpoint
+	c.GroupsClient.BaseClient.RetryableClient.RetryMax = retry
 
 	c.IdentityProvidersClient = msgraph.NewIdentityProvidersClient(c.Connection.AuthConfig.TenantID)
 	c.IdentityProvidersClient.BaseClient.Authorizer = c.Connection.Authorizer
 	c.IdentityProvidersClient.BaseClient.Endpoint = c.Connection.AuthConfig.Environment.MsGraph.Endpoint
+	c.IdentityProvidersClient.BaseClient.RetryableClient.RetryMax = retry
 
 	c.InvitationsClient = msgraph.NewInvitationsClient(c.Connection.AuthConfig.TenantID)
 	c.InvitationsClient.BaseClient.Authorizer = c.Connection.Authorizer
 	c.InvitationsClient.BaseClient.Endpoint = c.Connection.AuthConfig.Environment.MsGraph.Endpoint
+	c.InvitationsClient.BaseClient.RetryableClient.RetryMax = retry
 
 	c.MeClient = msgraph.NewMeClient(c.Connection.AuthConfig.TenantID)
 	c.MeClient.BaseClient.Authorizer = c.Connection.Authorizer
 	c.MeClient.BaseClient.Endpoint = c.Connection.AuthConfig.Environment.MsGraph.Endpoint
+	c.MeClient.BaseClient.RetryableClient.RetryMax = retry
 
 	c.NamedLocationsClient = msgraph.NewNamedLocationsClient(c.Connection.AuthConfig.TenantID)
 	c.NamedLocationsClient.BaseClient.Authorizer = c.Connection.Authorizer
 	c.NamedLocationsClient.BaseClient.Endpoint = c.Connection.AuthConfig.Environment.MsGraph.Endpoint
+	c.NamedLocationsClient.BaseClient.RetryableClient.RetryMax = retry
 
 	c.ReportsClient = msgraph.NewReportsClient(c.Connection.AuthConfig.TenantID)
 	c.ReportsClient.BaseClient.Authorizer = c.Connection.Authorizer
 	c.ReportsClient.BaseClient.Endpoint = c.Connection.AuthConfig.Environment.MsGraph.Endpoint
+	c.ReportsClient.BaseClient.RetryableClient.RetryMax = retry
 
 	c.SchemaExtensionsClient = msgraph.NewSchemaExtensionsClient(c.Connection.AuthConfig.TenantID)
 	c.SchemaExtensionsClient.BaseClient.Authorizer = c.Connection.Authorizer
 	c.SchemaExtensionsClient.BaseClient.Endpoint = c.Connection.AuthConfig.Environment.MsGraph.Endpoint
+	c.SchemaExtensionsClient.BaseClient.RetryableClient.RetryMax = retry
 
 	c.ServicePrincipalsAppRoleAssignmentsClient = msgraph.NewServicePrincipalsAppRoleAssignmentsClient(c.Connection.AuthConfig.TenantID)
 	c.ServicePrincipalsAppRoleAssignmentsClient.BaseClient.Authorizer = c.Connection.Authorizer
 	c.ServicePrincipalsAppRoleAssignmentsClient.BaseClient.Endpoint = c.Connection.AuthConfig.Environment.MsGraph.Endpoint
+	c.ServicePrincipalsAppRoleAssignmentsClient.BaseClient.RetryableClient.RetryMax = retry
 
 	c.ServicePrincipalsClient = msgraph.NewServicePrincipalsClient(c.Connection.AuthConfig.TenantID)
 	c.ServicePrincipalsClient.BaseClient.Authorizer = c.Connection.Authorizer
 	c.ServicePrincipalsClient.BaseClient.Endpoint = c.Connection.AuthConfig.Environment.MsGraph.Endpoint
+	c.ServicePrincipalsClient.BaseClient.RetryableClient.RetryMax = retry
 
 	c.SignInReportsClient = msgraph.NewSignInReportsClient(c.Connection.AuthConfig.TenantID)
 	c.SignInReportsClient.BaseClient.Authorizer = c.Connection.Authorizer
 	c.SignInReportsClient.BaseClient.Endpoint = c.Connection.AuthConfig.Environment.MsGraph.Endpoint
+	c.SignInReportsClient.BaseClient.RetryableClient.RetryMax = retry
 
 	c.UsersAppRoleAssignmentsClient = msgraph.NewUsersAppRoleAssignmentsClient(c.Connection.AuthConfig.TenantID)
 	c.UsersAppRoleAssignmentsClient.BaseClient.Authorizer = c.Connection.Authorizer
 	c.UsersAppRoleAssignmentsClient.BaseClient.Endpoint = c.Connection.AuthConfig.Environment.MsGraph.Endpoint
+	c.UsersAppRoleAssignmentsClient.BaseClient.RetryableClient.RetryMax = retry
 
 	c.UsersClient = msgraph.NewUsersClient(c.Connection.AuthConfig.TenantID)
 	c.UsersClient.BaseClient.Authorizer = c.Connection.Authorizer
 	c.UsersClient.BaseClient.Endpoint = c.Connection.AuthConfig.Environment.MsGraph.Endpoint
+	c.UsersClient.BaseClient.RetryableClient.RetryMax = retry
 
 	return
 }

--- a/internal/test/testing.go
+++ b/internal/test/testing.go
@@ -31,7 +31,7 @@ var (
 	clientCertPassword    = os.Getenv("CLIENT_CERTIFICATE_PASSWORD")
 	clientSecret          = os.Getenv("CLIENT_SECRET")
 	environment           = os.Getenv("AZURE_ENVIRONMENT")
-	retryMax              = envDefault("RETRY_MAX", "9")
+	retryMax              = envDefault("RETRY_MAX", "14")
 )
 
 type Connection struct {

--- a/internal/test/testing.go
+++ b/internal/test/testing.go
@@ -5,10 +5,13 @@ import (
 	"log"
 	"os"
 
-	"github.com/manicminer/hamilton/internal/utils"
+	"golang.org/x/oauth2"
+
+	"github.com/manicminer/hamilton/msgraph"
 
 	"github.com/manicminer/hamilton/auth"
 	"github.com/manicminer/hamilton/environments"
+	"github.com/manicminer/hamilton/internal/utils"
 )
 
 var (
@@ -30,7 +33,7 @@ type Connection struct {
 }
 
 // NewConnection configures and returns a Connection for use in tests.
-func NewConnection(api auth.Api, tokenVersion auth.TokenVersion) *Connection {
+func NewConnection(tokenVersion auth.TokenVersion) *Connection {
 	env, err := environments.EnvironmentFromString(environment)
 	if err != nil {
 		log.Fatal(err)
@@ -54,10 +57,192 @@ func NewConnection(api auth.Api, tokenVersion auth.TokenVersion) *Connection {
 		DomainName: tenantDomain,
 	}
 
-	t.Authorizer, err = t.AuthConfig.NewAuthorizer(t.Context, api)
+	return &t
+}
+
+// Authorize configures an Authorizer for the Connection
+func (c *Connection) Authorize(api environments.Api) {
+	var err error
+	c.Authorizer, err = c.AuthConfig.NewAuthorizer(c.Context, api)
 	if err != nil {
 		log.Fatal(err)
 	}
+}
 
-	return &t
+type Test struct {
+	Connection   *Connection
+	RandomString string
+
+	Claims auth.Claims
+	Token  *oauth2.Token
+
+	AccessPackageAssignmentPolicyClient       *msgraph.AccessPackageAssignmentPolicyClient
+	AccessPackageCatalogClient                *msgraph.AccessPackageCatalogClient
+	AccessPackageClient                       *msgraph.AccessPackageClient
+	AccessPackageResourceClient               *msgraph.AccessPackageResourceClient
+	AccessPackageResourceRequestClient        *msgraph.AccessPackageResourceRequestClient
+	AccessPackageResourceRoleScopeClient      *msgraph.AccessPackageResourceRoleScopeClient
+	ApplicationTemplatesClient                *msgraph.ApplicationTemplatesClient
+	ApplicationsClient                        *msgraph.ApplicationsClient
+	AppRoleAssignedToClient                   *msgraph.AppRoleAssignedToClient
+	AuthenticationMethodsClient               *msgraph.AuthenticationMethodsClient
+	ConditionalAccessPoliciesClient           *msgraph.ConditionalAccessPoliciesClient
+	DirectoryAuditReportsClient               *msgraph.DirectoryAuditReportsClient
+	DirectoryObjectsClient                    *msgraph.DirectoryObjectsClient
+	DirectoryRoleTemplatesClient              *msgraph.DirectoryRoleTemplatesClient
+	DirectoryRolesClient                      *msgraph.DirectoryRolesClient
+	DomainsClient                             *msgraph.DomainsClient
+	GroupsAppRoleAssignmentsClient            *msgraph.AppRoleAssignmentsClient
+	GroupsClient                              *msgraph.GroupsClient
+	IdentityProvidersClient                   *msgraph.IdentityProvidersClient
+	InvitationsClient                         *msgraph.InvitationsClient
+	MeClient                                  *msgraph.MeClient
+	NamedLocationsClient                      *msgraph.NamedLocationsClient
+	ReportsClient                             *msgraph.ReportsClient
+	SchemaExtensionsClient                    *msgraph.SchemaExtensionsClient
+	ServicePrincipalsAppRoleAssignmentsClient *msgraph.AppRoleAssignmentsClient
+	ServicePrincipalsClient                   *msgraph.ServicePrincipalsClient
+	SignInReportsClient                       *msgraph.SignInReportsClient
+	UsersAppRoleAssignmentsClient             *msgraph.AppRoleAssignmentsClient
+	UsersClient                               *msgraph.UsersClient
+}
+
+func NewTest() (c *Test) {
+	c = &Test{}
+	c.setup()
+	return
+}
+
+func (c *Test) setup() {
+	c.Connection = NewConnection(auth.TokenVersion2)
+	c.RandomString = RandomString()
+
+	c.Connection.Authorize(c.Connection.AuthConfig.Environment.MsGraph)
+
+	var err error
+	c.Token, err = c.Connection.Authorizer.Token()
+	if err != nil {
+		log.Fatalf("could not acquire access token: %v", err)
+	}
+
+	c.Claims, err = auth.ParseClaims(c.Token)
+	if err != nil {
+		log.Fatalf("could not parse claims: %v", err)
+	}
+
+	c.AccessPackageAssignmentPolicyClient = msgraph.NewAccessPackageAssignmentPolicyClient(c.Connection.AuthConfig.TenantID)
+	c.AccessPackageAssignmentPolicyClient.BaseClient.Authorizer = c.Connection.Authorizer
+	c.AccessPackageAssignmentPolicyClient.BaseClient.Endpoint = c.Connection.AuthConfig.Environment.MsGraph.Endpoint
+
+	c.AccessPackageCatalogClient = msgraph.NewAccessPackageCatalogClient(c.Connection.AuthConfig.TenantID)
+	c.AccessPackageCatalogClient.BaseClient.Authorizer = c.Connection.Authorizer
+	c.AccessPackageCatalogClient.BaseClient.Endpoint = c.Connection.AuthConfig.Environment.MsGraph.Endpoint
+
+	c.AccessPackageClient = msgraph.NewAccessPackageClient(c.Connection.AuthConfig.TenantID)
+	c.AccessPackageClient.BaseClient.Authorizer = c.Connection.Authorizer
+	c.AccessPackageClient.BaseClient.Endpoint = c.Connection.AuthConfig.Environment.MsGraph.Endpoint
+
+	c.AccessPackageResourceClient = msgraph.NewAccessPackageResourceClient(c.Connection.AuthConfig.TenantID)
+	c.AccessPackageResourceClient.BaseClient.Authorizer = c.Connection.Authorizer
+	c.AccessPackageResourceClient.BaseClient.Endpoint = c.Connection.AuthConfig.Environment.MsGraph.Endpoint
+
+	c.AccessPackageResourceRequestClient = msgraph.NewAccessPackageResourceRequestClient(c.Connection.AuthConfig.TenantID)
+	c.AccessPackageResourceRequestClient.BaseClient.Authorizer = c.Connection.Authorizer
+	c.AccessPackageResourceRequestClient.BaseClient.Endpoint = c.Connection.AuthConfig.Environment.MsGraph.Endpoint
+
+	c.AccessPackageResourceRoleScopeClient = msgraph.NewAccessPackageResourceRoleScopeClient(c.Connection.AuthConfig.TenantID)
+	c.AccessPackageResourceRoleScopeClient.BaseClient.Authorizer = c.Connection.Authorizer
+	c.AccessPackageResourceRoleScopeClient.BaseClient.Endpoint = c.Connection.AuthConfig.Environment.MsGraph.Endpoint
+
+	c.ApplicationTemplatesClient = msgraph.NewApplicationTemplatesClient(c.Connection.AuthConfig.TenantID)
+	c.ApplicationTemplatesClient.BaseClient.Authorizer = c.Connection.Authorizer
+	c.ApplicationTemplatesClient.BaseClient.Endpoint = c.Connection.AuthConfig.Environment.MsGraph.Endpoint
+
+	c.ApplicationsClient = msgraph.NewApplicationsClient(c.Connection.AuthConfig.TenantID)
+	c.ApplicationsClient.BaseClient.Authorizer = c.Connection.Authorizer
+	c.ApplicationsClient.BaseClient.Endpoint = c.Connection.AuthConfig.Environment.MsGraph.Endpoint
+
+	c.AppRoleAssignedToClient = msgraph.NewAppRoleAssignedToClient(c.Connection.AuthConfig.TenantID)
+	c.AppRoleAssignedToClient.BaseClient.Authorizer = c.Connection.Authorizer
+	c.AppRoleAssignedToClient.BaseClient.Endpoint = c.Connection.AuthConfig.Environment.MsGraph.Endpoint
+
+	c.AuthenticationMethodsClient = msgraph.NewAuthenticationMethodsClient(c.Connection.AuthConfig.TenantID)
+	c.AuthenticationMethodsClient.BaseClient.Authorizer = c.Connection.Authorizer
+	c.AuthenticationMethodsClient.BaseClient.Endpoint = c.Connection.AuthConfig.Environment.MsGraph.Endpoint
+
+	c.ConditionalAccessPoliciesClient = msgraph.NewConditionalAccessPoliciesClient(c.Connection.AuthConfig.TenantID)
+	c.ConditionalAccessPoliciesClient.BaseClient.Authorizer = c.Connection.Authorizer
+	c.ConditionalAccessPoliciesClient.BaseClient.Endpoint = c.Connection.AuthConfig.Environment.MsGraph.Endpoint
+
+	c.DirectoryAuditReportsClient = msgraph.NewDirectoryAuditReportsClient(c.Connection.AuthConfig.TenantID)
+	c.DirectoryAuditReportsClient.BaseClient.Authorizer = c.Connection.Authorizer
+	c.DirectoryAuditReportsClient.BaseClient.Endpoint = c.Connection.AuthConfig.Environment.MsGraph.Endpoint
+
+	c.DirectoryObjectsClient = msgraph.NewDirectoryObjectsClient(c.Connection.AuthConfig.TenantID)
+	c.DirectoryObjectsClient.BaseClient.Authorizer = c.Connection.Authorizer
+	c.DirectoryObjectsClient.BaseClient.Endpoint = c.Connection.AuthConfig.Environment.MsGraph.Endpoint
+
+	c.DirectoryRoleTemplatesClient = msgraph.NewDirectoryRoleTemplatesClient(c.Connection.AuthConfig.TenantID)
+	c.DirectoryRoleTemplatesClient.BaseClient.Authorizer = c.Connection.Authorizer
+	c.DirectoryRoleTemplatesClient.BaseClient.Endpoint = c.Connection.AuthConfig.Environment.MsGraph.Endpoint
+
+	c.DirectoryRolesClient = msgraph.NewDirectoryRolesClient(c.Connection.AuthConfig.TenantID)
+	c.DirectoryRolesClient.BaseClient.Authorizer = c.Connection.Authorizer
+	c.DirectoryRolesClient.BaseClient.Endpoint = c.Connection.AuthConfig.Environment.MsGraph.Endpoint
+
+	c.DomainsClient = msgraph.NewDomainsClient(c.Connection.AuthConfig.TenantID)
+	c.DomainsClient.BaseClient.Authorizer = c.Connection.Authorizer
+	c.DomainsClient.BaseClient.Endpoint = c.Connection.AuthConfig.Environment.MsGraph.Endpoint
+
+	c.GroupsAppRoleAssignmentsClient = msgraph.NewGroupsAppRoleAssignmentsClient(c.Connection.AuthConfig.TenantID)
+	c.GroupsAppRoleAssignmentsClient.BaseClient.Authorizer = c.Connection.Authorizer
+	c.GroupsAppRoleAssignmentsClient.BaseClient.Endpoint = c.Connection.AuthConfig.Environment.MsGraph.Endpoint
+
+	c.GroupsClient = msgraph.NewGroupsClient(c.Connection.AuthConfig.TenantID)
+	c.GroupsClient.BaseClient.Authorizer = c.Connection.Authorizer
+	c.GroupsClient.BaseClient.Endpoint = c.Connection.AuthConfig.Environment.MsGraph.Endpoint
+
+	c.IdentityProvidersClient = msgraph.NewIdentityProvidersClient(c.Connection.AuthConfig.TenantID)
+	c.IdentityProvidersClient.BaseClient.Authorizer = c.Connection.Authorizer
+	c.IdentityProvidersClient.BaseClient.Endpoint = c.Connection.AuthConfig.Environment.MsGraph.Endpoint
+
+	c.InvitationsClient = msgraph.NewInvitationsClient(c.Connection.AuthConfig.TenantID)
+	c.InvitationsClient.BaseClient.Authorizer = c.Connection.Authorizer
+	c.InvitationsClient.BaseClient.Endpoint = c.Connection.AuthConfig.Environment.MsGraph.Endpoint
+
+	c.MeClient = msgraph.NewMeClient(c.Connection.AuthConfig.TenantID)
+	c.MeClient.BaseClient.Authorizer = c.Connection.Authorizer
+	c.MeClient.BaseClient.Endpoint = c.Connection.AuthConfig.Environment.MsGraph.Endpoint
+
+	c.NamedLocationsClient = msgraph.NewNamedLocationsClient(c.Connection.AuthConfig.TenantID)
+	c.NamedLocationsClient.BaseClient.Authorizer = c.Connection.Authorizer
+	c.NamedLocationsClient.BaseClient.Endpoint = c.Connection.AuthConfig.Environment.MsGraph.Endpoint
+
+	c.ReportsClient = msgraph.NewReportsClient(c.Connection.AuthConfig.TenantID)
+	c.ReportsClient.BaseClient.Authorizer = c.Connection.Authorizer
+	c.ReportsClient.BaseClient.Endpoint = c.Connection.AuthConfig.Environment.MsGraph.Endpoint
+
+	c.SchemaExtensionsClient = msgraph.NewSchemaExtensionsClient(c.Connection.AuthConfig.TenantID)
+	c.SchemaExtensionsClient.BaseClient.Authorizer = c.Connection.Authorizer
+	c.SchemaExtensionsClient.BaseClient.Endpoint = c.Connection.AuthConfig.Environment.MsGraph.Endpoint
+
+	c.ServicePrincipalsAppRoleAssignmentsClient = msgraph.NewServicePrincipalsAppRoleAssignmentsClient(c.Connection.AuthConfig.TenantID)
+	c.ServicePrincipalsAppRoleAssignmentsClient.BaseClient.Authorizer = c.Connection.Authorizer
+	c.ServicePrincipalsAppRoleAssignmentsClient.BaseClient.Endpoint = c.Connection.AuthConfig.Environment.MsGraph.Endpoint
+
+	c.ServicePrincipalsClient = msgraph.NewServicePrincipalsClient(c.Connection.AuthConfig.TenantID)
+	c.ServicePrincipalsClient.BaseClient.Authorizer = c.Connection.Authorizer
+	c.ServicePrincipalsClient.BaseClient.Endpoint = c.Connection.AuthConfig.Environment.MsGraph.Endpoint
+
+	c.SignInReportsClient = msgraph.NewSignInReportsClient(c.Connection.AuthConfig.TenantID)
+	c.SignInReportsClient.BaseClient.Authorizer = c.Connection.Authorizer
+	c.SignInReportsClient.BaseClient.Endpoint = c.Connection.AuthConfig.Environment.MsGraph.Endpoint
+
+	c.UsersAppRoleAssignmentsClient = msgraph.NewUsersAppRoleAssignmentsClient(c.Connection.AuthConfig.TenantID)
+	c.UsersAppRoleAssignmentsClient.BaseClient.Authorizer = c.Connection.Authorizer
+	c.UsersAppRoleAssignmentsClient.BaseClient.Endpoint = c.Connection.AuthConfig.Environment.MsGraph.Endpoint
+
+	c.UsersClient = msgraph.NewUsersClient(c.Connection.AuthConfig.TenantID)
+	c.UsersClient.BaseClient.Authorizer = c.Connection.Authorizer
+	c.UsersClient.BaseClient.Endpoint = c.Connection.AuthConfig.Environment.MsGraph.Endpoint
 }

--- a/msgraph/accesspackage_test.go
+++ b/msgraph/accesspackage_test.go
@@ -4,41 +4,21 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/manicminer/hamilton/auth"
 	"github.com/manicminer/hamilton/internal/test"
 	"github.com/manicminer/hamilton/internal/utils"
 	"github.com/manicminer/hamilton/msgraph"
 	"github.com/manicminer/hamilton/odata"
 )
 
-type AccessPackageTest struct {
-	connection      *test.Connection
-	apClient        *msgraph.AccessPackageClient        //apClient
-	apCatalogClient *msgraph.AccessPackageCatalogClient //Client for Catalog Test to associate as required
-	randomString    string
-}
-
 func TestAccessPackageClient(t *testing.T) {
-	c := AccessPackageTest{
-		connection:   test.NewConnection(auth.MsGraph, auth.TokenVersion2),
-		randomString: test.RandomString(),
-	}
-
-	// Init clients
-	c.apClient = msgraph.NewAccessPackageClient(c.connection.AuthConfig.TenantID)
-	c.apClient.BaseClient.Authorizer = c.connection.Authorizer
-	c.apClient.BaseClient.Endpoint = c.connection.AuthConfig.Environment.MsGraph.Endpoint
-
-	c.apCatalogClient = msgraph.NewAccessPackageCatalogClient(c.connection.AuthConfig.TenantID)
-	c.apCatalogClient.BaseClient.Authorizer = c.connection.Authorizer
-	c.apCatalogClient.BaseClient.Endpoint = c.connection.AuthConfig.Environment.MsGraph.Endpoint
+	c := test.NewTest()
 
 	// Create test catalog
 	accessPackageCatalog := testapCatalog_Create(t, c)
 
 	// Create AP
 	accessPackage := testAccessPackageClient_Create(t, c, msgraph.AccessPackage{
-		DisplayName:         utils.StringPtr(fmt.Sprintf("test-accesspackage-%s", c.randomString)),
+		DisplayName:         utils.StringPtr(fmt.Sprintf("test-accesspackage-%s", c.RandomString)),
 		CatalogId:           accessPackageCatalog.ID,
 		Description:         utils.StringPtr("Test Access Package"),
 		IsHidden:            utils.BoolPtr(false),
@@ -48,7 +28,7 @@ func TestAccessPackageClient(t *testing.T) {
 	// Update test
 	testAccessPackageClient_Update(t, c, msgraph.AccessPackage{
 		ID:          accessPackage.ID,
-		DisplayName: utils.StringPtr(fmt.Sprintf("test-accesspackage-updated-%s", c.randomString)),
+		DisplayName: utils.StringPtr(fmt.Sprintf("test-accesspackage-updated-%s", c.RandomString)),
 	})
 
 	// Other operations
@@ -62,8 +42,8 @@ func TestAccessPackageClient(t *testing.T) {
 
 // AP
 
-func testAccessPackageClient_Create(t *testing.T, c AccessPackageTest, a msgraph.AccessPackage) (accessPackage *msgraph.AccessPackage) {
-	accessPackage, status, err := c.apClient.Create(c.connection.Context, a)
+func testAccessPackageClient_Create(t *testing.T, c *test.Test, a msgraph.AccessPackage) (accessPackage *msgraph.AccessPackage) {
+	accessPackage, status, err := c.AccessPackageClient.Create(c.Connection.Context, a)
 	if err != nil {
 		t.Fatalf("AccessPackageClient.Create(): %v", err)
 	}
@@ -79,8 +59,8 @@ func testAccessPackageClient_Create(t *testing.T, c AccessPackageTest, a msgraph
 	return
 }
 
-func testAccessPackageClient_Get(t *testing.T, c AccessPackageTest, id string) (accessPackage *msgraph.AccessPackage) {
-	accessPackage, status, err := c.apClient.Get(c.connection.Context, id, odata.Query{})
+func testAccessPackageClient_Get(t *testing.T, c *test.Test, id string) (accessPackage *msgraph.AccessPackage) {
+	accessPackage, status, err := c.AccessPackageClient.Get(c.Connection.Context, id, odata.Query{})
 	if err != nil {
 		t.Fatalf("AccessPackageClient.Get(): %v", err)
 	}
@@ -93,8 +73,8 @@ func testAccessPackageClient_Get(t *testing.T, c AccessPackageTest, id string) (
 	return
 }
 
-func testAccessPackageClient_Update(t *testing.T, c AccessPackageTest, accessPackage msgraph.AccessPackage) {
-	status, err := c.apClient.Update(c.connection.Context, accessPackage)
+func testAccessPackageClient_Update(t *testing.T, c *test.Test, accessPackage msgraph.AccessPackage) {
+	status, err := c.AccessPackageClient.Update(c.Connection.Context, accessPackage)
 	if err != nil {
 		t.Fatalf("AccessPackageClient.Update(): %v", err)
 	}
@@ -103,8 +83,8 @@ func testAccessPackageClient_Update(t *testing.T, c AccessPackageTest, accessPac
 	}
 }
 
-func testAccessPackageClient_List(t *testing.T, c AccessPackageTest) (accessPackages *[]msgraph.AccessPackage) {
-	accessPackages, _, err := c.apClient.List(c.connection.Context, odata.Query{Top: 10})
+func testAccessPackageClient_List(t *testing.T, c *test.Test) (accessPackages *[]msgraph.AccessPackage) {
+	accessPackages, _, err := c.AccessPackageClient.List(c.Connection.Context, odata.Query{Top: 10})
 	if err != nil {
 		t.Fatalf("AccessPackageClient.List(): %v", err)
 	}
@@ -114,8 +94,8 @@ func testAccessPackageClient_List(t *testing.T, c AccessPackageTest) (accessPack
 	return
 }
 
-func testAccessPackageClient_Delete(t *testing.T, c AccessPackageTest, id string) {
-	status, err := c.apClient.Delete(c.connection.Context, id)
+func testAccessPackageClient_Delete(t *testing.T, c *test.Test, id string) {
+	status, err := c.AccessPackageClient.Delete(c.Connection.Context, id)
 	if err != nil {
 		t.Fatalf("AccessPackageClient.Delete(): %v", err)
 	}
@@ -126,9 +106,9 @@ func testAccessPackageClient_Delete(t *testing.T, c AccessPackageTest, id string
 
 // AP Catalog
 
-func testapCatalog_Create(t *testing.T, c AccessPackageTest) (accessPackageCatalog *msgraph.AccessPackageCatalog) {
-	accessPackageCatalog, _, err := c.apCatalogClient.Create(c.connection.Context, msgraph.AccessPackageCatalog{
-		DisplayName:         utils.StringPtr(fmt.Sprintf("test-catalog-%s", c.randomString)),
+func testapCatalog_Create(t *testing.T, c *test.Test) (accessPackageCatalog *msgraph.AccessPackageCatalog) {
+	accessPackageCatalog, _, err := c.AccessPackageCatalogClient.Create(c.Connection.Context, msgraph.AccessPackageCatalog{
+		DisplayName:         utils.StringPtr(fmt.Sprintf("test-catalog-%s", c.RandomString)),
 		CatalogType:         msgraph.AccessPackageCatalogTypeUserManaged,
 		CatalogStatus:       msgraph.AccessPackageCatalogStatusPublished,
 		Description:         utils.StringPtr("Test Access Catalog"),
@@ -141,8 +121,8 @@ func testapCatalog_Create(t *testing.T, c AccessPackageTest) (accessPackageCatal
 	return
 }
 
-func testapCatalog_Delete(t *testing.T, c AccessPackageTest, accessPackageCatalog *msgraph.AccessPackageCatalog) {
-	_, err := c.apCatalogClient.Delete(c.connection.Context, *accessPackageCatalog.ID)
+func testapCatalog_Delete(t *testing.T, c *test.Test, accessPackageCatalog *msgraph.AccessPackageCatalog) {
+	_, err := c.AccessPackageCatalogClient.Delete(c.Connection.Context, *accessPackageCatalog.ID)
 	if err != nil {
 		t.Fatalf("AccessPackageCatalogClient.Delete() - Could not delete test AccessPackage catalog")
 	}

--- a/msgraph/accesspackage_test.go
+++ b/msgraph/accesspackage_test.go
@@ -11,7 +11,8 @@ import (
 )
 
 func TestAccessPackageClient(t *testing.T) {
-	c := test.NewTest()
+	c := test.NewTest(t)
+	defer c.CancelFunc()
 
 	// Create test catalog
 	accessPackageCatalog := testapCatalog_Create(t, c)
@@ -43,7 +44,7 @@ func TestAccessPackageClient(t *testing.T) {
 // AP
 
 func testAccessPackageClient_Create(t *testing.T, c *test.Test, a msgraph.AccessPackage) (accessPackage *msgraph.AccessPackage) {
-	accessPackage, status, err := c.AccessPackageClient.Create(c.Connection.Context, a)
+	accessPackage, status, err := c.AccessPackageClient.Create(c.Context, a)
 	if err != nil {
 		t.Fatalf("AccessPackageClient.Create(): %v", err)
 	}
@@ -60,7 +61,7 @@ func testAccessPackageClient_Create(t *testing.T, c *test.Test, a msgraph.Access
 }
 
 func testAccessPackageClient_Get(t *testing.T, c *test.Test, id string) (accessPackage *msgraph.AccessPackage) {
-	accessPackage, status, err := c.AccessPackageClient.Get(c.Connection.Context, id, odata.Query{})
+	accessPackage, status, err := c.AccessPackageClient.Get(c.Context, id, odata.Query{})
 	if err != nil {
 		t.Fatalf("AccessPackageClient.Get(): %v", err)
 	}
@@ -74,7 +75,7 @@ func testAccessPackageClient_Get(t *testing.T, c *test.Test, id string) (accessP
 }
 
 func testAccessPackageClient_Update(t *testing.T, c *test.Test, accessPackage msgraph.AccessPackage) {
-	status, err := c.AccessPackageClient.Update(c.Connection.Context, accessPackage)
+	status, err := c.AccessPackageClient.Update(c.Context, accessPackage)
 	if err != nil {
 		t.Fatalf("AccessPackageClient.Update(): %v", err)
 	}
@@ -84,7 +85,7 @@ func testAccessPackageClient_Update(t *testing.T, c *test.Test, accessPackage ms
 }
 
 func testAccessPackageClient_List(t *testing.T, c *test.Test) (accessPackages *[]msgraph.AccessPackage) {
-	accessPackages, _, err := c.AccessPackageClient.List(c.Connection.Context, odata.Query{Top: 10})
+	accessPackages, _, err := c.AccessPackageClient.List(c.Context, odata.Query{Top: 10})
 	if err != nil {
 		t.Fatalf("AccessPackageClient.List(): %v", err)
 	}
@@ -95,7 +96,7 @@ func testAccessPackageClient_List(t *testing.T, c *test.Test) (accessPackages *[
 }
 
 func testAccessPackageClient_Delete(t *testing.T, c *test.Test, id string) {
-	status, err := c.AccessPackageClient.Delete(c.Connection.Context, id)
+	status, err := c.AccessPackageClient.Delete(c.Context, id)
 	if err != nil {
 		t.Fatalf("AccessPackageClient.Delete(): %v", err)
 	}
@@ -107,7 +108,7 @@ func testAccessPackageClient_Delete(t *testing.T, c *test.Test, id string) {
 // AP Catalog
 
 func testapCatalog_Create(t *testing.T, c *test.Test) (accessPackageCatalog *msgraph.AccessPackageCatalog) {
-	accessPackageCatalog, _, err := c.AccessPackageCatalogClient.Create(c.Connection.Context, msgraph.AccessPackageCatalog{
+	accessPackageCatalog, _, err := c.AccessPackageCatalogClient.Create(c.Context, msgraph.AccessPackageCatalog{
 		DisplayName:         utils.StringPtr(fmt.Sprintf("test-catalog-%s", c.RandomString)),
 		CatalogType:         msgraph.AccessPackageCatalogTypeUserManaged,
 		CatalogStatus:       msgraph.AccessPackageCatalogStatusPublished,
@@ -122,7 +123,7 @@ func testapCatalog_Create(t *testing.T, c *test.Test) (accessPackageCatalog *msg
 }
 
 func testapCatalog_Delete(t *testing.T, c *test.Test, accessPackageCatalog *msgraph.AccessPackageCatalog) {
-	_, err := c.AccessPackageCatalogClient.Delete(c.Connection.Context, *accessPackageCatalog.ID)
+	_, err := c.AccessPackageCatalogClient.Delete(c.Context, *accessPackageCatalog.ID)
 	if err != nil {
 		t.Fatalf("AccessPackageCatalogClient.Delete() - Could not delete test AccessPackage catalog")
 	}

--- a/msgraph/accesspackageassignmentpolicy_test.go
+++ b/msgraph/accesspackageassignmentpolicy_test.go
@@ -11,7 +11,8 @@ import (
 )
 
 func TestAccessPackageAssignmentPolicyClient(t *testing.T) {
-	c := test.NewTest()
+	c := test.NewTest(t)
+	defer c.CancelFunc()
 
 	// Create test catalog
 	accessPackageCatalog := testAccessPackageCatalog_Create(t, c)
@@ -62,7 +63,7 @@ func TestAccessPackageAssignmentPolicyClient(t *testing.T) {
 // AccessPackageAssignmentPolicy
 
 func testAccessPackageAssignmentPolicyClient_Create(t *testing.T, c *test.Test, a msgraph.AccessPackageAssignmentPolicy) (accessPackageAssignmentPolicy *msgraph.AccessPackageAssignmentPolicy) {
-	accessPackageAssignmentPolicy, status, err := c.AccessPackageAssignmentPolicyClient.Create(c.Connection.Context, a)
+	accessPackageAssignmentPolicy, status, err := c.AccessPackageAssignmentPolicyClient.Create(c.Context, a)
 	if err != nil {
 		t.Fatalf("AccessPackageAssignmentPolicyClient.Create(): %v", err)
 	}
@@ -79,7 +80,7 @@ func testAccessPackageAssignmentPolicyClient_Create(t *testing.T, c *test.Test, 
 }
 
 func testAccessPackageAssignmentPolicyClient_Get(t *testing.T, c *test.Test, id string) (accessPackageAssignmentPolicy *msgraph.AccessPackageAssignmentPolicy) {
-	accessPackageAssignmentPolicy, status, err := c.AccessPackageAssignmentPolicyClient.Get(c.Connection.Context, id, odata.Query{})
+	accessPackageAssignmentPolicy, status, err := c.AccessPackageAssignmentPolicyClient.Get(c.Context, id, odata.Query{})
 	if err != nil {
 		t.Fatalf("AccessPackageAssignmentPolicyClient.Get(): %v", err)
 	}
@@ -93,7 +94,7 @@ func testAccessPackageAssignmentPolicyClient_Get(t *testing.T, c *test.Test, id 
 }
 
 func testAccessPackageAssignmentPolicyClient_Update(t *testing.T, c *test.Test, accessPackageAssignmentPolicy msgraph.AccessPackageAssignmentPolicy) {
-	status, err := c.AccessPackageAssignmentPolicyClient.Update(c.Connection.Context, accessPackageAssignmentPolicy)
+	status, err := c.AccessPackageAssignmentPolicyClient.Update(c.Context, accessPackageAssignmentPolicy)
 	if err != nil {
 		t.Fatalf("AccessPackageAssignmentPolicyClient.Update(): %v", err)
 	}
@@ -103,7 +104,7 @@ func testAccessPackageAssignmentPolicyClient_Update(t *testing.T, c *test.Test, 
 }
 
 func testAccessPackageAssignmentPolicyClient_List(t *testing.T, c *test.Test) (accessPackageAssignmentPolicys *[]msgraph.AccessPackageAssignmentPolicy) {
-	accessPackageAssignmentPolicys, _, err := c.AccessPackageAssignmentPolicyClient.List(c.Connection.Context, odata.Query{Top: 10})
+	accessPackageAssignmentPolicys, _, err := c.AccessPackageAssignmentPolicyClient.List(c.Context, odata.Query{Top: 10})
 	if err != nil {
 		t.Fatalf("AccessPackageAssignmentPolicyClient.List(): %v", err)
 	}
@@ -114,7 +115,7 @@ func testAccessPackageAssignmentPolicyClient_List(t *testing.T, c *test.Test) (a
 }
 
 func testAccessPackageAssignmentPolicyClient_Delete(t *testing.T, c *test.Test, id string) {
-	status, err := c.AccessPackageAssignmentPolicyClient.Delete(c.Connection.Context, id)
+	status, err := c.AccessPackageAssignmentPolicyClient.Delete(c.Context, id)
 	if err != nil {
 		t.Fatalf("AccessPackageAssignmentPolicyClient.Delete(): %v", err)
 	}
@@ -126,7 +127,7 @@ func testAccessPackageAssignmentPolicyClient_Delete(t *testing.T, c *test.Test, 
 // AccessPackage
 
 func testAccessPackage_Create(t *testing.T, c *test.Test, accessPackageCatalog *msgraph.AccessPackageCatalog) (accessPackage *msgraph.AccessPackage) {
-	accessPackage, _, err := c.AccessPackageClient.Create(c.Connection.Context, msgraph.AccessPackage{
+	accessPackage, _, err := c.AccessPackageClient.Create(c.Context, msgraph.AccessPackage{
 		DisplayName:         utils.StringPtr(fmt.Sprintf("test-accesspackage-%s", c.RandomString)),
 		CatalogId:           accessPackageCatalog.ID,
 		Description:         utils.StringPtr("Test Access Package"),
@@ -141,7 +142,7 @@ func testAccessPackage_Create(t *testing.T, c *test.Test, accessPackageCatalog *
 }
 
 func testAccessPackage_Delete(t *testing.T, c *test.Test, id string) {
-	_, err := c.AccessPackageClient.Delete(c.Connection.Context, id)
+	_, err := c.AccessPackageClient.Delete(c.Context, id)
 	if err != nil {
 		t.Fatalf("AccessPackageClient.Delete() - Could not delete test AccessPackage catalog")
 	}
@@ -150,7 +151,7 @@ func testAccessPackage_Delete(t *testing.T, c *test.Test, id string) {
 // AccessPackageCatalog
 
 func testAccessPackageCatalog_Create(t *testing.T, c *test.Test) (accessPackageCatalog *msgraph.AccessPackageCatalog) {
-	accessPackageCatalog, _, err := c.AccessPackageCatalogClient.Create(c.Connection.Context, msgraph.AccessPackageCatalog{
+	accessPackageCatalog, _, err := c.AccessPackageCatalogClient.Create(c.Context, msgraph.AccessPackageCatalog{
 		DisplayName:         utils.StringPtr(fmt.Sprintf("test-catalog-%s", c.RandomString)),
 		CatalogType:         msgraph.AccessPackageCatalogTypeUserManaged,
 		CatalogStatus:       msgraph.AccessPackageCatalogStatusPublished,
@@ -165,7 +166,7 @@ func testAccessPackageCatalog_Create(t *testing.T, c *test.Test) (accessPackageC
 }
 
 func testAccessPackageCatalog_Delete(t *testing.T, c *test.Test, accessPackageCatalog *msgraph.AccessPackageCatalog) {
-	_, err := c.AccessPackageCatalogClient.Delete(c.Connection.Context, *accessPackageCatalog.ID)
+	_, err := c.AccessPackageCatalogClient.Delete(c.Context, *accessPackageCatalog.ID)
 	if err != nil {
 		t.Fatalf("AccessPackageCatalogClient.Delete() - Could not delete test AccessPackage catalog")
 	}

--- a/msgraph/accesspackageassignmentpolicy_test.go
+++ b/msgraph/accesspackageassignmentpolicy_test.go
@@ -4,39 +4,14 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/manicminer/hamilton/auth"
 	"github.com/manicminer/hamilton/internal/test"
 	"github.com/manicminer/hamilton/internal/utils"
 	"github.com/manicminer/hamilton/msgraph"
 	"github.com/manicminer/hamilton/odata"
 )
 
-type AccessPackageAssignmentPolicyTest struct {
-	connection               *test.Connection
-	apClient                 *msgraph.AccessPackageClient        //apClient
-	apCatalogClient          *msgraph.AccessPackageCatalogClient //Client for Catalog Test to associate as required
-	apAssignmentPolicyClient *msgraph.AccessPackageAssignmentPolicyClient
-	randomString             string
-}
-
 func TestAccessPackageAssignmentPolicyClient(t *testing.T) {
-	c := AccessPackageAssignmentPolicyTest{
-		connection:   test.NewConnection(auth.MsGraph, auth.TokenVersion2),
-		randomString: test.RandomString(),
-	}
-
-	// Init clients
-	c.apClient = msgraph.NewAccessPackageClient(c.connection.AuthConfig.TenantID)
-	c.apClient.BaseClient.Authorizer = c.connection.Authorizer
-	c.apClient.BaseClient.Endpoint = c.connection.AuthConfig.Environment.MsGraph.Endpoint
-
-	c.apCatalogClient = msgraph.NewAccessPackageCatalogClient(c.connection.AuthConfig.TenantID)
-	c.apCatalogClient.BaseClient.Authorizer = c.connection.Authorizer
-	c.apCatalogClient.BaseClient.Endpoint = c.connection.AuthConfig.Environment.MsGraph.Endpoint
-
-	c.apAssignmentPolicyClient = msgraph.NewAccessPackageAssignmentPolicyClient(c.connection.AuthConfig.TenantID)
-	c.apAssignmentPolicyClient.BaseClient.Authorizer = c.connection.Authorizer
-	c.apAssignmentPolicyClient.BaseClient.Endpoint = c.connection.AuthConfig.Environment.MsGraph.Endpoint
+	c := test.NewTest()
 
 	// Create test catalog
 	accessPackageCatalog := testAccessPackageCatalog_Create(t, c)
@@ -47,7 +22,7 @@ func TestAccessPackageAssignmentPolicyClient(t *testing.T) {
 	// Create Assignment Policy
 	accessPackageAssignmentPolicy := testAccessPackageAssignmentPolicyClient_Create(t, c, msgraph.AccessPackageAssignmentPolicy{
 		AccessPackageId: accessPackage.ID,
-		DisplayName:     utils.StringPtr(fmt.Sprintf("Test-AP-Policy-Assignment-%s", c.randomString)),
+		DisplayName:     utils.StringPtr(fmt.Sprintf("Test-AP-Policy-Assignment-%s", c.RandomString)),
 		Description:     utils.StringPtr("Test AP Policy Assignment Description"),
 		//AccessReviewSettings: utils.BoolPtr()
 		RequestorSettings: &msgraph.RequestorSettings{
@@ -70,7 +45,7 @@ func TestAccessPackageAssignmentPolicyClient(t *testing.T) {
 	newAccessPackageAssignmentPolicy := msgraph.AccessPackageAssignmentPolicy{
 		ID:              accessPackageAssignmentPolicy.ID,
 		AccessPackageId: accessPackageAssignmentPolicy.AccessPackageId, // Both the ID and AccessPackageId MUST Be specified. API complains vaguely as just "the Id"
-		DisplayName:     utils.StringPtr(fmt.Sprintf("Test-AP-Policy-Assignment-Updated-%s", c.randomString)),
+		DisplayName:     utils.StringPtr(fmt.Sprintf("Test-AP-Policy-Assignment-Updated-%s", c.RandomString)),
 		Description:     utils.StringPtr("Test AP Policy Assignment Description Updated"),
 	}
 
@@ -86,8 +61,8 @@ func TestAccessPackageAssignmentPolicyClient(t *testing.T) {
 
 // AccessPackageAssignmentPolicy
 
-func testAccessPackageAssignmentPolicyClient_Create(t *testing.T, c AccessPackageAssignmentPolicyTest, a msgraph.AccessPackageAssignmentPolicy) (accessPackageAssignmentPolicy *msgraph.AccessPackageAssignmentPolicy) {
-	accessPackageAssignmentPolicy, status, err := c.apAssignmentPolicyClient.Create(c.connection.Context, a)
+func testAccessPackageAssignmentPolicyClient_Create(t *testing.T, c *test.Test, a msgraph.AccessPackageAssignmentPolicy) (accessPackageAssignmentPolicy *msgraph.AccessPackageAssignmentPolicy) {
+	accessPackageAssignmentPolicy, status, err := c.AccessPackageAssignmentPolicyClient.Create(c.Connection.Context, a)
 	if err != nil {
 		t.Fatalf("AccessPackageAssignmentPolicyClient.Create(): %v", err)
 	}
@@ -103,8 +78,8 @@ func testAccessPackageAssignmentPolicyClient_Create(t *testing.T, c AccessPackag
 	return
 }
 
-func testAccessPackageAssignmentPolicyClient_Get(t *testing.T, c AccessPackageAssignmentPolicyTest, id string) (accessPackageAssignmentPolicy *msgraph.AccessPackageAssignmentPolicy) {
-	accessPackageAssignmentPolicy, status, err := c.apAssignmentPolicyClient.Get(c.connection.Context, id, odata.Query{})
+func testAccessPackageAssignmentPolicyClient_Get(t *testing.T, c *test.Test, id string) (accessPackageAssignmentPolicy *msgraph.AccessPackageAssignmentPolicy) {
+	accessPackageAssignmentPolicy, status, err := c.AccessPackageAssignmentPolicyClient.Get(c.Connection.Context, id, odata.Query{})
 	if err != nil {
 		t.Fatalf("AccessPackageAssignmentPolicyClient.Get(): %v", err)
 	}
@@ -117,8 +92,8 @@ func testAccessPackageAssignmentPolicyClient_Get(t *testing.T, c AccessPackageAs
 	return
 }
 
-func testAccessPackageAssignmentPolicyClient_Update(t *testing.T, c AccessPackageAssignmentPolicyTest, accessPackageAssignmentPolicy msgraph.AccessPackageAssignmentPolicy) {
-	status, err := c.apAssignmentPolicyClient.Update(c.connection.Context, accessPackageAssignmentPolicy)
+func testAccessPackageAssignmentPolicyClient_Update(t *testing.T, c *test.Test, accessPackageAssignmentPolicy msgraph.AccessPackageAssignmentPolicy) {
+	status, err := c.AccessPackageAssignmentPolicyClient.Update(c.Connection.Context, accessPackageAssignmentPolicy)
 	if err != nil {
 		t.Fatalf("AccessPackageAssignmentPolicyClient.Update(): %v", err)
 	}
@@ -127,8 +102,8 @@ func testAccessPackageAssignmentPolicyClient_Update(t *testing.T, c AccessPackag
 	}
 }
 
-func testAccessPackageAssignmentPolicyClient_List(t *testing.T, c AccessPackageAssignmentPolicyTest) (accessPackageAssignmentPolicys *[]msgraph.AccessPackageAssignmentPolicy) {
-	accessPackageAssignmentPolicys, _, err := c.apAssignmentPolicyClient.List(c.connection.Context, odata.Query{Top: 10})
+func testAccessPackageAssignmentPolicyClient_List(t *testing.T, c *test.Test) (accessPackageAssignmentPolicys *[]msgraph.AccessPackageAssignmentPolicy) {
+	accessPackageAssignmentPolicys, _, err := c.AccessPackageAssignmentPolicyClient.List(c.Connection.Context, odata.Query{Top: 10})
 	if err != nil {
 		t.Fatalf("AccessPackageAssignmentPolicyClient.List(): %v", err)
 	}
@@ -138,8 +113,8 @@ func testAccessPackageAssignmentPolicyClient_List(t *testing.T, c AccessPackageA
 	return
 }
 
-func testAccessPackageAssignmentPolicyClient_Delete(t *testing.T, c AccessPackageAssignmentPolicyTest, id string) {
-	status, err := c.apAssignmentPolicyClient.Delete(c.connection.Context, id)
+func testAccessPackageAssignmentPolicyClient_Delete(t *testing.T, c *test.Test, id string) {
+	status, err := c.AccessPackageAssignmentPolicyClient.Delete(c.Connection.Context, id)
 	if err != nil {
 		t.Fatalf("AccessPackageAssignmentPolicyClient.Delete(): %v", err)
 	}
@@ -150,9 +125,9 @@ func testAccessPackageAssignmentPolicyClient_Delete(t *testing.T, c AccessPackag
 
 // AccessPackage
 
-func testAccessPackage_Create(t *testing.T, c AccessPackageAssignmentPolicyTest, accessPackageCatalog *msgraph.AccessPackageCatalog) (accessPackage *msgraph.AccessPackage) {
-	accessPackage, _, err := c.apClient.Create(c.connection.Context, msgraph.AccessPackage{
-		DisplayName:         utils.StringPtr(fmt.Sprintf("test-accesspackage-%s", c.randomString)),
+func testAccessPackage_Create(t *testing.T, c *test.Test, accessPackageCatalog *msgraph.AccessPackageCatalog) (accessPackage *msgraph.AccessPackage) {
+	accessPackage, _, err := c.AccessPackageClient.Create(c.Connection.Context, msgraph.AccessPackage{
+		DisplayName:         utils.StringPtr(fmt.Sprintf("test-accesspackage-%s", c.RandomString)),
 		CatalogId:           accessPackageCatalog.ID,
 		Description:         utils.StringPtr("Test Access Package"),
 		IsHidden:            utils.BoolPtr(false),
@@ -165,8 +140,8 @@ func testAccessPackage_Create(t *testing.T, c AccessPackageAssignmentPolicyTest,
 	return
 }
 
-func testAccessPackage_Delete(t *testing.T, c AccessPackageAssignmentPolicyTest, id string) {
-	_, err := c.apClient.Delete(c.connection.Context, id)
+func testAccessPackage_Delete(t *testing.T, c *test.Test, id string) {
+	_, err := c.AccessPackageClient.Delete(c.Connection.Context, id)
 	if err != nil {
 		t.Fatalf("AccessPackageClient.Delete() - Could not delete test AccessPackage catalog")
 	}
@@ -174,9 +149,9 @@ func testAccessPackage_Delete(t *testing.T, c AccessPackageAssignmentPolicyTest,
 
 // AccessPackageCatalog
 
-func testAccessPackageCatalog_Create(t *testing.T, c AccessPackageAssignmentPolicyTest) (accessPackageCatalog *msgraph.AccessPackageCatalog) {
-	accessPackageCatalog, _, err := c.apCatalogClient.Create(c.connection.Context, msgraph.AccessPackageCatalog{
-		DisplayName:         utils.StringPtr(fmt.Sprintf("test-catalog-%s", c.randomString)),
+func testAccessPackageCatalog_Create(t *testing.T, c *test.Test) (accessPackageCatalog *msgraph.AccessPackageCatalog) {
+	accessPackageCatalog, _, err := c.AccessPackageCatalogClient.Create(c.Connection.Context, msgraph.AccessPackageCatalog{
+		DisplayName:         utils.StringPtr(fmt.Sprintf("test-catalog-%s", c.RandomString)),
 		CatalogType:         msgraph.AccessPackageCatalogTypeUserManaged,
 		CatalogStatus:       msgraph.AccessPackageCatalogStatusPublished,
 		Description:         utils.StringPtr("Test Access Catalog"),
@@ -189,8 +164,8 @@ func testAccessPackageCatalog_Create(t *testing.T, c AccessPackageAssignmentPoli
 	return
 }
 
-func testAccessPackageCatalog_Delete(t *testing.T, c AccessPackageAssignmentPolicyTest, accessPackageCatalog *msgraph.AccessPackageCatalog) {
-	_, err := c.apCatalogClient.Delete(c.connection.Context, *accessPackageCatalog.ID)
+func testAccessPackageCatalog_Delete(t *testing.T, c *test.Test, accessPackageCatalog *msgraph.AccessPackageCatalog) {
+	_, err := c.AccessPackageCatalogClient.Delete(c.Connection.Context, *accessPackageCatalog.ID)
 	if err != nil {
 		t.Fatalf("AccessPackageCatalogClient.Delete() - Could not delete test AccessPackage catalog")
 	}

--- a/msgraph/accesspackagecatalog_test.go
+++ b/msgraph/accesspackagecatalog_test.go
@@ -4,31 +4,17 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/manicminer/hamilton/auth"
 	"github.com/manicminer/hamilton/internal/test"
 	"github.com/manicminer/hamilton/internal/utils"
 	"github.com/manicminer/hamilton/msgraph"
 	"github.com/manicminer/hamilton/odata"
 )
 
-type AccessPackageCatalogTest struct {
-	connection      *test.Connection
-	apCatalogClient *msgraph.AccessPackageCatalogClient
-	randomString    string
-}
-
 func TestAccessPackageCatalogClient(t *testing.T) {
-	c := AccessPackageCatalogTest{
-		connection:   test.NewConnection(auth.MsGraph, auth.TokenVersion2),
-		randomString: test.RandomString(),
-	}
-
-	c.apCatalogClient = msgraph.NewAccessPackageCatalogClient(c.connection.AuthConfig.TenantID)
-	c.apCatalogClient.BaseClient.Authorizer = c.connection.Authorizer
-	c.apCatalogClient.BaseClient.Endpoint = c.connection.AuthConfig.Environment.MsGraph.Endpoint
+	c := test.NewTest()
 
 	accessPackageCatalog := testAccessPackageCatalogClient_Create(t, c, msgraph.AccessPackageCatalog{
-		DisplayName:         utils.StringPtr(fmt.Sprintf("test-catalog-%s", c.randomString)),
+		DisplayName:         utils.StringPtr(fmt.Sprintf("test-catalog-%s", c.RandomString)),
 		CatalogType:         msgraph.AccessPackageCatalogTypeUserManaged,
 		CatalogStatus:       msgraph.AccessPackageCatalogStatusPublished,
 		Description:         utils.StringPtr("Test Access Catalog"),
@@ -37,7 +23,7 @@ func TestAccessPackageCatalogClient(t *testing.T) {
 
 	testAccessPackageCatalogClient_Update(t, c, msgraph.AccessPackageCatalog{
 		ID:          accessPackageCatalog.ID,
-		DisplayName: utils.StringPtr(fmt.Sprintf("test-catalog-updated-%s", c.randomString)),
+		DisplayName: utils.StringPtr(fmt.Sprintf("test-catalog-updated-%s", c.RandomString)),
 		Description: utils.StringPtr("Test Access Catalog"),
 	})
 
@@ -46,8 +32,8 @@ func TestAccessPackageCatalogClient(t *testing.T) {
 	testAccessPackageCatalogClient_Delete(t, c, *accessPackageCatalog.ID)
 }
 
-func testAccessPackageCatalogClient_Create(t *testing.T, c AccessPackageCatalogTest, a msgraph.AccessPackageCatalog) (accessPackageCatalog *msgraph.AccessPackageCatalog) {
-	accessPackageCatalog, status, err := c.apCatalogClient.Create(c.connection.Context, a)
+func testAccessPackageCatalogClient_Create(t *testing.T, c *test.Test, a msgraph.AccessPackageCatalog) (accessPackageCatalog *msgraph.AccessPackageCatalog) {
+	accessPackageCatalog, status, err := c.AccessPackageCatalogClient.Create(c.Connection.Context, a)
 	if err != nil {
 		t.Fatalf("AccessPackageCatalogClient.Create(): %v", err)
 	}
@@ -63,8 +49,8 @@ func testAccessPackageCatalogClient_Create(t *testing.T, c AccessPackageCatalogT
 	return
 }
 
-func testAccessPackageCatalogClient_Get(t *testing.T, c AccessPackageCatalogTest, id string) (accessPackageCatalog *msgraph.AccessPackageCatalog) {
-	accessPackageCatalog, status, err := c.apCatalogClient.Get(c.connection.Context, id, odata.Query{})
+func testAccessPackageCatalogClient_Get(t *testing.T, c *test.Test, id string) (accessPackageCatalog *msgraph.AccessPackageCatalog) {
+	accessPackageCatalog, status, err := c.AccessPackageCatalogClient.Get(c.Connection.Context, id, odata.Query{})
 	if err != nil {
 		t.Fatalf("AccessPackageCatalogClient.Get(): %v", err)
 	}
@@ -77,8 +63,8 @@ func testAccessPackageCatalogClient_Get(t *testing.T, c AccessPackageCatalogTest
 	return
 }
 
-func testAccessPackageCatalogClient_Update(t *testing.T, c AccessPackageCatalogTest, accessPackageCatalog msgraph.AccessPackageCatalog) {
-	status, err := c.apCatalogClient.Update(c.connection.Context, accessPackageCatalog)
+func testAccessPackageCatalogClient_Update(t *testing.T, c *test.Test, accessPackageCatalog msgraph.AccessPackageCatalog) {
+	status, err := c.AccessPackageCatalogClient.Update(c.Connection.Context, accessPackageCatalog)
 	if err != nil {
 		t.Fatalf("AccessPackageCatalogClient.Update(): %v", err)
 	}
@@ -87,8 +73,8 @@ func testAccessPackageCatalogClient_Update(t *testing.T, c AccessPackageCatalogT
 	}
 }
 
-func testAccessPackageCatalogClient_List(t *testing.T, c AccessPackageCatalogTest) (accessPackageCatalogs *[]msgraph.AccessPackageCatalog) {
-	accessPackageCatalogs, _, err := c.apCatalogClient.List(c.connection.Context, odata.Query{Top: 10})
+func testAccessPackageCatalogClient_List(t *testing.T, c *test.Test) (accessPackageCatalogs *[]msgraph.AccessPackageCatalog) {
+	accessPackageCatalogs, _, err := c.AccessPackageCatalogClient.List(c.Connection.Context, odata.Query{Top: 10})
 	if err != nil {
 		t.Fatalf("AccessPackageCatalogClient.List(): %v", err)
 	}
@@ -98,8 +84,8 @@ func testAccessPackageCatalogClient_List(t *testing.T, c AccessPackageCatalogTes
 	return
 }
 
-func testAccessPackageCatalogClient_Delete(t *testing.T, c AccessPackageCatalogTest, id string) {
-	status, err := c.apCatalogClient.Delete(c.connection.Context, id)
+func testAccessPackageCatalogClient_Delete(t *testing.T, c *test.Test, id string) {
+	status, err := c.AccessPackageCatalogClient.Delete(c.Connection.Context, id)
 	if err != nil {
 		t.Fatalf("AccessPackageCatalogClient.Delete(): %v", err)
 	}

--- a/msgraph/accesspackagecatalog_test.go
+++ b/msgraph/accesspackagecatalog_test.go
@@ -11,7 +11,8 @@ import (
 )
 
 func TestAccessPackageCatalogClient(t *testing.T) {
-	c := test.NewTest()
+	c := test.NewTest(t)
+	defer c.CancelFunc()
 
 	accessPackageCatalog := testAccessPackageCatalogClient_Create(t, c, msgraph.AccessPackageCatalog{
 		DisplayName:         utils.StringPtr(fmt.Sprintf("test-catalog-%s", c.RandomString)),
@@ -33,7 +34,7 @@ func TestAccessPackageCatalogClient(t *testing.T) {
 }
 
 func testAccessPackageCatalogClient_Create(t *testing.T, c *test.Test, a msgraph.AccessPackageCatalog) (accessPackageCatalog *msgraph.AccessPackageCatalog) {
-	accessPackageCatalog, status, err := c.AccessPackageCatalogClient.Create(c.Connection.Context, a)
+	accessPackageCatalog, status, err := c.AccessPackageCatalogClient.Create(c.Context, a)
 	if err != nil {
 		t.Fatalf("AccessPackageCatalogClient.Create(): %v", err)
 	}
@@ -50,7 +51,7 @@ func testAccessPackageCatalogClient_Create(t *testing.T, c *test.Test, a msgraph
 }
 
 func testAccessPackageCatalogClient_Get(t *testing.T, c *test.Test, id string) (accessPackageCatalog *msgraph.AccessPackageCatalog) {
-	accessPackageCatalog, status, err := c.AccessPackageCatalogClient.Get(c.Connection.Context, id, odata.Query{})
+	accessPackageCatalog, status, err := c.AccessPackageCatalogClient.Get(c.Context, id, odata.Query{})
 	if err != nil {
 		t.Fatalf("AccessPackageCatalogClient.Get(): %v", err)
 	}
@@ -64,7 +65,7 @@ func testAccessPackageCatalogClient_Get(t *testing.T, c *test.Test, id string) (
 }
 
 func testAccessPackageCatalogClient_Update(t *testing.T, c *test.Test, accessPackageCatalog msgraph.AccessPackageCatalog) {
-	status, err := c.AccessPackageCatalogClient.Update(c.Connection.Context, accessPackageCatalog)
+	status, err := c.AccessPackageCatalogClient.Update(c.Context, accessPackageCatalog)
 	if err != nil {
 		t.Fatalf("AccessPackageCatalogClient.Update(): %v", err)
 	}
@@ -74,7 +75,7 @@ func testAccessPackageCatalogClient_Update(t *testing.T, c *test.Test, accessPac
 }
 
 func testAccessPackageCatalogClient_List(t *testing.T, c *test.Test) (accessPackageCatalogs *[]msgraph.AccessPackageCatalog) {
-	accessPackageCatalogs, _, err := c.AccessPackageCatalogClient.List(c.Connection.Context, odata.Query{Top: 10})
+	accessPackageCatalogs, _, err := c.AccessPackageCatalogClient.List(c.Context, odata.Query{Top: 10})
 	if err != nil {
 		t.Fatalf("AccessPackageCatalogClient.List(): %v", err)
 	}
@@ -85,7 +86,7 @@ func testAccessPackageCatalogClient_List(t *testing.T, c *test.Test) (accessPack
 }
 
 func testAccessPackageCatalogClient_Delete(t *testing.T, c *test.Test, id string) {
-	status, err := c.AccessPackageCatalogClient.Delete(c.Connection.Context, id)
+	status, err := c.AccessPackageCatalogClient.Delete(c.Context, id)
 	if err != nil {
 		t.Fatalf("AccessPackageCatalogClient.Delete(): %v", err)
 	}

--- a/msgraph/accesspackageresourcerequest_test.go
+++ b/msgraph/accesspackageresourcerequest_test.go
@@ -4,66 +4,15 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/manicminer/hamilton/auth"
 	"github.com/manicminer/hamilton/internal/test"
 	"github.com/manicminer/hamilton/internal/utils"
 	"github.com/manicminer/hamilton/msgraph"
 	"github.com/manicminer/hamilton/odata"
 )
 
-type AccessPackageResourceRequestTest struct {
-	connection              *test.Connection
-	apClient                *msgraph.AccessPackageClient        //apClient
-	apCatalogClient         *msgraph.AccessPackageCatalogClient //Client for Catalog Test to associate as required
-	apResourceRequestClient *msgraph.AccessPackageResourceRequestClient
-	apResourceClient        *msgraph.AccessPackageResourceClient
-	groupsClient            *msgraph.GroupsClient
-	randomString            string
-}
-
 func TestAccessPackageResourceRequestClient(t *testing.T) {
-	c := AccessPackageResourceRequestTest{
-		connection:   test.NewConnection(auth.MsGraph, auth.TokenVersion2),
-		randomString: test.RandomString(),
-	}
-
-	// Init clients
-	c.apClient = msgraph.NewAccessPackageClient(c.connection.AuthConfig.TenantID)
-	c.apClient.BaseClient.Authorizer = c.connection.Authorizer
-	c.apClient.BaseClient.Endpoint = c.connection.AuthConfig.Environment.MsGraph.Endpoint
-
-	c.apCatalogClient = msgraph.NewAccessPackageCatalogClient(c.connection.AuthConfig.TenantID)
-	c.apCatalogClient.BaseClient.Authorizer = c.connection.Authorizer
-	c.apCatalogClient.BaseClient.Endpoint = c.connection.AuthConfig.Environment.MsGraph.Endpoint
-
-	c.groupsClient = msgraph.NewGroupsClient(c.connection.AuthConfig.TenantID)
-	c.groupsClient.BaseClient.Authorizer = c.connection.Authorizer
-	c.groupsClient.BaseClient.Endpoint = c.connection.AuthConfig.Environment.MsGraph.Endpoint
-
-	c.apResourceRequestClient = msgraph.NewAccessPackageResourceRequestClient(c.connection.AuthConfig.TenantID)
-	c.apResourceRequestClient.BaseClient.Authorizer = c.connection.Authorizer
-	c.apResourceRequestClient.BaseClient.Endpoint = c.connection.AuthConfig.Environment.MsGraph.Endpoint
-
-	c.apResourceClient = msgraph.NewAccessPackageResourceClient(c.connection.AuthConfig.TenantID)
-	c.apResourceClient.BaseClient.Authorizer = c.connection.Authorizer
-	c.apResourceClient.BaseClient.Endpoint = c.connection.AuthConfig.Environment.MsGraph.Endpoint
-
-	token, err := c.connection.Authorizer.Token()
-	if err != nil {
-		t.Fatalf("could not acquire access token: %v", err)
-	}
-	claims, err := auth.ParseClaims(token)
-	if err != nil {
-		t.Fatalf("could not parse claims: %v", err)
-	}
-
-	o := DirectoryObjectsClientTest{
-		connection:   test.NewConnection(auth.MsGraph, auth.TokenVersion2),
-		randomString: test.RandomString(),
-	}
-	o.client = msgraph.NewDirectoryObjectsClient(c.connection.AuthConfig.TenantID)
-	o.client.BaseClient.Authorizer = o.connection.Authorizer
-	self := testDirectoryObjectsClient_Get(t, o, claims.ObjectId)
+	c := test.NewTest()
+	self := testDirectoryObjectsClient_Get(t, c, c.Claims.ObjectId)
 
 	// Create group
 	aadGroup := testAccessPackageResourceRequestGroup_Create(t, c, msgraph.Owners{*self})
@@ -73,7 +22,7 @@ func TestAccessPackageResourceRequestClient(t *testing.T) {
 
 	// Create access package
 	accessPackage := testAccessPackageResourceRequestAP_Create(t, c, msgraph.AccessPackage{
-		DisplayName:         utils.StringPtr(fmt.Sprintf("test-accesspackage-%s", c.randomString)),
+		DisplayName:         utils.StringPtr(fmt.Sprintf("test-accesspackage-%s", c.RandomString)),
 		CatalogId:           accessPackageCatalog.ID,
 		Description:         utils.StringPtr("Test Access Package"),
 		IsHidden:            utils.BoolPtr(false),
@@ -107,8 +56,8 @@ func TestAccessPackageResourceRequestClient(t *testing.T) {
 
 // AccessPackageResourceRequest
 
-func testAccessPackageResourceRequestClient_Create(t *testing.T, c AccessPackageResourceRequestTest, a msgraph.AccessPackageResourceRequest, pollForId bool) (accessPackageResourceRequest *msgraph.AccessPackageResourceRequest) {
-	accessPackageResourceRequest, status, err := c.apResourceRequestClient.Create(c.connection.Context, a, pollForId)
+func testAccessPackageResourceRequestClient_Create(t *testing.T, c *test.Test, a msgraph.AccessPackageResourceRequest, pollForId bool) (accessPackageResourceRequest *msgraph.AccessPackageResourceRequest) {
+	accessPackageResourceRequest, status, err := c.AccessPackageResourceRequestClient.Create(c.Connection.Context, a, pollForId)
 	if err != nil {
 		t.Fatalf("AccessPackageResourceRequestClient.Create(): %v", err)
 	}
@@ -124,8 +73,8 @@ func testAccessPackageResourceRequestClient_Create(t *testing.T, c AccessPackage
 	return
 }
 
-func testAccessPackageResourceRequestClient_Get(t *testing.T, c AccessPackageResourceRequestTest, id string) (accessPackageResourceRequest *msgraph.AccessPackageResourceRequest) {
-	accessPackageResourceRequest, status, err := c.apResourceRequestClient.Get(c.connection.Context, id)
+func testAccessPackageResourceRequestClient_Get(t *testing.T, c *test.Test, id string) (accessPackageResourceRequest *msgraph.AccessPackageResourceRequest) {
+	accessPackageResourceRequest, status, err := c.AccessPackageResourceRequestClient.Get(c.Connection.Context, id)
 	if err != nil {
 		t.Fatalf("AccessPackageResourceRequestClient.Get(): %v", err)
 	}
@@ -138,8 +87,8 @@ func testAccessPackageResourceRequestClient_Get(t *testing.T, c AccessPackageRes
 	return
 }
 
-func testAccessPackageResourceRequestClient_List(t *testing.T, c AccessPackageResourceRequestTest) (accessPackageResourceRequests *[]msgraph.AccessPackageResourceRequest) {
-	accessPackageResourceRequests, _, err := c.apResourceRequestClient.List(c.connection.Context, odata.Query{Top: 10})
+func testAccessPackageResourceRequestClient_List(t *testing.T, c *test.Test) (accessPackageResourceRequests *[]msgraph.AccessPackageResourceRequest) {
+	accessPackageResourceRequests, _, err := c.AccessPackageResourceRequestClient.List(c.Connection.Context, odata.Query{Top: 10})
 	if err != nil {
 		t.Fatalf("AccessPackageResourceRequestClient.List(): %v", err)
 	}
@@ -149,8 +98,8 @@ func testAccessPackageResourceRequestClient_List(t *testing.T, c AccessPackageRe
 	return
 }
 
-func testAccessPackageResourceRequestClient_Delete(t *testing.T, c AccessPackageResourceRequestTest, accessPackageResourceRequest *msgraph.AccessPackageResourceRequest) {
-	status, err := c.apResourceRequestClient.Delete(c.connection.Context, *accessPackageResourceRequest)
+func testAccessPackageResourceRequestClient_Delete(t *testing.T, c *test.Test, accessPackageResourceRequest *msgraph.AccessPackageResourceRequest) {
+	status, err := c.AccessPackageResourceRequestClient.Delete(c.Connection.Context, *accessPackageResourceRequest)
 	if err != nil {
 		t.Fatalf("AccessPackageResourceRequestClient.Delete(): %v", err)
 	}
@@ -161,8 +110,8 @@ func testAccessPackageResourceRequestClient_Delete(t *testing.T, c AccessPackage
 
 // AccessPackage
 
-func testAccessPackageResourceRequestAP_Create(t *testing.T, c AccessPackageResourceRequestTest, a msgraph.AccessPackage) (accessPackage *msgraph.AccessPackage) {
-	accessPackage, status, err := c.apClient.Create(c.connection.Context, a)
+func testAccessPackageResourceRequestAP_Create(t *testing.T, c *test.Test, a msgraph.AccessPackage) (accessPackage *msgraph.AccessPackage) {
+	accessPackage, status, err := c.AccessPackageClient.Create(c.Connection.Context, a)
 	if err != nil {
 		t.Fatalf("AccessPackageClient.Create(): %v", err)
 	}
@@ -178,8 +127,8 @@ func testAccessPackageResourceRequestAP_Create(t *testing.T, c AccessPackageReso
 	return
 }
 
-func testAccessPackageResourceRequestAP_Delete(t *testing.T, c AccessPackageResourceRequestTest, id string) {
-	status, err := c.apClient.Delete(c.connection.Context, id)
+func testAccessPackageResourceRequestAP_Delete(t *testing.T, c *test.Test, id string) {
+	status, err := c.AccessPackageClient.Delete(c.Connection.Context, id)
 	if err != nil {
 		t.Fatalf("AccessPackageClient.Delete(): %v", err)
 	}
@@ -190,9 +139,9 @@ func testAccessPackageResourceRequestAP_Delete(t *testing.T, c AccessPackageReso
 
 // AccessPackageCatalog
 
-func testAccessPackageResourceRequestCatalog_Create(t *testing.T, c AccessPackageResourceRequestTest) (accessPackageCatalog *msgraph.AccessPackageCatalog) {
-	accessPackageCatalog, _, err := c.apCatalogClient.Create(c.connection.Context, msgraph.AccessPackageCatalog{
-		DisplayName:         utils.StringPtr(fmt.Sprintf("test-catalog-%s", c.randomString)),
+func testAccessPackageResourceRequestCatalog_Create(t *testing.T, c *test.Test) (accessPackageCatalog *msgraph.AccessPackageCatalog) {
+	accessPackageCatalog, _, err := c.AccessPackageCatalogClient.Create(c.Connection.Context, msgraph.AccessPackageCatalog{
+		DisplayName:         utils.StringPtr(fmt.Sprintf("test-catalog-%s", c.RandomString)),
 		CatalogType:         msgraph.AccessPackageCatalogTypeUserManaged,
 		CatalogStatus:       msgraph.AccessPackageCatalogStatusPublished,
 		Description:         utils.StringPtr("Test Access Catalog"),
@@ -205,18 +154,18 @@ func testAccessPackageResourceRequestCatalog_Create(t *testing.T, c AccessPackag
 	return
 }
 
-func testAccessPackageResourceRequestCatalog_Delete(t *testing.T, c AccessPackageResourceRequestTest, id string) {
-	_, err := c.apCatalogClient.Delete(c.connection.Context, id)
+func testAccessPackageResourceRequestCatalog_Delete(t *testing.T, c *test.Test, id string) {
+	_, err := c.AccessPackageCatalogClient.Delete(c.Connection.Context, id)
 	if err != nil {
 		t.Fatalf("AccessPackageCatalogClient.Delete() - Could not delete test AccessPackage catalog")
 	}
 }
 
-func testAccessPackageResourceRequestGroup_Create(t *testing.T, c AccessPackageResourceRequestTest, owners msgraph.Owners) (group *msgraph.Group) {
-	group, _, err := c.groupsClient.Create(c.connection.Context, msgraph.Group{
-		DisplayName:     utils.StringPtr(fmt.Sprintf("%s-%s", "testapresourcerequest", c.randomString)),
+func testAccessPackageResourceRequestGroup_Create(t *testing.T, c *test.Test, owners msgraph.Owners) (group *msgraph.Group) {
+	group, _, err := c.GroupsClient.Create(c.Connection.Context, msgraph.Group{
+		DisplayName:     utils.StringPtr(fmt.Sprintf("%s-%s", "testapresourcerequest", c.RandomString)),
 		MailEnabled:     utils.BoolPtr(false),
-		MailNickname:    utils.StringPtr(fmt.Sprintf("%s-%s", "testapresourcerequest", c.randomString)),
+		MailNickname:    utils.StringPtr(fmt.Sprintf("%s-%s", "testapresourcerequest", c.RandomString)),
 		SecurityEnabled: utils.BoolPtr(true),
 		Owners:          &owners,
 	})
@@ -227,8 +176,8 @@ func testAccessPackageResourceRequestGroup_Create(t *testing.T, c AccessPackageR
 	return
 }
 
-func testAccessPackageResourceRequestGroup_Delete(t *testing.T, c AccessPackageResourceRequestTest, group *msgraph.Group) {
-	_, err := c.groupsClient.Delete(c.connection.Context, *group.ID)
+func testAccessPackageResourceRequestGroup_Delete(t *testing.T, c *test.Test, group *msgraph.Group) {
+	_, err := c.GroupsClient.Delete(c.Connection.Context, *group.ID)
 	if err != nil {
 		t.Fatalf("GroupsClient.Delete() - Could not delete test group: %v", err)
 	}
@@ -236,8 +185,8 @@ func testAccessPackageResourceRequestGroup_Delete(t *testing.T, c AccessPackageR
 
 // AccessPackageResource
 
-func testAccessPackageResourceRequestResource_Get(t *testing.T, c AccessPackageResourceRequestTest, catalogId string, originId string) (accessPackageResource *msgraph.AccessPackageResource) {
-	accessPackageResource, status, err := c.apResourceClient.Get(c.connection.Context, catalogId, originId)
+func testAccessPackageResourceRequestResource_Get(t *testing.T, c *test.Test, catalogId string, originId string) (accessPackageResource *msgraph.AccessPackageResource) {
+	accessPackageResource, status, err := c.AccessPackageResourceClient.Get(c.Connection.Context, catalogId, originId)
 
 	if err != nil {
 		t.Fatalf("AccessPackageCatalogClient.Get(): %v", err)
@@ -252,8 +201,8 @@ func testAccessPackageResourceRequestResource_Get(t *testing.T, c AccessPackageR
 	return
 }
 
-func testAccessPackageResourceRequestResource_List(t *testing.T, c AccessPackageResourceRequestTest, catalogId string) (accessPackageResources *[]msgraph.AccessPackageResource) {
-	accessPackageResources, status, err := c.apResourceClient.List(c.connection.Context, catalogId, odata.Query{Top: 10})
+func testAccessPackageResourceRequestResource_List(t *testing.T, c *test.Test, catalogId string) (accessPackageResources *[]msgraph.AccessPackageResource) {
+	accessPackageResources, status, err := c.AccessPackageResourceClient.List(c.Connection.Context, catalogId, odata.Query{Top: 10})
 
 	if err != nil {
 		t.Fatalf("AccessPackageCatalogClient.Get(): %v", err)

--- a/msgraph/accesspackageresourcerequest_test.go
+++ b/msgraph/accesspackageresourcerequest_test.go
@@ -11,7 +11,9 @@ import (
 )
 
 func TestAccessPackageResourceRequestClient(t *testing.T) {
-	c := test.NewTest()
+	c := test.NewTest(t)
+	defer c.CancelFunc()
+
 	self := testDirectoryObjectsClient_Get(t, c, c.Claims.ObjectId)
 
 	// Create group
@@ -57,7 +59,7 @@ func TestAccessPackageResourceRequestClient(t *testing.T) {
 // AccessPackageResourceRequest
 
 func testAccessPackageResourceRequestClient_Create(t *testing.T, c *test.Test, a msgraph.AccessPackageResourceRequest, pollForId bool) (accessPackageResourceRequest *msgraph.AccessPackageResourceRequest) {
-	accessPackageResourceRequest, status, err := c.AccessPackageResourceRequestClient.Create(c.Connection.Context, a, pollForId)
+	accessPackageResourceRequest, status, err := c.AccessPackageResourceRequestClient.Create(c.Context, a, pollForId)
 	if err != nil {
 		t.Fatalf("AccessPackageResourceRequestClient.Create(): %v", err)
 	}
@@ -74,7 +76,7 @@ func testAccessPackageResourceRequestClient_Create(t *testing.T, c *test.Test, a
 }
 
 func testAccessPackageResourceRequestClient_Get(t *testing.T, c *test.Test, id string) (accessPackageResourceRequest *msgraph.AccessPackageResourceRequest) {
-	accessPackageResourceRequest, status, err := c.AccessPackageResourceRequestClient.Get(c.Connection.Context, id)
+	accessPackageResourceRequest, status, err := c.AccessPackageResourceRequestClient.Get(c.Context, id)
 	if err != nil {
 		t.Fatalf("AccessPackageResourceRequestClient.Get(): %v", err)
 	}
@@ -88,7 +90,7 @@ func testAccessPackageResourceRequestClient_Get(t *testing.T, c *test.Test, id s
 }
 
 func testAccessPackageResourceRequestClient_List(t *testing.T, c *test.Test) (accessPackageResourceRequests *[]msgraph.AccessPackageResourceRequest) {
-	accessPackageResourceRequests, _, err := c.AccessPackageResourceRequestClient.List(c.Connection.Context, odata.Query{Top: 10})
+	accessPackageResourceRequests, _, err := c.AccessPackageResourceRequestClient.List(c.Context, odata.Query{Top: 10})
 	if err != nil {
 		t.Fatalf("AccessPackageResourceRequestClient.List(): %v", err)
 	}
@@ -99,7 +101,7 @@ func testAccessPackageResourceRequestClient_List(t *testing.T, c *test.Test) (ac
 }
 
 func testAccessPackageResourceRequestClient_Delete(t *testing.T, c *test.Test, accessPackageResourceRequest *msgraph.AccessPackageResourceRequest) {
-	status, err := c.AccessPackageResourceRequestClient.Delete(c.Connection.Context, *accessPackageResourceRequest)
+	status, err := c.AccessPackageResourceRequestClient.Delete(c.Context, *accessPackageResourceRequest)
 	if err != nil {
 		t.Fatalf("AccessPackageResourceRequestClient.Delete(): %v", err)
 	}
@@ -111,7 +113,7 @@ func testAccessPackageResourceRequestClient_Delete(t *testing.T, c *test.Test, a
 // AccessPackage
 
 func testAccessPackageResourceRequestAP_Create(t *testing.T, c *test.Test, a msgraph.AccessPackage) (accessPackage *msgraph.AccessPackage) {
-	accessPackage, status, err := c.AccessPackageClient.Create(c.Connection.Context, a)
+	accessPackage, status, err := c.AccessPackageClient.Create(c.Context, a)
 	if err != nil {
 		t.Fatalf("AccessPackageClient.Create(): %v", err)
 	}
@@ -128,7 +130,7 @@ func testAccessPackageResourceRequestAP_Create(t *testing.T, c *test.Test, a msg
 }
 
 func testAccessPackageResourceRequestAP_Delete(t *testing.T, c *test.Test, id string) {
-	status, err := c.AccessPackageClient.Delete(c.Connection.Context, id)
+	status, err := c.AccessPackageClient.Delete(c.Context, id)
 	if err != nil {
 		t.Fatalf("AccessPackageClient.Delete(): %v", err)
 	}
@@ -140,7 +142,7 @@ func testAccessPackageResourceRequestAP_Delete(t *testing.T, c *test.Test, id st
 // AccessPackageCatalog
 
 func testAccessPackageResourceRequestCatalog_Create(t *testing.T, c *test.Test) (accessPackageCatalog *msgraph.AccessPackageCatalog) {
-	accessPackageCatalog, _, err := c.AccessPackageCatalogClient.Create(c.Connection.Context, msgraph.AccessPackageCatalog{
+	accessPackageCatalog, _, err := c.AccessPackageCatalogClient.Create(c.Context, msgraph.AccessPackageCatalog{
 		DisplayName:         utils.StringPtr(fmt.Sprintf("test-catalog-%s", c.RandomString)),
 		CatalogType:         msgraph.AccessPackageCatalogTypeUserManaged,
 		CatalogStatus:       msgraph.AccessPackageCatalogStatusPublished,
@@ -155,14 +157,14 @@ func testAccessPackageResourceRequestCatalog_Create(t *testing.T, c *test.Test) 
 }
 
 func testAccessPackageResourceRequestCatalog_Delete(t *testing.T, c *test.Test, id string) {
-	_, err := c.AccessPackageCatalogClient.Delete(c.Connection.Context, id)
+	_, err := c.AccessPackageCatalogClient.Delete(c.Context, id)
 	if err != nil {
 		t.Fatalf("AccessPackageCatalogClient.Delete() - Could not delete test AccessPackage catalog")
 	}
 }
 
 func testAccessPackageResourceRequestGroup_Create(t *testing.T, c *test.Test, owners msgraph.Owners) (group *msgraph.Group) {
-	group, _, err := c.GroupsClient.Create(c.Connection.Context, msgraph.Group{
+	group, _, err := c.GroupsClient.Create(c.Context, msgraph.Group{
 		DisplayName:     utils.StringPtr(fmt.Sprintf("%s-%s", "testapresourcerequest", c.RandomString)),
 		MailEnabled:     utils.BoolPtr(false),
 		MailNickname:    utils.StringPtr(fmt.Sprintf("%s-%s", "testapresourcerequest", c.RandomString)),
@@ -177,7 +179,7 @@ func testAccessPackageResourceRequestGroup_Create(t *testing.T, c *test.Test, ow
 }
 
 func testAccessPackageResourceRequestGroup_Delete(t *testing.T, c *test.Test, group *msgraph.Group) {
-	_, err := c.GroupsClient.Delete(c.Connection.Context, *group.ID)
+	_, err := c.GroupsClient.Delete(c.Context, *group.ID)
 	if err != nil {
 		t.Fatalf("GroupsClient.Delete() - Could not delete test group: %v", err)
 	}
@@ -186,7 +188,7 @@ func testAccessPackageResourceRequestGroup_Delete(t *testing.T, c *test.Test, gr
 // AccessPackageResource
 
 func testAccessPackageResourceRequestResource_Get(t *testing.T, c *test.Test, catalogId string, originId string) (accessPackageResource *msgraph.AccessPackageResource) {
-	accessPackageResource, status, err := c.AccessPackageResourceClient.Get(c.Connection.Context, catalogId, originId)
+	accessPackageResource, status, err := c.AccessPackageResourceClient.Get(c.Context, catalogId, originId)
 
 	if err != nil {
 		t.Fatalf("AccessPackageCatalogClient.Get(): %v", err)
@@ -202,7 +204,7 @@ func testAccessPackageResourceRequestResource_Get(t *testing.T, c *test.Test, ca
 }
 
 func testAccessPackageResourceRequestResource_List(t *testing.T, c *test.Test, catalogId string) (accessPackageResources *[]msgraph.AccessPackageResource) {
-	accessPackageResources, status, err := c.AccessPackageResourceClient.List(c.Connection.Context, catalogId, odata.Query{Top: 10})
+	accessPackageResources, status, err := c.AccessPackageResourceClient.List(c.Context, catalogId, odata.Query{Top: 10})
 
 	if err != nil {
 		t.Fatalf("AccessPackageCatalogClient.Get(): %v", err)

--- a/msgraph/accesspackageresourcerolescope_test.go
+++ b/msgraph/accesspackageresourcerolescope_test.go
@@ -11,7 +11,9 @@ import (
 )
 
 func TestAccessPackageResourceRoleScopeClient(t *testing.T) {
-	c := test.NewTest()
+	c := test.NewTest(t)
+	defer c.CancelFunc()
+
 	self := testDirectoryObjectsClient_Get(t, c, c.Claims.ObjectId)
 
 	// Create group
@@ -103,7 +105,7 @@ func TestAccessPackageResourceRoleScopeClient(t *testing.T) {
 // AccessPackageResourceScope
 
 func testAccessPackageResourceRoleScopeClient_Create(t *testing.T, c *test.Test, a msgraph.AccessPackageResourceRoleScope) (accessPackageResourceRoleScope *msgraph.AccessPackageResourceRoleScope) {
-	accessPackageResourceRoleScope, status, err := c.AccessPackageResourceRoleScopeClient.Create(c.Connection.Context, a)
+	accessPackageResourceRoleScope, status, err := c.AccessPackageResourceRoleScopeClient.Create(c.Context, a)
 	if err != nil {
 		t.Fatalf("AccessPackageResourceRequestClient.Create(): %v", err)
 	}
@@ -120,7 +122,7 @@ func testAccessPackageResourceRoleScopeClient_Create(t *testing.T, c *test.Test,
 }
 
 func testAccessPackageResourceRoleScopeClient_Get(t *testing.T, c *test.Test, accessPackageId string, id string) (accessPackageResourceRoleScope *msgraph.AccessPackageResourceRoleScope) {
-	accessPackageResourceRoleScope, status, err := c.AccessPackageResourceRoleScopeClient.Get(c.Connection.Context, accessPackageId, id)
+	accessPackageResourceRoleScope, status, err := c.AccessPackageResourceRoleScopeClient.Get(c.Context, accessPackageId, id)
 	if err != nil {
 		t.Fatalf("AccessPackageResourceRequestClient.Get(): %v", err)
 	}
@@ -134,7 +136,7 @@ func testAccessPackageResourceRoleScopeClient_Get(t *testing.T, c *test.Test, ac
 }
 
 func testAccessPackageResourceRoleScopeClient_List(t *testing.T, c *test.Test, accessPackageId string) (accessPackageResourceRoleScope *[]msgraph.AccessPackageResourceRoleScope) {
-	accessPackageResourceRoleScopes, _, err := c.AccessPackageResourceRoleScopeClient.List(c.Connection.Context, odata.Query{}, accessPackageId)
+	accessPackageResourceRoleScopes, _, err := c.AccessPackageResourceRoleScopeClient.List(c.Context, odata.Query{}, accessPackageId)
 	if err != nil {
 		t.Fatalf("AccessPackageResourceRequestClient.List(): %v", err)
 	}
@@ -147,7 +149,7 @@ func testAccessPackageResourceRoleScopeClient_List(t *testing.T, c *test.Test, a
 // AccessPackageResourceRequest
 
 func testAccessPackageResourceRoleScopeResourceRequest_Create(t *testing.T, c *test.Test, a msgraph.AccessPackageResourceRequest, pollForId bool) (accessPackageResourceRequest *msgraph.AccessPackageResourceRequest) {
-	accessPackageResourceRequest, status, err := c.AccessPackageResourceRequestClient.Create(c.Connection.Context, a, pollForId)
+	accessPackageResourceRequest, status, err := c.AccessPackageResourceRequestClient.Create(c.Context, a, pollForId)
 	if err != nil {
 		t.Fatalf("AccessPackageResourceRequestClient.Create(): %v", err)
 	}
@@ -164,7 +166,7 @@ func testAccessPackageResourceRoleScopeResourceRequest_Create(t *testing.T, c *t
 }
 
 func testAccessPackageResourceRoleScopeResourceRequest_Delete(t *testing.T, c *test.Test, accessPackageResourceRequest *msgraph.AccessPackageResourceRequest) {
-	status, err := c.AccessPackageResourceRequestClient.Delete(c.Connection.Context, *accessPackageResourceRequest)
+	status, err := c.AccessPackageResourceRequestClient.Delete(c.Context, *accessPackageResourceRequest)
 	if err != nil {
 		t.Fatalf("AccessPackageResourceRequestClient.Delete(): %v", err)
 	}
@@ -176,7 +178,7 @@ func testAccessPackageResourceRoleScopeResourceRequest_Delete(t *testing.T, c *t
 // AccessPackage
 
 func testAccessPackageResourceRoleScopeAP_Create(t *testing.T, c *test.Test, a msgraph.AccessPackage) (accessPackage *msgraph.AccessPackage) {
-	accessPackage, status, err := c.AccessPackageClient.Create(c.Connection.Context, a)
+	accessPackage, status, err := c.AccessPackageClient.Create(c.Context, a)
 	if err != nil {
 		t.Fatalf("AccessPackageClient.Create(): %v", err)
 	}
@@ -193,7 +195,7 @@ func testAccessPackageResourceRoleScopeAP_Create(t *testing.T, c *test.Test, a m
 }
 
 func testAccessPackageResourceRoleScopeAP_Delete(t *testing.T, c *test.Test, id string) {
-	status, err := c.AccessPackageClient.Delete(c.Connection.Context, id)
+	status, err := c.AccessPackageClient.Delete(c.Context, id)
 	if err != nil {
 		t.Fatalf("AccessPackageClient.Delete(): %v", err)
 	}
@@ -205,7 +207,7 @@ func testAccessPackageResourceRoleScopeAP_Delete(t *testing.T, c *test.Test, id 
 // AccessPackageCatalog
 
 func testAccessPackageResourceRoleScopeCatalog_Create(t *testing.T, c *test.Test) (accessPackageCatalog *msgraph.AccessPackageCatalog) {
-	accessPackageCatalog, _, err := c.AccessPackageCatalogClient.Create(c.Connection.Context, msgraph.AccessPackageCatalog{
+	accessPackageCatalog, _, err := c.AccessPackageCatalogClient.Create(c.Context, msgraph.AccessPackageCatalog{
 		DisplayName:         utils.StringPtr(fmt.Sprintf("test-catalog-%s", c.RandomString)),
 		CatalogType:         msgraph.AccessPackageCatalogTypeUserManaged,
 		CatalogStatus:       msgraph.AccessPackageCatalogStatusPublished,
@@ -220,14 +222,14 @@ func testAccessPackageResourceRoleScopeCatalog_Create(t *testing.T, c *test.Test
 }
 
 func testAccessPackageResourceRoleScopeCatalog_Delete(t *testing.T, c *test.Test, id string) {
-	_, err := c.AccessPackageCatalogClient.Delete(c.Connection.Context, id)
+	_, err := c.AccessPackageCatalogClient.Delete(c.Context, id)
 	if err != nil {
 		t.Fatalf("AccessPackageCatalogClient.Delete() - Could not delete test AccessPackage catalog")
 	}
 }
 
 func testAccessPackageResourceRoleScopeGroup_Create(t *testing.T, c *test.Test, self msgraph.Owners) (group *msgraph.Group) {
-	group, _, err := c.GroupsClient.Create(c.Connection.Context, msgraph.Group{
+	group, _, err := c.GroupsClient.Create(c.Context, msgraph.Group{
 		DisplayName:     utils.StringPtr(fmt.Sprintf("%s-%s", "testapresourcerequest", c.RandomString)),
 		MailEnabled:     utils.BoolPtr(false),
 		MailNickname:    utils.StringPtr(fmt.Sprintf("%s-%s", "testapresourcerequest", c.RandomString)),
@@ -242,7 +244,7 @@ func testAccessPackageResourceRoleScopeGroup_Create(t *testing.T, c *test.Test, 
 }
 
 func testAccessPackageResourceRoleScopeGroup_Delete(t *testing.T, c *test.Test, group *msgraph.Group) {
-	_, err := c.GroupsClient.Delete(c.Connection.Context, *group.ID)
+	_, err := c.GroupsClient.Delete(c.Context, *group.ID)
 	if err != nil {
 		t.Fatalf("GroupsClient.Delete() - Could not delete test group: %v", err)
 	}
@@ -251,7 +253,7 @@ func testAccessPackageResourceRoleScopeGroup_Delete(t *testing.T, c *test.Test, 
 // AccessPackageResource
 
 func testAccessPackageResourceRoleScopeResource_Get(t *testing.T, c *test.Test, catalogId string, originId string) (accessPackageResource *msgraph.AccessPackageResource) {
-	accessPackageResource, status, err := c.AccessPackageResourceClient.Get(c.Connection.Context, catalogId, originId)
+	accessPackageResource, status, err := c.AccessPackageResourceClient.Get(c.Context, catalogId, originId)
 
 	if err != nil {
 		t.Fatalf("AccessPackageCatalogClient.Get(): %v", err)

--- a/msgraph/accesspackageresourcerolescope_test.go
+++ b/msgraph/accesspackageresourcerolescope_test.go
@@ -4,71 +4,15 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/manicminer/hamilton/auth"
 	"github.com/manicminer/hamilton/internal/test"
 	"github.com/manicminer/hamilton/internal/utils"
 	"github.com/manicminer/hamilton/msgraph"
 	"github.com/manicminer/hamilton/odata"
 )
 
-type AccessPackageResourceRoleScopeTest struct {
-	connection                *test.Connection
-	apClient                  *msgraph.AccessPackageClient        //apClient
-	apCatalogClient           *msgraph.AccessPackageCatalogClient //Client for Catalog Test to associate as required
-	apResourceRequestClient   *msgraph.AccessPackageResourceRequestClient
-	apResourceClient          *msgraph.AccessPackageResourceClient
-	groupsClient              *msgraph.GroupsClient
-	apResourceRoleScopeClient *msgraph.AccessPackageResourceRoleScopeClient
-	randomString              string
-}
-
 func TestAccessPackageResourceRoleScopeClient(t *testing.T) {
-	c := AccessPackageResourceRoleScopeTest{
-		connection:   test.NewConnection(auth.MsGraph, auth.TokenVersion2),
-		randomString: test.RandomString(),
-	}
-
-	// Init clients
-	c.apClient = msgraph.NewAccessPackageClient(c.connection.AuthConfig.TenantID)
-	c.apClient.BaseClient.Authorizer = c.connection.Authorizer
-	c.apClient.BaseClient.Endpoint = c.connection.AuthConfig.Environment.MsGraph.Endpoint
-
-	c.apCatalogClient = msgraph.NewAccessPackageCatalogClient(c.connection.AuthConfig.TenantID)
-	c.apCatalogClient.BaseClient.Authorizer = c.connection.Authorizer
-	c.apCatalogClient.BaseClient.Endpoint = c.connection.AuthConfig.Environment.MsGraph.Endpoint
-
-	c.groupsClient = msgraph.NewGroupsClient(c.connection.AuthConfig.TenantID)
-	c.groupsClient.BaseClient.Authorizer = c.connection.Authorizer
-	c.groupsClient.BaseClient.Endpoint = c.connection.AuthConfig.Environment.MsGraph.Endpoint
-
-	c.apResourceRequestClient = msgraph.NewAccessPackageResourceRequestClient(c.connection.AuthConfig.TenantID)
-	c.apResourceRequestClient.BaseClient.Authorizer = c.connection.Authorizer
-	c.apResourceRequestClient.BaseClient.Endpoint = c.connection.AuthConfig.Environment.MsGraph.Endpoint
-
-	c.apResourceClient = msgraph.NewAccessPackageResourceClient(c.connection.AuthConfig.TenantID)
-	c.apResourceClient.BaseClient.Authorizer = c.connection.Authorizer
-	c.apResourceClient.BaseClient.Endpoint = c.connection.AuthConfig.Environment.MsGraph.Endpoint
-
-	c.apResourceRoleScopeClient = msgraph.NewAccessPackageResourceRoleScopeClient(c.connection.AuthConfig.TenantID)
-	c.apResourceRoleScopeClient.BaseClient.Authorizer = c.connection.Authorizer
-	c.apResourceRoleScopeClient.BaseClient.Endpoint = c.connection.AuthConfig.Environment.MsGraph.Endpoint
-
-	token, err := c.connection.Authorizer.Token()
-	if err != nil {
-		t.Fatalf("could not acquire access token: %v", err)
-	}
-	claims, err := auth.ParseClaims(token)
-	if err != nil {
-		t.Fatalf("could not parse claims: %v", err)
-	}
-
-	o := DirectoryObjectsClientTest{
-		connection:   test.NewConnection(auth.MsGraph, auth.TokenVersion2),
-		randomString: test.RandomString(),
-	}
-	o.client = msgraph.NewDirectoryObjectsClient(c.connection.AuthConfig.TenantID)
-	o.client.BaseClient.Authorizer = o.connection.Authorizer
-	self := testDirectoryObjectsClient_Get(t, o, claims.ObjectId)
+	c := test.NewTest()
+	self := testDirectoryObjectsClient_Get(t, c, c.Claims.ObjectId)
 
 	// Create group
 	aadGroup := testAccessPackageResourceRoleScopeGroup_Create(t, c, msgraph.Owners{*self})
@@ -78,7 +22,7 @@ func TestAccessPackageResourceRoleScopeClient(t *testing.T) {
 
 	// Create access package
 	accessPackage := testAccessPackageResourceRoleScopeAP_Create(t, c, msgraph.AccessPackage{
-		DisplayName:         utils.StringPtr(fmt.Sprintf("test-accesspackage-%s", c.randomString)),
+		DisplayName:         utils.StringPtr(fmt.Sprintf("test-accesspackage-%s", c.RandomString)),
 		CatalogId:           accessPackageCatalog.ID,
 		Description:         utils.StringPtr("Test Access Package"),
 		IsHidden:            utils.BoolPtr(false),
@@ -158,8 +102,8 @@ func TestAccessPackageResourceRoleScopeClient(t *testing.T) {
 
 // AccessPackageResourceScope
 
-func testAccessPackageResourceRoleScopeClient_Create(t *testing.T, c AccessPackageResourceRoleScopeTest, a msgraph.AccessPackageResourceRoleScope) (accessPackageResourceRoleScope *msgraph.AccessPackageResourceRoleScope) {
-	accessPackageResourceRoleScope, status, err := c.apResourceRoleScopeClient.Create(c.connection.Context, a)
+func testAccessPackageResourceRoleScopeClient_Create(t *testing.T, c *test.Test, a msgraph.AccessPackageResourceRoleScope) (accessPackageResourceRoleScope *msgraph.AccessPackageResourceRoleScope) {
+	accessPackageResourceRoleScope, status, err := c.AccessPackageResourceRoleScopeClient.Create(c.Connection.Context, a)
 	if err != nil {
 		t.Fatalf("AccessPackageResourceRequestClient.Create(): %v", err)
 	}
@@ -175,8 +119,8 @@ func testAccessPackageResourceRoleScopeClient_Create(t *testing.T, c AccessPacka
 	return
 }
 
-func testAccessPackageResourceRoleScopeClient_Get(t *testing.T, c AccessPackageResourceRoleScopeTest, accessPackageId string, id string) (accessPackageResourceRoleScope *msgraph.AccessPackageResourceRoleScope) {
-	accessPackageResourceRoleScope, status, err := c.apResourceRoleScopeClient.Get(c.connection.Context, accessPackageId, id)
+func testAccessPackageResourceRoleScopeClient_Get(t *testing.T, c *test.Test, accessPackageId string, id string) (accessPackageResourceRoleScope *msgraph.AccessPackageResourceRoleScope) {
+	accessPackageResourceRoleScope, status, err := c.AccessPackageResourceRoleScopeClient.Get(c.Connection.Context, accessPackageId, id)
 	if err != nil {
 		t.Fatalf("AccessPackageResourceRequestClient.Get(): %v", err)
 	}
@@ -189,8 +133,8 @@ func testAccessPackageResourceRoleScopeClient_Get(t *testing.T, c AccessPackageR
 	return
 }
 
-func testAccessPackageResourceRoleScopeClient_List(t *testing.T, c AccessPackageResourceRoleScopeTest, accessPackageId string) (accessPackageResourceRoleScope *[]msgraph.AccessPackageResourceRoleScope) {
-	accessPackageResourceRoleScopes, _, err := c.apResourceRoleScopeClient.List(c.connection.Context, odata.Query{}, accessPackageId)
+func testAccessPackageResourceRoleScopeClient_List(t *testing.T, c *test.Test, accessPackageId string) (accessPackageResourceRoleScope *[]msgraph.AccessPackageResourceRoleScope) {
+	accessPackageResourceRoleScopes, _, err := c.AccessPackageResourceRoleScopeClient.List(c.Connection.Context, odata.Query{}, accessPackageId)
 	if err != nil {
 		t.Fatalf("AccessPackageResourceRequestClient.List(): %v", err)
 	}
@@ -202,8 +146,8 @@ func testAccessPackageResourceRoleScopeClient_List(t *testing.T, c AccessPackage
 
 // AccessPackageResourceRequest
 
-func testAccessPackageResourceRoleScopeResourceRequest_Create(t *testing.T, c AccessPackageResourceRoleScopeTest, a msgraph.AccessPackageResourceRequest, pollForId bool) (accessPackageResourceRequest *msgraph.AccessPackageResourceRequest) {
-	accessPackageResourceRequest, status, err := c.apResourceRequestClient.Create(c.connection.Context, a, pollForId)
+func testAccessPackageResourceRoleScopeResourceRequest_Create(t *testing.T, c *test.Test, a msgraph.AccessPackageResourceRequest, pollForId bool) (accessPackageResourceRequest *msgraph.AccessPackageResourceRequest) {
+	accessPackageResourceRequest, status, err := c.AccessPackageResourceRequestClient.Create(c.Connection.Context, a, pollForId)
 	if err != nil {
 		t.Fatalf("AccessPackageResourceRequestClient.Create(): %v", err)
 	}
@@ -219,8 +163,8 @@ func testAccessPackageResourceRoleScopeResourceRequest_Create(t *testing.T, c Ac
 	return
 }
 
-func testAccessPackageResourceRoleScopeResourceRequest_Delete(t *testing.T, c AccessPackageResourceRoleScopeTest, accessPackageResourceRequest *msgraph.AccessPackageResourceRequest) {
-	status, err := c.apResourceRequestClient.Delete(c.connection.Context, *accessPackageResourceRequest)
+func testAccessPackageResourceRoleScopeResourceRequest_Delete(t *testing.T, c *test.Test, accessPackageResourceRequest *msgraph.AccessPackageResourceRequest) {
+	status, err := c.AccessPackageResourceRequestClient.Delete(c.Connection.Context, *accessPackageResourceRequest)
 	if err != nil {
 		t.Fatalf("AccessPackageResourceRequestClient.Delete(): %v", err)
 	}
@@ -231,8 +175,8 @@ func testAccessPackageResourceRoleScopeResourceRequest_Delete(t *testing.T, c Ac
 
 // AccessPackage
 
-func testAccessPackageResourceRoleScopeAP_Create(t *testing.T, c AccessPackageResourceRoleScopeTest, a msgraph.AccessPackage) (accessPackage *msgraph.AccessPackage) {
-	accessPackage, status, err := c.apClient.Create(c.connection.Context, a)
+func testAccessPackageResourceRoleScopeAP_Create(t *testing.T, c *test.Test, a msgraph.AccessPackage) (accessPackage *msgraph.AccessPackage) {
+	accessPackage, status, err := c.AccessPackageClient.Create(c.Connection.Context, a)
 	if err != nil {
 		t.Fatalf("AccessPackageClient.Create(): %v", err)
 	}
@@ -248,8 +192,8 @@ func testAccessPackageResourceRoleScopeAP_Create(t *testing.T, c AccessPackageRe
 	return
 }
 
-func testAccessPackageResourceRoleScopeAP_Delete(t *testing.T, c AccessPackageResourceRoleScopeTest, id string) {
-	status, err := c.apClient.Delete(c.connection.Context, id)
+func testAccessPackageResourceRoleScopeAP_Delete(t *testing.T, c *test.Test, id string) {
+	status, err := c.AccessPackageClient.Delete(c.Connection.Context, id)
 	if err != nil {
 		t.Fatalf("AccessPackageClient.Delete(): %v", err)
 	}
@@ -260,9 +204,9 @@ func testAccessPackageResourceRoleScopeAP_Delete(t *testing.T, c AccessPackageRe
 
 // AccessPackageCatalog
 
-func testAccessPackageResourceRoleScopeCatalog_Create(t *testing.T, c AccessPackageResourceRoleScopeTest) (accessPackageCatalog *msgraph.AccessPackageCatalog) {
-	accessPackageCatalog, _, err := c.apCatalogClient.Create(c.connection.Context, msgraph.AccessPackageCatalog{
-		DisplayName:         utils.StringPtr(fmt.Sprintf("test-catalog-%s", c.randomString)),
+func testAccessPackageResourceRoleScopeCatalog_Create(t *testing.T, c *test.Test) (accessPackageCatalog *msgraph.AccessPackageCatalog) {
+	accessPackageCatalog, _, err := c.AccessPackageCatalogClient.Create(c.Connection.Context, msgraph.AccessPackageCatalog{
+		DisplayName:         utils.StringPtr(fmt.Sprintf("test-catalog-%s", c.RandomString)),
 		CatalogType:         msgraph.AccessPackageCatalogTypeUserManaged,
 		CatalogStatus:       msgraph.AccessPackageCatalogStatusPublished,
 		Description:         utils.StringPtr("Test Access Catalog"),
@@ -275,18 +219,18 @@ func testAccessPackageResourceRoleScopeCatalog_Create(t *testing.T, c AccessPack
 	return
 }
 
-func testAccessPackageResourceRoleScopeCatalog_Delete(t *testing.T, c AccessPackageResourceRoleScopeTest, id string) {
-	_, err := c.apCatalogClient.Delete(c.connection.Context, id)
+func testAccessPackageResourceRoleScopeCatalog_Delete(t *testing.T, c *test.Test, id string) {
+	_, err := c.AccessPackageCatalogClient.Delete(c.Connection.Context, id)
 	if err != nil {
 		t.Fatalf("AccessPackageCatalogClient.Delete() - Could not delete test AccessPackage catalog")
 	}
 }
 
-func testAccessPackageResourceRoleScopeGroup_Create(t *testing.T, c AccessPackageResourceRoleScopeTest, self msgraph.Owners) (group *msgraph.Group) {
-	group, _, err := c.groupsClient.Create(c.connection.Context, msgraph.Group{
-		DisplayName:     utils.StringPtr(fmt.Sprintf("%s-%s", "testapresourcerequest", c.randomString)),
+func testAccessPackageResourceRoleScopeGroup_Create(t *testing.T, c *test.Test, self msgraph.Owners) (group *msgraph.Group) {
+	group, _, err := c.GroupsClient.Create(c.Connection.Context, msgraph.Group{
+		DisplayName:     utils.StringPtr(fmt.Sprintf("%s-%s", "testapresourcerequest", c.RandomString)),
 		MailEnabled:     utils.BoolPtr(false),
-		MailNickname:    utils.StringPtr(fmt.Sprintf("%s-%s", "testapresourcerequest", c.randomString)),
+		MailNickname:    utils.StringPtr(fmt.Sprintf("%s-%s", "testapresourcerequest", c.RandomString)),
 		SecurityEnabled: utils.BoolPtr(true),
 		Owners:          &self,
 	})
@@ -297,8 +241,8 @@ func testAccessPackageResourceRoleScopeGroup_Create(t *testing.T, c AccessPackag
 	return
 }
 
-func testAccessPackageResourceRoleScopeGroup_Delete(t *testing.T, c AccessPackageResourceRoleScopeTest, group *msgraph.Group) {
-	_, err := c.groupsClient.Delete(c.connection.Context, *group.ID)
+func testAccessPackageResourceRoleScopeGroup_Delete(t *testing.T, c *test.Test, group *msgraph.Group) {
+	_, err := c.GroupsClient.Delete(c.Connection.Context, *group.ID)
 	if err != nil {
 		t.Fatalf("GroupsClient.Delete() - Could not delete test group: %v", err)
 	}
@@ -306,8 +250,8 @@ func testAccessPackageResourceRoleScopeGroup_Delete(t *testing.T, c AccessPackag
 
 // AccessPackageResource
 
-func testAccessPackageResourceRoleScopeResource_Get(t *testing.T, c AccessPackageResourceRoleScopeTest, catalogId string, originId string) (accessPackageResource *msgraph.AccessPackageResource) {
-	accessPackageResource, status, err := c.apResourceClient.Get(c.connection.Context, catalogId, originId)
+func testAccessPackageResourceRoleScopeResource_Get(t *testing.T, c *test.Test, catalogId string, originId string) (accessPackageResource *msgraph.AccessPackageResource) {
+	accessPackageResource, status, err := c.AccessPackageResourceClient.Get(c.Connection.Context, catalogId, originId)
 
 	if err != nil {
 		t.Fatalf("AccessPackageCatalogClient.Get(): %v", err)

--- a/msgraph/app_role_assignments_test.go
+++ b/msgraph/app_role_assignments_test.go
@@ -13,7 +13,8 @@ import (
 )
 
 func TestAppRoleAssignedToClient(t *testing.T) {
-	c := test.NewTest()
+	c := test.NewTest(t)
+	defer c.CancelFunc()
 
 	// Scaffold the resource application
 	testResourceAppRoleId, _ := uuid.GenerateUUID()
@@ -114,7 +115,8 @@ func TestAppRoleAssignedToClient(t *testing.T) {
 }
 
 func TestGroupsAppRoleAssignmentsClient(t *testing.T) {
-	c := test.NewTest()
+	c := test.NewTest(t)
+	defer c.CancelFunc()
 
 	// create a new test group
 	newGroup := msgraph.Group{
@@ -172,7 +174,8 @@ func TestGroupsAppRoleAssignmentsClient(t *testing.T) {
 }
 
 func TestUsersAppRoleAssignmentsClient(t *testing.T) {
-	c := test.NewTest()
+	c := test.NewTest(t)
+	defer c.CancelFunc()
 
 	// create a new test user
 	newUser := msgraph.User{
@@ -233,7 +236,8 @@ func TestUsersAppRoleAssignmentsClient(t *testing.T) {
 }
 
 func TestServicePrincipalsAppRoleAssignmentsClient(t *testing.T) {
-	c := test.NewTest()
+	c := test.NewTest(t)
+	defer c.CancelFunc()
 
 	// pre-generate uuid for a test resourceApp role
 	testResourceAppRoleId, _ := uuid.GenerateUUID()
@@ -307,7 +311,7 @@ func TestServicePrincipalsAppRoleAssignmentsClient(t *testing.T) {
 }
 
 func testGroupsAppRoleAssignmentsClient_List(t *testing.T, c *test.Test, id string) (appRoleAssignments *[]msgraph.AppRoleAssignment) {
-	appRoleAssignments, _, err := c.GroupsAppRoleAssignmentsClient.List(c.Connection.Context, id)
+	appRoleAssignments, _, err := c.GroupsAppRoleAssignmentsClient.List(c.Context, id)
 	if err != nil {
 		t.Fatalf("AppRoleAssignmentsClient.List(): %v", err)
 	}
@@ -318,7 +322,7 @@ func testGroupsAppRoleAssignmentsClient_List(t *testing.T, c *test.Test, id stri
 }
 
 func testServicePrincipalsAppRoleAssignmentsClient_List(t *testing.T, c *test.Test, id string) (appRoleAssignments *[]msgraph.AppRoleAssignment) {
-	appRoleAssignments, _, err := c.ServicePrincipalsAppRoleAssignmentsClient.List(c.Connection.Context, id)
+	appRoleAssignments, _, err := c.ServicePrincipalsAppRoleAssignmentsClient.List(c.Context, id)
 	if err != nil {
 		t.Fatalf("AppRoleAssignmentsClient.List(): %v", err)
 	}
@@ -329,7 +333,7 @@ func testServicePrincipalsAppRoleAssignmentsClient_List(t *testing.T, c *test.Te
 }
 
 func testUsersAppRoleAssignmentsClient_List(t *testing.T, c *test.Test, id string) (appRoleAssignments *[]msgraph.AppRoleAssignment) {
-	appRoleAssignments, _, err := c.UsersAppRoleAssignmentsClient.List(c.Connection.Context, id)
+	appRoleAssignments, _, err := c.UsersAppRoleAssignmentsClient.List(c.Context, id)
 	if err != nil {
 		t.Fatalf("AppRoleAssignmentsClient.List(): %v", err)
 	}
@@ -340,7 +344,7 @@ func testUsersAppRoleAssignmentsClient_List(t *testing.T, c *test.Test, id strin
 }
 
 func testGroupsAppRoleAssignmentsClient_Remove(t *testing.T, c *test.Test, id, appRoleAssignmentId string) {
-	status, err := c.GroupsAppRoleAssignmentsClient.Remove(c.Connection.Context, id, appRoleAssignmentId)
+	status, err := c.GroupsAppRoleAssignmentsClient.Remove(c.Context, id, appRoleAssignmentId)
 	if err != nil {
 		t.Fatalf("AppRoleAssignmentsClient.Remove(): %v", err)
 	}
@@ -350,7 +354,7 @@ func testGroupsAppRoleAssignmentsClient_Remove(t *testing.T, c *test.Test, id, a
 }
 
 func testServicePrincipalsAppRoleAssignmentsClient_Remove(t *testing.T, c *test.Test, id, appRoleAssignmentId string) {
-	status, err := c.ServicePrincipalsAppRoleAssignmentsClient.Remove(c.Connection.Context, id, appRoleAssignmentId)
+	status, err := c.ServicePrincipalsAppRoleAssignmentsClient.Remove(c.Context, id, appRoleAssignmentId)
 	if err != nil {
 		t.Fatalf("AppRoleAssignmentsClient.Remove(): %v", err)
 	}
@@ -360,7 +364,7 @@ func testServicePrincipalsAppRoleAssignmentsClient_Remove(t *testing.T, c *test.
 }
 
 func testUsersAppRoleAssignmentsClient_Remove(t *testing.T, c *test.Test, id, appRoleAssignmentId string) {
-	status, err := c.UsersAppRoleAssignmentsClient.Remove(c.Connection.Context, id, appRoleAssignmentId)
+	status, err := c.UsersAppRoleAssignmentsClient.Remove(c.Context, id, appRoleAssignmentId)
 	if err != nil {
 		t.Fatalf("AppRoleAssignmentsClient.Remove(): %v", err)
 	}
@@ -370,7 +374,7 @@ func testUsersAppRoleAssignmentsClient_Remove(t *testing.T, c *test.Test, id, ap
 }
 
 func testGroupsAppRoleAssignmentsClient_Assign(t *testing.T, c *test.Test, principalId, resourceServicePrincipalId, appRoleId string) (appRoleAssignment *msgraph.AppRoleAssignment) {
-	appRoleAssignment, status, err := c.GroupsAppRoleAssignmentsClient.Assign(c.Connection.Context, principalId, resourceServicePrincipalId, appRoleId)
+	appRoleAssignment, status, err := c.GroupsAppRoleAssignmentsClient.Assign(c.Context, principalId, resourceServicePrincipalId, appRoleId)
 	if err != nil {
 		t.Fatalf("AppRoleAssignmentsClient.Assign(): %v", err)
 	}
@@ -387,7 +391,7 @@ func testGroupsAppRoleAssignmentsClient_Assign(t *testing.T, c *test.Test, princ
 }
 
 func testServicePrincipalsAppRoleAssignmentsClient_Assign(t *testing.T, c *test.Test, principalId, resourceServicePrincipalId, appRoleId string) (appRoleAssignment *msgraph.AppRoleAssignment) {
-	appRoleAssignment, status, err := c.ServicePrincipalsAppRoleAssignmentsClient.Assign(c.Connection.Context, principalId, resourceServicePrincipalId, appRoleId)
+	appRoleAssignment, status, err := c.ServicePrincipalsAppRoleAssignmentsClient.Assign(c.Context, principalId, resourceServicePrincipalId, appRoleId)
 	if err != nil {
 		t.Fatalf("AppRoleAssignmentsClient.Assign(): %v", err)
 	}
@@ -404,7 +408,7 @@ func testServicePrincipalsAppRoleAssignmentsClient_Assign(t *testing.T, c *test.
 }
 
 func testUsersAppRoleAssignmentsClient_Assign(t *testing.T, c *test.Test, principalId, resourceServicePrincipalId, appRoleId string) (appRoleAssignment *msgraph.AppRoleAssignment) {
-	appRoleAssignment, status, err := c.UsersAppRoleAssignmentsClient.Assign(c.Connection.Context, principalId, resourceServicePrincipalId, appRoleId)
+	appRoleAssignment, status, err := c.UsersAppRoleAssignmentsClient.Assign(c.Context, principalId, resourceServicePrincipalId, appRoleId)
 	if err != nil {
 		t.Fatalf("AppRoleAssignmentsClient.Assign(): %v", err)
 	}
@@ -421,7 +425,7 @@ func testUsersAppRoleAssignmentsClient_Assign(t *testing.T, c *test.Test, princi
 }
 
 func testAppRoleAssignedToClient_List(t *testing.T, c *test.Test, resourceAppId string) (appRoleAssignments *[]msgraph.AppRoleAssignment) {
-	appRoleAssignments, status, err := c.AppRoleAssignedToClient.List(c.Connection.Context, resourceAppId, odata.Query{})
+	appRoleAssignments, status, err := c.AppRoleAssignedToClient.List(c.Context, resourceAppId, odata.Query{})
 	if err != nil {
 		t.Fatalf("AppRoleAssignedToClient.List(): %v", err)
 	}
@@ -438,7 +442,7 @@ func testAppRoleAssignedToClient_List(t *testing.T, c *test.Test, resourceAppId 
 }
 
 func testAppRoleAssignedToClient_Assign(t *testing.T, c *test.Test, appRoleAssignment msgraph.AppRoleAssignment) (newAppRoleAssignment *msgraph.AppRoleAssignment) {
-	newAppRoleAssignment, status, err := c.AppRoleAssignedToClient.Assign(c.Connection.Context, appRoleAssignment)
+	newAppRoleAssignment, status, err := c.AppRoleAssignedToClient.Assign(c.Context, appRoleAssignment)
 	if err != nil {
 		t.Fatalf("AppRoleAssignedToClient.Assign(): %v", err)
 	}
@@ -455,7 +459,7 @@ func testAppRoleAssignedToClient_Assign(t *testing.T, c *test.Test, appRoleAssig
 }
 
 func testAppRoleAssignedToClient_Remove(t *testing.T, c *test.Test, resourceAppId, appRoleAssignmentId string) {
-	status, err := c.AppRoleAssignedToClient.Remove(c.Connection.Context, resourceAppId, appRoleAssignmentId)
+	status, err := c.AppRoleAssignedToClient.Remove(c.Context, resourceAppId, appRoleAssignmentId)
 	if err != nil {
 		t.Fatalf("AppRoleAssignedToClient.Remove(): %v", err)
 	}

--- a/msgraph/app_role_assignments_test.go
+++ b/msgraph/app_role_assignments_test.go
@@ -4,82 +4,28 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/manicminer/hamilton/odata"
-
 	"github.com/hashicorp/go-uuid"
 
-	"github.com/manicminer/hamilton/auth"
 	"github.com/manicminer/hamilton/internal/test"
 	"github.com/manicminer/hamilton/internal/utils"
 	"github.com/manicminer/hamilton/msgraph"
+	"github.com/manicminer/hamilton/odata"
 )
 
-type AppRoleAssignedToClientTest struct {
-	connection   *test.Connection
-	client       *msgraph.AppRoleAssignedToClient
-	randomString string
-}
-
-type AppRoleAssignmentsClientTest struct {
-	connection   *test.Connection
-	client       *msgraph.AppRoleAssignmentsClient
-	randomString string
-}
-
 func TestAppRoleAssignedToClient(t *testing.T) {
-	rs := test.RandomString()
-
-	c := AppRoleAssignedToClientTest{
-		connection:   test.NewConnection(auth.MsGraph, auth.TokenVersion2),
-		randomString: rs,
-	}
-	c.client = msgraph.NewAppRoleAssignedToClient(c.connection.AuthConfig.TenantID)
-	c.client.BaseClient.Authorizer = c.connection.Authorizer
-	c.client.BaseClient.Endpoint = c.connection.AuthConfig.Environment.MsGraph.Endpoint
-
-	a := ApplicationsClientTest{
-		connection:   test.NewConnection(auth.MsGraph, auth.TokenVersion2),
-		randomString: rs,
-	}
-	a.client = msgraph.NewApplicationsClient(a.connection.AuthConfig.TenantID)
-	a.client.BaseClient.Authorizer = a.connection.Authorizer
-	a.client.BaseClient.Endpoint = a.connection.AuthConfig.Environment.MsGraph.Endpoint
-
-	s := ServicePrincipalsClientTest{
-		connection:   test.NewConnection(auth.MsGraph, auth.TokenVersion2),
-		randomString: rs,
-	}
-	s.client = msgraph.NewServicePrincipalsClient(s.connection.AuthConfig.TenantID)
-	s.client.BaseClient.Authorizer = s.connection.Authorizer
-	s.client.BaseClient.Endpoint = s.connection.AuthConfig.Environment.MsGraph.Endpoint
-
-	g := GroupsClientTest{
-		connection:   test.NewConnection(auth.MsGraph, auth.TokenVersion2),
-		randomString: rs,
-	}
-	g.client = msgraph.NewGroupsClient(g.connection.AuthConfig.TenantID)
-	g.client.BaseClient.Authorizer = g.connection.Authorizer
-	g.client.BaseClient.Endpoint = g.connection.AuthConfig.Environment.MsGraph.Endpoint
-
-	u := UsersClientTest{
-		connection:   test.NewConnection(auth.MsGraph, auth.TokenVersion2),
-		randomString: rs,
-	}
-	u.client = msgraph.NewUsersClient(u.connection.AuthConfig.TenantID)
-	u.client.BaseClient.Authorizer = u.connection.Authorizer
-	u.client.BaseClient.Endpoint = u.connection.AuthConfig.Environment.MsGraph.Endpoint
+	c := test.NewTest()
 
 	// Scaffold the resource application
 	testResourceAppRoleId, _ := uuid.GenerateUUID()
-	resourceApp := testApplicationsClient_Create(t, a, msgraph.Application{
-		DisplayName: utils.StringPtr(fmt.Sprintf("test-application-appRoleAssignedTo-%s", a.randomString)),
+	resourceApp := testApplicationsClient_Create(t, c, msgraph.Application{
+		DisplayName: utils.StringPtr(fmt.Sprintf("test-application-appRoleAssignedTo-%s", c.RandomString)),
 		AppRoles: &[]msgraph.AppRole{
 			{
 				ID:          utils.StringPtr(testResourceAppRoleId),
-				DisplayName: utils.StringPtr(fmt.Sprintf("test-resourceApp-role-%s", a.randomString)),
+				DisplayName: utils.StringPtr(fmt.Sprintf("test-resourceApp-role-%s", c.RandomString)),
 				IsEnabled:   utils.BoolPtr(true),
-				Description: utils.StringPtr(fmt.Sprintf("test-resourceApp-role-description-%s", a.randomString)),
-				Value:       utils.StringPtr(fmt.Sprintf("test-resourceApp-role-value-%s", a.randomString)),
+				Description: utils.StringPtr(fmt.Sprintf("test-resourceApp-role-description-%s", c.RandomString)),
+				Value:       utils.StringPtr(fmt.Sprintf("test-resourceApp-role-value-%s", c.RandomString)),
 				AllowedMemberTypes: &[]msgraph.AppRoleAllowedMemberType{
 					msgraph.AppRoleAllowedMemberTypeApplication,
 					msgraph.AppRoleAllowedMemberTypeUser,
@@ -87,7 +33,7 @@ func TestAppRoleAssignedToClient(t *testing.T) {
 			},
 		},
 	})
-	resourceServicePrincipal := testServicePrincipalsClient_Create(t, s, msgraph.ServicePrincipal{
+	resourceServicePrincipal := testServicePrincipalsClient_Create(t, c, msgraph.ServicePrincipal{
 		AccountEnabled:            utils.BoolPtr(true),
 		AppId:                     resourceApp.AppId,
 		AppRoleAssignmentRequired: utils.BoolPtr(true),
@@ -95,23 +41,23 @@ func TestAppRoleAssignedToClient(t *testing.T) {
 	})
 
 	// Scaffold the group, user and service principal to assign roles to
-	group := testGroupsClient_Create(t, g, msgraph.Group{
+	group := testGroupsClient_Create(t, c, msgraph.Group{
 		DisplayName:     utils.StringPtr("test-group-appRoleAssignments"),
 		MailEnabled:     utils.BoolPtr(false),
-		MailNickname:    utils.StringPtr(fmt.Sprintf("test-group-%s", g.randomString)),
+		MailNickname:    utils.StringPtr(fmt.Sprintf("test-group-%s", c.RandomString)),
 		SecurityEnabled: utils.BoolPtr(true),
 	})
-	user := testUsersClient_Create(t, u, msgraph.User{
+	user := testUsersClient_Create(t, c, msgraph.User{
 		AccountEnabled:    utils.BoolPtr(true),
 		DisplayName:       utils.StringPtr("test-user-appRoleAssignments"),
-		MailNickname:      utils.StringPtr(fmt.Sprintf("test-user-%s", u.randomString)),
-		UserPrincipalName: utils.StringPtr(fmt.Sprintf("test-user-%s@%s", u.randomString, u.connection.DomainName)),
+		MailNickname:      utils.StringPtr(fmt.Sprintf("test-user-%s", c.RandomString)),
+		UserPrincipalName: utils.StringPtr(fmt.Sprintf("test-user-%s@%s", c.RandomString, c.Connection.DomainName)),
 		PasswordProfile: &msgraph.UserPasswordProfile{
-			Password: utils.StringPtr(fmt.Sprintf("IrPa55w0rd%s", u.randomString)),
+			Password: utils.StringPtr(fmt.Sprintf("IrPa55w0rd%s", c.RandomString)),
 		},
 	})
-	app := testApplicationsClient_Create(t, a, msgraph.Application{
-		DisplayName: utils.StringPtr(fmt.Sprintf("test-application-appRoleAssignments-2-%s", a.randomString)),
+	app := testApplicationsClient_Create(t, c, msgraph.Application{
+		DisplayName: utils.StringPtr(fmt.Sprintf("test-application-appRoleAssignments-2-%s", c.RandomString)),
 		RequiredResourceAccess: &[]msgraph.RequiredResourceAccess{
 			{
 				ResourceAppId: resourceApp.AppId,
@@ -124,7 +70,7 @@ func TestAppRoleAssignedToClient(t *testing.T) {
 			},
 		},
 	})
-	servicePrincipal := testServicePrincipalsClient_Create(t, s, msgraph.ServicePrincipal{
+	servicePrincipal := testServicePrincipalsClient_Create(t, c, msgraph.ServicePrincipal{
 		AccountEnabled: utils.BoolPtr(true),
 		AppId:          app.AppId,
 		DisplayName:    app.DisplayName,
@@ -160,72 +106,37 @@ func TestAppRoleAssignedToClient(t *testing.T) {
 	testAppRoleAssignedToClient_Remove(t, c, *resourceServicePrincipal.ID, *servicePrincipalAssignment.Id)
 
 	// clean up
-	testGroupsClient_Delete(t, g, *group.ID)
-	testUsersClient_Delete(t, u, *user.ID)
-	testServicePrincipalsClient_Delete(t, s, *servicePrincipal.ID)
-	testServicePrincipalsClient_Delete(t, s, *resourceServicePrincipal.ID)
-	testApplicationsClient_Delete(t, a, *resourceApp.ID)
+	testGroupsClient_Delete(t, c, *group.ID)
+	testUsersClient_Delete(t, c, *user.ID)
+	testServicePrincipalsClient_Delete(t, c, *servicePrincipal.ID)
+	testServicePrincipalsClient_Delete(t, c, *resourceServicePrincipal.ID)
+	testApplicationsClient_Delete(t, c, *resourceApp.ID)
 }
 
 func TestGroupsAppRoleAssignmentsClient(t *testing.T) {
-	rs := test.RandomString()
-	// setup service principal test client
-	servicePrincipalsClient := ServicePrincipalsClientTest{
-		connection:   test.NewConnection(auth.MsGraph, auth.TokenVersion2),
-		randomString: rs,
-	}
-	servicePrincipalsClient.client = msgraph.NewServicePrincipalsClient(servicePrincipalsClient.connection.AuthConfig.TenantID)
-	servicePrincipalsClient.client.BaseClient.Authorizer = servicePrincipalsClient.connection.Authorizer
-	servicePrincipalsClient.client.BaseClient.Endpoint = servicePrincipalsClient.connection.AuthConfig.Environment.MsGraph.Endpoint
-
-	// setup groups test client
-	groupsClient := GroupsClientTest{
-		connection:   test.NewConnection(auth.MsGraph, auth.TokenVersion2),
-		randomString: rs,
-	}
-	groupsClient.client = msgraph.NewGroupsClient(groupsClient.connection.AuthConfig.TenantID)
-	groupsClient.client.BaseClient.Authorizer = groupsClient.connection.Authorizer
-	groupsClient.client.BaseClient.Endpoint = groupsClient.connection.AuthConfig.Environment.MsGraph.Endpoint
-
-	// setup resourceApp role assignments test client
-	appRoleAssignClient := AppRoleAssignmentsClientTest{
-		connection:   test.NewConnection(auth.MsGraph, auth.TokenVersion2),
-		randomString: rs,
-	}
-	appRoleAssignClient.client = msgraph.NewGroupsAppRoleAssignmentsClient(appRoleAssignClient.connection.AuthConfig.TenantID)
-	appRoleAssignClient.client.BaseClient.Authorizer = appRoleAssignClient.connection.Authorizer
-	appRoleAssignClient.client.BaseClient.Endpoint = appRoleAssignClient.connection.AuthConfig.Environment.MsGraph.Endpoint
-
-	// setup applications test client
-	appClient := ApplicationsClientTest{
-		connection:   test.NewConnection(auth.MsGraph, auth.TokenVersion2),
-		randomString: rs,
-	}
-	appClient.client = msgraph.NewApplicationsClient(appClient.connection.AuthConfig.TenantID)
-	appClient.client.BaseClient.Authorizer = appClient.connection.Authorizer
-	appClient.client.BaseClient.Endpoint = appClient.connection.AuthConfig.Environment.MsGraph.Endpoint
+	c := test.NewTest()
 
 	// create a new test group
 	newGroup := msgraph.Group{
 		DisplayName:     utils.StringPtr("test-group-appRoleAssignments"),
 		MailEnabled:     utils.BoolPtr(false),
-		MailNickname:    utils.StringPtr(fmt.Sprintf("test-group-%s", groupsClient.randomString)),
+		MailNickname:    utils.StringPtr(fmt.Sprintf("test-group-%s", c.RandomString)),
 		SecurityEnabled: utils.BoolPtr(true),
 	}
-	group := testGroupsClient_Create(t, groupsClient, newGroup)
+	group := testGroupsClient_Create(t, c, newGroup)
 
 	// pre-generate uuid for a test resourceApp role
 	testResourceAppRoleId, _ := uuid.GenerateUUID()
 	// create a new test application with a test resourceApp role
-	resourceApp := testApplicationsClient_Create(t, appClient, msgraph.Application{
-		DisplayName: utils.StringPtr(fmt.Sprintf("test-application-appRoleAssignments-%s", appClient.randomString)),
+	resourceApp := testApplicationsClient_Create(t, c, msgraph.Application{
+		DisplayName: utils.StringPtr(fmt.Sprintf("test-application-appRoleAssignments-%s", c.RandomString)),
 		AppRoles: &[]msgraph.AppRole{
 			{
 				ID:          utils.StringPtr(testResourceAppRoleId),
-				DisplayName: utils.StringPtr(fmt.Sprintf("test-resourceApp-role-%s", appClient.randomString)),
+				DisplayName: utils.StringPtr(fmt.Sprintf("test-resourceApp-role-%s", c.RandomString)),
 				IsEnabled:   utils.BoolPtr(true),
-				Description: utils.StringPtr(fmt.Sprintf("test-resourceApp-role-description-%s", appClient.randomString)),
-				Value:       utils.StringPtr(fmt.Sprintf("test-resourceApp-role-value-%s", appClient.randomString)),
+				Description: utils.StringPtr(fmt.Sprintf("test-resourceApp-role-description-%s", c.RandomString)),
+				Value:       utils.StringPtr(fmt.Sprintf("test-resourceApp-role-value-%s", c.RandomString)),
 				AllowedMemberTypes: &[]msgraph.AppRoleAllowedMemberType{
 					msgraph.AppRoleAllowedMemberTypeUser,
 					msgraph.AppRoleAllowedMemberTypeApplication,
@@ -235,7 +146,7 @@ func TestGroupsAppRoleAssignmentsClient(t *testing.T) {
 	})
 
 	// create a new test resource (API) service principal which has defined the resourceApp role (the application permission)
-	resourceServicePrincipal := testServicePrincipalsClient_Create(t, servicePrincipalsClient, msgraph.ServicePrincipal{
+	resourceServicePrincipal := testServicePrincipalsClient_Create(t, c, msgraph.ServicePrincipal{
 		AccountEnabled: utils.BoolPtr(true),
 		AppId:          resourceApp.AppId,
 		// display name needs to match resourceApp's display name
@@ -243,85 +154,50 @@ func TestGroupsAppRoleAssignmentsClient(t *testing.T) {
 	})
 
 	// assign resourceApp role to the test group
-	appRoleAssignment := testAppRoleAssignmentsClient_Assign(t, appRoleAssignClient, *group.ID, *resourceServicePrincipal.ID, testResourceAppRoleId)
+	appRoleAssignment := testGroupsAppRoleAssignmentsClient_Assign(t, c, *group.ID, *resourceServicePrincipal.ID, testResourceAppRoleId)
 
 	// list resourceApp role assignments for a test group
-	appRoleAssignments := testAppRoleAssignmentsClient_List(t, appRoleAssignClient, *group.ID)
+	appRoleAssignments := testGroupsAppRoleAssignmentsClient_List(t, c, *group.ID)
 	if len(*appRoleAssignments) == 0 {
 		t.Fatal("expected at least one resourceApp role assignment assigned to the test group")
 	}
 
 	// removes resourceApp role assignment previously set to the test group
-	testAppRoleAssignmentsClient_Remove(t, appRoleAssignClient, *group.ID, *appRoleAssignment.Id)
+	testGroupsAppRoleAssignmentsClient_Remove(t, c, *group.ID, *appRoleAssignment.Id)
 
 	// remove all test resources to clean up
-	testGroupsClient_Delete(t, groupsClient, *group.ID)
-	testServicePrincipalsClient_Delete(t, servicePrincipalsClient, *resourceServicePrincipal.ID)
-	testApplicationsClient_Delete(t, appClient, *resourceApp.ID)
+	testGroupsClient_Delete(t, c, *group.ID)
+	testServicePrincipalsClient_Delete(t, c, *resourceServicePrincipal.ID)
+	testApplicationsClient_Delete(t, c, *resourceApp.ID)
 }
 
 func TestUsersAppRoleAssignmentsClient(t *testing.T) {
-	rs := test.RandomString()
-	// setup service principal test client
-	servicePrincipalsClient := ServicePrincipalsClientTest{
-		connection:   test.NewConnection(auth.MsGraph, auth.TokenVersion2),
-		randomString: rs,
-	}
-	servicePrincipalsClient.client = msgraph.NewServicePrincipalsClient(servicePrincipalsClient.connection.AuthConfig.TenantID)
-	servicePrincipalsClient.client.BaseClient.Authorizer = servicePrincipalsClient.connection.Authorizer
-	servicePrincipalsClient.client.BaseClient.Endpoint = servicePrincipalsClient.connection.AuthConfig.Environment.MsGraph.Endpoint
-
-	// setup users test client
-	usersClient := UsersClientTest{
-		connection:   test.NewConnection(auth.MsGraph, auth.TokenVersion2),
-		randomString: rs,
-	}
-	usersClient.client = msgraph.NewUsersClient(usersClient.connection.AuthConfig.TenantID)
-	usersClient.client.BaseClient.Authorizer = usersClient.connection.Authorizer
-	usersClient.client.BaseClient.Endpoint = usersClient.connection.AuthConfig.Environment.MsGraph.Endpoint
-
-	// setup resourceApp role assignments test client
-	appRoleAssignClient := AppRoleAssignmentsClientTest{
-		connection:   test.NewConnection(auth.MsGraph, auth.TokenVersion2),
-		randomString: rs,
-	}
-	appRoleAssignClient.client = msgraph.NewUsersAppRoleAssignmentsClient(appRoleAssignClient.connection.AuthConfig.TenantID)
-	appRoleAssignClient.client.BaseClient.Authorizer = appRoleAssignClient.connection.Authorizer
-	appRoleAssignClient.client.BaseClient.Endpoint = appRoleAssignClient.connection.AuthConfig.Environment.MsGraph.Endpoint
-
-	// setup applications test client
-	appClient := ApplicationsClientTest{
-		connection:   test.NewConnection(auth.MsGraph, auth.TokenVersion2),
-		randomString: rs,
-	}
-	appClient.client = msgraph.NewApplicationsClient(appClient.connection.AuthConfig.TenantID)
-	appClient.client.BaseClient.Authorizer = appClient.connection.Authorizer
-	appClient.client.BaseClient.Endpoint = appClient.connection.AuthConfig.Environment.MsGraph.Endpoint
+	c := test.NewTest()
 
 	// create a new test user
 	newUser := msgraph.User{
 		AccountEnabled:    utils.BoolPtr(true),
 		DisplayName:       utils.StringPtr("test-user-appRoleAssignments"),
-		MailNickname:      utils.StringPtr(fmt.Sprintf("test-user-%s", usersClient.randomString)),
-		UserPrincipalName: utils.StringPtr(fmt.Sprintf("test-user-%s@%s", usersClient.randomString, usersClient.connection.DomainName)),
+		MailNickname:      utils.StringPtr(fmt.Sprintf("test-user-%s", c.RandomString)),
+		UserPrincipalName: utils.StringPtr(fmt.Sprintf("test-user-%s@%s", c.RandomString, c.Connection.DomainName)),
 		PasswordProfile: &msgraph.UserPasswordProfile{
-			Password: utils.StringPtr(fmt.Sprintf("IrPa55w0rd%s", usersClient.randomString)),
+			Password: utils.StringPtr(fmt.Sprintf("IrPa55w0rd%s", c.RandomString)),
 		},
 	}
-	user := testUsersClient_Create(t, usersClient, newUser)
+	user := testUsersClient_Create(t, c, newUser)
 
 	// pre-generate uuid for a test resourceApp role
 	testResourceAppRoleId, _ := uuid.GenerateUUID()
 	// create a new test application with a test resourceApp role
-	resourceApp := testApplicationsClient_Create(t, appClient, msgraph.Application{
-		DisplayName: utils.StringPtr(fmt.Sprintf("test-application-appRoleAssignments-%s", appClient.randomString)),
+	resourceApp := testApplicationsClient_Create(t, c, msgraph.Application{
+		DisplayName: utils.StringPtr(fmt.Sprintf("test-application-appRoleAssignments-%s", c.RandomString)),
 		AppRoles: &[]msgraph.AppRole{
 			{
 				ID:          utils.StringPtr(testResourceAppRoleId),
-				DisplayName: utils.StringPtr(fmt.Sprintf("test-resourceApp-role-%s", appClient.randomString)),
+				DisplayName: utils.StringPtr(fmt.Sprintf("test-resourceApp-role-%s", c.RandomString)),
 				IsEnabled:   utils.BoolPtr(true),
-				Description: utils.StringPtr(fmt.Sprintf("test-resourceApp-role-description-%s", appClient.randomString)),
-				Value:       utils.StringPtr(fmt.Sprintf("test-resourceApp-role-value-%s", appClient.randomString)),
+				Description: utils.StringPtr(fmt.Sprintf("test-resourceApp-role-description-%s", c.RandomString)),
+				Value:       utils.StringPtr(fmt.Sprintf("test-resourceApp-role-value-%s", c.RandomString)),
 				AllowedMemberTypes: &[]msgraph.AppRoleAllowedMemberType{
 					msgraph.AppRoleAllowedMemberTypeUser,
 					msgraph.AppRoleAllowedMemberTypeApplication,
@@ -331,7 +207,7 @@ func TestUsersAppRoleAssignmentsClient(t *testing.T) {
 	})
 
 	// create a new test resource (API) service principal which has defined the resourceApp role (the application permission)
-	resourceServicePrincipal := testServicePrincipalsClient_Create(t, servicePrincipalsClient, msgraph.ServicePrincipal{
+	resourceServicePrincipal := testServicePrincipalsClient_Create(t, c, msgraph.ServicePrincipal{
 		AccountEnabled: utils.BoolPtr(true),
 		AppId:          resourceApp.AppId,
 		// display name needs to match resourceApp's display name
@@ -339,64 +215,38 @@ func TestUsersAppRoleAssignmentsClient(t *testing.T) {
 	})
 
 	// assign resourceApp role to the test user
-	appRoleAssignment := testAppRoleAssignmentsClient_Assign(t, appRoleAssignClient, *user.ID, *resourceServicePrincipal.ID, testResourceAppRoleId)
+	appRoleAssignment := testUsersAppRoleAssignmentsClient_Assign(t, c, *user.ID, *resourceServicePrincipal.ID, testResourceAppRoleId)
 
 	// list resourceApp role assignments for a test user
-	appRoleAssignments := testAppRoleAssignmentsClient_List(t, appRoleAssignClient, *user.ID)
+	appRoleAssignments := testUsersAppRoleAssignmentsClient_List(t, c, *user.ID)
 	if len(*appRoleAssignments) == 0 {
 		t.Fatal("expected at least one resourceApp role assignment assigned to the test user")
 	}
 
 	// removes resourceApp role assignment previously set to the test user
-	testAppRoleAssignmentsClient_Remove(t, appRoleAssignClient, *user.ID, *appRoleAssignment.Id)
+	testUsersAppRoleAssignmentsClient_Remove(t, c, *user.ID, *appRoleAssignment.Id)
 
 	// remove all test resources to clean up
-	testUsersClient_Delete(t, usersClient, *user.ID)
-	testServicePrincipalsClient_Delete(t, servicePrincipalsClient, *resourceServicePrincipal.ID)
-	testApplicationsClient_Delete(t, appClient, *resourceApp.ID)
+	testUsersClient_Delete(t, c, *user.ID)
+	testServicePrincipalsClient_Delete(t, c, *resourceServicePrincipal.ID)
+	testApplicationsClient_Delete(t, c, *resourceApp.ID)
 }
 
 func TestServicePrincipalsAppRoleAssignmentsClient(t *testing.T) {
-	rs := test.RandomString()
-	// setup service principal test client
-	servicePrincipalsClient := ServicePrincipalsClientTest{
-		connection:   test.NewConnection(auth.MsGraph, auth.TokenVersion2),
-		randomString: rs,
-	}
-	servicePrincipalsClient.client = msgraph.NewServicePrincipalsClient(servicePrincipalsClient.connection.AuthConfig.TenantID)
-	servicePrincipalsClient.client.BaseClient.Authorizer = servicePrincipalsClient.connection.Authorizer
-	servicePrincipalsClient.client.BaseClient.Endpoint = servicePrincipalsClient.connection.AuthConfig.Environment.MsGraph.Endpoint
-
-	// setup resourceApp role assignments test client
-	appRoleAssignClient := AppRoleAssignmentsClientTest{
-		connection:   test.NewConnection(auth.MsGraph, auth.TokenVersion2),
-		randomString: rs,
-	}
-	appRoleAssignClient.client = msgraph.NewServicePrincipalsAppRoleAssignmentsClient(appRoleAssignClient.connection.AuthConfig.TenantID)
-	appRoleAssignClient.client.BaseClient.Authorizer = appRoleAssignClient.connection.Authorizer
-	appRoleAssignClient.client.BaseClient.Endpoint = appRoleAssignClient.connection.AuthConfig.Environment.MsGraph.Endpoint
-
-	// setup applications test client
-	appClient := ApplicationsClientTest{
-		connection:   test.NewConnection(auth.MsGraph, auth.TokenVersion2),
-		randomString: rs,
-	}
-	appClient.client = msgraph.NewApplicationsClient(appClient.connection.AuthConfig.TenantID)
-	appClient.client.BaseClient.Authorizer = appClient.connection.Authorizer
-	appClient.client.BaseClient.Endpoint = appClient.connection.AuthConfig.Environment.MsGraph.Endpoint
+	c := test.NewTest()
 
 	// pre-generate uuid for a test resourceApp role
 	testResourceAppRoleId, _ := uuid.GenerateUUID()
 	// create a new test application with a test resourceApp role
-	resourceApp := testApplicationsClient_Create(t, appClient, msgraph.Application{
-		DisplayName: utils.StringPtr(fmt.Sprintf("test-application-appRoleAssignments-%s", appClient.randomString)),
+	resourceApp := testApplicationsClient_Create(t, c, msgraph.Application{
+		DisplayName: utils.StringPtr(fmt.Sprintf("test-application-appRoleAssignments-%s", c.RandomString)),
 		AppRoles: &[]msgraph.AppRole{
 			{
 				ID:          utils.StringPtr(testResourceAppRoleId),
-				DisplayName: utils.StringPtr(fmt.Sprintf("test-resourceApp-role-%s", appClient.randomString)),
+				DisplayName: utils.StringPtr(fmt.Sprintf("test-resourceApp-role-%s", c.RandomString)),
 				IsEnabled:   utils.BoolPtr(true),
-				Description: utils.StringPtr(fmt.Sprintf("test-resourceApp-role-description-%s", appClient.randomString)),
-				Value:       utils.StringPtr(fmt.Sprintf("test-resourceApp-role-value-%s", appClient.randomString)),
+				Description: utils.StringPtr(fmt.Sprintf("test-resourceApp-role-description-%s", c.RandomString)),
+				Value:       utils.StringPtr(fmt.Sprintf("test-resourceApp-role-value-%s", c.RandomString)),
 				AllowedMemberTypes: &[]msgraph.AppRoleAllowedMemberType{
 					msgraph.AppRoleAllowedMemberTypeUser,
 					msgraph.AppRoleAllowedMemberTypeApplication,
@@ -406,7 +256,7 @@ func TestServicePrincipalsAppRoleAssignmentsClient(t *testing.T) {
 	})
 
 	// create a new test resource (API) service principal which has defined the resourceApp role (the application permission)
-	resourceServicePrincipal := testServicePrincipalsClient_Create(t, servicePrincipalsClient, msgraph.ServicePrincipal{
+	resourceServicePrincipal := testServicePrincipalsClient_Create(t, c, msgraph.ServicePrincipal{
 		AccountEnabled: utils.BoolPtr(true),
 		AppId:          resourceApp.AppId,
 		// display name needs to match resourceApp's display name
@@ -414,15 +264,15 @@ func TestServicePrincipalsAppRoleAssignmentsClient(t *testing.T) {
 	})
 
 	// create a new test 2 application
-	clientApp := testApplicationsClient_Create(t, appClient, msgraph.Application{
-		DisplayName: utils.StringPtr(fmt.Sprintf("test-application-appRoleAssignments-2-%s", appClient.randomString)),
+	clientApp := testApplicationsClient_Create(t, c, msgraph.Application{
+		DisplayName: utils.StringPtr(fmt.Sprintf("test-application-appRoleAssignments-2-%s", c.RandomString)),
 		AppRoles: &[]msgraph.AppRole{
 			{
 				ID:          utils.StringPtr(testResourceAppRoleId),
-				DisplayName: utils.StringPtr(fmt.Sprintf("test-2-resourceApp-role-%s", appClient.randomString)),
+				DisplayName: utils.StringPtr(fmt.Sprintf("test-2-resourceApp-role-%s", c.RandomString)),
 				IsEnabled:   utils.BoolPtr(true),
-				Description: utils.StringPtr(fmt.Sprintf("test-2-resourceApp-role-description-%s", appClient.randomString)),
-				Value:       utils.StringPtr(fmt.Sprintf("test-2-resourceApp-role-value-%s", appClient.randomString)),
+				Description: utils.StringPtr(fmt.Sprintf("test-2-resourceApp-role-description-%s", c.RandomString)),
+				Value:       utils.StringPtr(fmt.Sprintf("test-2-resourceApp-role-value-%s", c.RandomString)),
 				AllowedMemberTypes: &[]msgraph.AppRoleAllowedMemberType{
 					msgraph.AppRoleAllowedMemberTypeUser,
 					msgraph.AppRoleAllowedMemberTypeApplication,
@@ -431,7 +281,7 @@ func TestServicePrincipalsAppRoleAssignmentsClient(t *testing.T) {
 		},
 	})
 	// create a new test client service principal
-	clientServicePrincipal := testServicePrincipalsClient_Create(t, servicePrincipalsClient, msgraph.ServicePrincipal{
+	clientServicePrincipal := testServicePrincipalsClient_Create(t, c, msgraph.ServicePrincipal{
 		AccountEnabled: utils.BoolPtr(true),
 		AppId:          clientApp.AppId,
 		// display name needs to match clientApp's display name
@@ -439,25 +289,25 @@ func TestServicePrincipalsAppRoleAssignmentsClient(t *testing.T) {
 	})
 
 	// assign resourceApp role to the test client service principal
-	appRoleAssignment := testAppRoleAssignmentsClient_Assign(t, appRoleAssignClient, *clientServicePrincipal.ID, *resourceServicePrincipal.ID, testResourceAppRoleId)
+	appRoleAssignment := testServicePrincipalsAppRoleAssignmentsClient_Assign(t, c, *clientServicePrincipal.ID, *resourceServicePrincipal.ID, testResourceAppRoleId)
 
 	// list resourceApp role assignments for a test client service principal
-	appRoleAssignments := testAppRoleAssignmentsClient_List(t, appRoleAssignClient, *clientServicePrincipal.ID)
+	appRoleAssignments := testServicePrincipalsAppRoleAssignmentsClient_List(t, c, *clientServicePrincipal.ID)
 	if len(*appRoleAssignments) == 0 {
 		t.Fatal("expected at least one resourceApp role assignment assigned to the test client service principal")
 	}
 
 	// removes resourceApp role assignment previously set to the test client service principal
-	testAppRoleAssignmentsClient_Remove(t, appRoleAssignClient, *clientServicePrincipal.ID, *appRoleAssignment.Id)
+	testServicePrincipalsAppRoleAssignmentsClient_Remove(t, c, *clientServicePrincipal.ID, *appRoleAssignment.Id)
 
 	// remove all test resources to clean up
-	testServicePrincipalsClient_Delete(t, servicePrincipalsClient, *clientServicePrincipal.ID)
-	testServicePrincipalsClient_Delete(t, servicePrincipalsClient, *resourceServicePrincipal.ID)
-	testApplicationsClient_Delete(t, appClient, *resourceApp.ID)
+	testServicePrincipalsClient_Delete(t, c, *clientServicePrincipal.ID)
+	testServicePrincipalsClient_Delete(t, c, *resourceServicePrincipal.ID)
+	testApplicationsClient_Delete(t, c, *resourceApp.ID)
 }
 
-func testAppRoleAssignmentsClient_List(t *testing.T, c AppRoleAssignmentsClientTest, id string) (appRoleAssignments *[]msgraph.AppRoleAssignment) {
-	appRoleAssignments, _, err := c.client.List(c.connection.Context, id)
+func testGroupsAppRoleAssignmentsClient_List(t *testing.T, c *test.Test, id string) (appRoleAssignments *[]msgraph.AppRoleAssignment) {
+	appRoleAssignments, _, err := c.GroupsAppRoleAssignmentsClient.List(c.Connection.Context, id)
 	if err != nil {
 		t.Fatalf("AppRoleAssignmentsClient.List(): %v", err)
 	}
@@ -467,8 +317,30 @@ func testAppRoleAssignmentsClient_List(t *testing.T, c AppRoleAssignmentsClientT
 	return
 }
 
-func testAppRoleAssignmentsClient_Remove(t *testing.T, c AppRoleAssignmentsClientTest, id, appRoleAssignmentId string) {
-	status, err := c.client.Remove(c.connection.Context, id, appRoleAssignmentId)
+func testServicePrincipalsAppRoleAssignmentsClient_List(t *testing.T, c *test.Test, id string) (appRoleAssignments *[]msgraph.AppRoleAssignment) {
+	appRoleAssignments, _, err := c.ServicePrincipalsAppRoleAssignmentsClient.List(c.Connection.Context, id)
+	if err != nil {
+		t.Fatalf("AppRoleAssignmentsClient.List(): %v", err)
+	}
+	if appRoleAssignments == nil {
+		t.Fatal("AppRoleAssignmentsClient.List(): appRoleAssignments was nil")
+	}
+	return
+}
+
+func testUsersAppRoleAssignmentsClient_List(t *testing.T, c *test.Test, id string) (appRoleAssignments *[]msgraph.AppRoleAssignment) {
+	appRoleAssignments, _, err := c.UsersAppRoleAssignmentsClient.List(c.Connection.Context, id)
+	if err != nil {
+		t.Fatalf("AppRoleAssignmentsClient.List(): %v", err)
+	}
+	if appRoleAssignments == nil {
+		t.Fatal("AppRoleAssignmentsClient.List(): appRoleAssignments was nil")
+	}
+	return
+}
+
+func testGroupsAppRoleAssignmentsClient_Remove(t *testing.T, c *test.Test, id, appRoleAssignmentId string) {
+	status, err := c.GroupsAppRoleAssignmentsClient.Remove(c.Connection.Context, id, appRoleAssignmentId)
 	if err != nil {
 		t.Fatalf("AppRoleAssignmentsClient.Remove(): %v", err)
 	}
@@ -477,8 +349,28 @@ func testAppRoleAssignmentsClient_Remove(t *testing.T, c AppRoleAssignmentsClien
 	}
 }
 
-func testAppRoleAssignmentsClient_Assign(t *testing.T, c AppRoleAssignmentsClientTest, principalId, resourceServicePrincipalId, appRoleId string) (appRoleAssignment *msgraph.AppRoleAssignment) {
-	appRoleAssignment, status, err := c.client.Assign(c.connection.Context, principalId, resourceServicePrincipalId, appRoleId)
+func testServicePrincipalsAppRoleAssignmentsClient_Remove(t *testing.T, c *test.Test, id, appRoleAssignmentId string) {
+	status, err := c.ServicePrincipalsAppRoleAssignmentsClient.Remove(c.Connection.Context, id, appRoleAssignmentId)
+	if err != nil {
+		t.Fatalf("AppRoleAssignmentsClient.Remove(): %v", err)
+	}
+	if status < 200 || status >= 300 {
+		t.Fatalf("AppRoleAssignmentsClient.Remove(): invalid status: %d", status)
+	}
+}
+
+func testUsersAppRoleAssignmentsClient_Remove(t *testing.T, c *test.Test, id, appRoleAssignmentId string) {
+	status, err := c.UsersAppRoleAssignmentsClient.Remove(c.Connection.Context, id, appRoleAssignmentId)
+	if err != nil {
+		t.Fatalf("AppRoleAssignmentsClient.Remove(): %v", err)
+	}
+	if status < 200 || status >= 300 {
+		t.Fatalf("AppRoleAssignmentsClient.Remove(): invalid status: %d", status)
+	}
+}
+
+func testGroupsAppRoleAssignmentsClient_Assign(t *testing.T, c *test.Test, principalId, resourceServicePrincipalId, appRoleId string) (appRoleAssignment *msgraph.AppRoleAssignment) {
+	appRoleAssignment, status, err := c.GroupsAppRoleAssignmentsClient.Assign(c.Connection.Context, principalId, resourceServicePrincipalId, appRoleId)
 	if err != nil {
 		t.Fatalf("AppRoleAssignmentsClient.Assign(): %v", err)
 	}
@@ -494,8 +386,42 @@ func testAppRoleAssignmentsClient_Assign(t *testing.T, c AppRoleAssignmentsClien
 	return
 }
 
-func testAppRoleAssignedToClient_List(t *testing.T, c AppRoleAssignedToClientTest, resourceAppId string) (appRoleAssignments *[]msgraph.AppRoleAssignment) {
-	appRoleAssignments, status, err := c.client.List(c.connection.Context, resourceAppId, odata.Query{})
+func testServicePrincipalsAppRoleAssignmentsClient_Assign(t *testing.T, c *test.Test, principalId, resourceServicePrincipalId, appRoleId string) (appRoleAssignment *msgraph.AppRoleAssignment) {
+	appRoleAssignment, status, err := c.ServicePrincipalsAppRoleAssignmentsClient.Assign(c.Connection.Context, principalId, resourceServicePrincipalId, appRoleId)
+	if err != nil {
+		t.Fatalf("AppRoleAssignmentsClient.Assign(): %v", err)
+	}
+	if status < 200 || status >= 300 {
+		t.Fatalf("AppRoleAssignmentsClient.Assign(): invalid status: %d", status)
+	}
+	if appRoleAssignment == nil {
+		t.Fatal("AppRoleAssignmentsClient.Assign(): appRoleAssignment was nil")
+	}
+	if appRoleAssignment.Id == nil {
+		t.Fatal("AppRoleAssignmentsClient.Assign(): appRoleAssignment.Id was nil")
+	}
+	return
+}
+
+func testUsersAppRoleAssignmentsClient_Assign(t *testing.T, c *test.Test, principalId, resourceServicePrincipalId, appRoleId string) (appRoleAssignment *msgraph.AppRoleAssignment) {
+	appRoleAssignment, status, err := c.UsersAppRoleAssignmentsClient.Assign(c.Connection.Context, principalId, resourceServicePrincipalId, appRoleId)
+	if err != nil {
+		t.Fatalf("AppRoleAssignmentsClient.Assign(): %v", err)
+	}
+	if status < 200 || status >= 300 {
+		t.Fatalf("AppRoleAssignmentsClient.Assign(): invalid status: %d", status)
+	}
+	if appRoleAssignment == nil {
+		t.Fatal("AppRoleAssignmentsClient.Assign(): appRoleAssignment was nil")
+	}
+	if appRoleAssignment.Id == nil {
+		t.Fatal("AppRoleAssignmentsClient.Assign(): appRoleAssignment.Id was nil")
+	}
+	return
+}
+
+func testAppRoleAssignedToClient_List(t *testing.T, c *test.Test, resourceAppId string) (appRoleAssignments *[]msgraph.AppRoleAssignment) {
+	appRoleAssignments, status, err := c.AppRoleAssignedToClient.List(c.Connection.Context, resourceAppId, odata.Query{})
 	if err != nil {
 		t.Fatalf("AppRoleAssignedToClient.List(): %v", err)
 	}
@@ -511,8 +437,8 @@ func testAppRoleAssignedToClient_List(t *testing.T, c AppRoleAssignedToClientTes
 	return
 }
 
-func testAppRoleAssignedToClient_Assign(t *testing.T, c AppRoleAssignedToClientTest, appRoleAssignment msgraph.AppRoleAssignment) (newAppRoleAssignment *msgraph.AppRoleAssignment) {
-	newAppRoleAssignment, status, err := c.client.Assign(c.connection.Context, appRoleAssignment)
+func testAppRoleAssignedToClient_Assign(t *testing.T, c *test.Test, appRoleAssignment msgraph.AppRoleAssignment) (newAppRoleAssignment *msgraph.AppRoleAssignment) {
+	newAppRoleAssignment, status, err := c.AppRoleAssignedToClient.Assign(c.Connection.Context, appRoleAssignment)
 	if err != nil {
 		t.Fatalf("AppRoleAssignedToClient.Assign(): %v", err)
 	}
@@ -528,8 +454,8 @@ func testAppRoleAssignedToClient_Assign(t *testing.T, c AppRoleAssignedToClientT
 	return
 }
 
-func testAppRoleAssignedToClient_Remove(t *testing.T, c AppRoleAssignedToClientTest, resourceAppId, appRoleAssignmentId string) {
-	status, err := c.client.Remove(c.connection.Context, resourceAppId, appRoleAssignmentId)
+func testAppRoleAssignedToClient_Remove(t *testing.T, c *test.Test, resourceAppId, appRoleAssignmentId string) {
+	status, err := c.AppRoleAssignedToClient.Remove(c.Connection.Context, resourceAppId, appRoleAssignmentId)
 	if err != nil {
 		t.Fatalf("AppRoleAssignedToClient.Remove(): %v", err)
 	}

--- a/msgraph/application_templates_test.go
+++ b/msgraph/application_templates_test.go
@@ -4,63 +4,33 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/manicminer/hamilton/auth"
 	"github.com/manicminer/hamilton/internal/test"
 	"github.com/manicminer/hamilton/internal/utils"
 	"github.com/manicminer/hamilton/msgraph"
 	"github.com/manicminer/hamilton/odata"
 )
 
-type ApplicationTemplatesClientTest struct {
-	connection   *test.Connection
-	client       *msgraph.ApplicationTemplatesClient
-	randomString string
-}
-
 const testApplicationTemplateId = "4601ed45-8ff3-4599-8377-b6649007e876" // Marketo
 
 func TestApplicationTemplatesClient(t *testing.T) {
-	rs := test.RandomString()
-	c := ApplicationTemplatesClientTest{
-		connection:   test.NewConnection(auth.MsGraph, auth.TokenVersion2),
-		randomString: rs,
-	}
-	c.client = msgraph.NewApplicationTemplatesClient(c.connection.AuthConfig.TenantID)
-	c.client.BaseClient.Authorizer = c.connection.Authorizer
-	c.client.BaseClient.Endpoint = c.connection.AuthConfig.Environment.MsGraph.Endpoint
+	c := test.NewTest()
 
 	testApplicationTemplatesClient_List(t, c, odata.Query{})
 	testApplicationTemplatesClient_List(t, c, odata.Query{Filter: fmt.Sprintf("categories/any(c:contains(c, '%s'))", msgraph.ApplicationTemplateCategoryEducation)})
 	template := testApplicationTemplatesClient_Get(t, c, testApplicationTemplateId)
 	app := testApplicationTemplatesClient_Instantiate(t, c, msgraph.ApplicationTemplate{
 		ID:          template.ID,
-		DisplayName: utils.StringPtr(fmt.Sprintf("test-applicationTemplate-%s", c.randomString)),
+		DisplayName: utils.StringPtr(fmt.Sprintf("test-applicationTemplate-%s", c.RandomString)),
 	})
 
-	s := ServicePrincipalsClientTest{
-		connection:   test.NewConnection(auth.MsGraph, auth.TokenVersion2),
-		randomString: rs,
-	}
-	s.client = msgraph.NewServicePrincipalsClient(s.connection.AuthConfig.TenantID)
-	s.client.BaseClient.Authorizer = s.connection.Authorizer
-	s.client.BaseClient.Endpoint = s.connection.AuthConfig.Environment.MsGraph.Endpoint
+	testServicePrincipalsClient_Delete(t, c, *app.ServicePrincipal.ID)
 
-	testServicePrincipalsClient_Delete(t, s, *app.ServicePrincipal.ID)
-
-	a := ApplicationsClientTest{
-		connection:   test.NewConnection(auth.MsGraph, auth.TokenVersion2),
-		randomString: rs,
-	}
-	a.client = msgraph.NewApplicationsClient(a.connection.AuthConfig.TenantID)
-	a.client.BaseClient.Authorizer = a.connection.Authorizer
-	a.client.BaseClient.Endpoint = a.connection.AuthConfig.Environment.MsGraph.Endpoint
-
-	testApplicationsClient_Delete(t, a, *app.Application.ID)
-	testApplicationsClient_DeletePermanently(t, a, *app.Application.ID)
+	testApplicationsClient_Delete(t, c, *app.Application.ID)
+	testApplicationsClient_DeletePermanently(t, c, *app.Application.ID)
 }
 
-func testApplicationTemplatesClient_List(t *testing.T, c ApplicationTemplatesClientTest, o odata.Query) (applicationTemplates []msgraph.ApplicationTemplate) {
-	result, _, err := c.client.List(c.connection.Context, o)
+func testApplicationTemplatesClient_List(t *testing.T, c *test.Test, o odata.Query) (applicationTemplates []msgraph.ApplicationTemplate) {
+	result, _, err := c.ApplicationTemplatesClient.List(c.Connection.Context, o)
 	if err != nil {
 		t.Fatalf("ApplicationTemplatesClient.List(): %v", err)
 	}
@@ -77,8 +47,8 @@ func testApplicationTemplatesClient_List(t *testing.T, c ApplicationTemplatesCli
 	return
 }
 
-func testApplicationTemplatesClient_Get(t *testing.T, c ApplicationTemplatesClientTest, id string) (applicationTemplate *msgraph.ApplicationTemplate) {
-	applicationTemplate, status, err := c.client.Get(c.connection.Context, id, odata.Query{})
+func testApplicationTemplatesClient_Get(t *testing.T, c *test.Test, id string) (applicationTemplate *msgraph.ApplicationTemplate) {
+	applicationTemplate, status, err := c.ApplicationTemplatesClient.Get(c.Connection.Context, id, odata.Query{})
 	if err != nil {
 		t.Fatalf("ApplicationTemplatesClient.Get(): %v", err)
 	}
@@ -94,8 +64,8 @@ func testApplicationTemplatesClient_Get(t *testing.T, c ApplicationTemplatesClie
 	return
 }
 
-func testApplicationTemplatesClient_Instantiate(t *testing.T, c ApplicationTemplatesClientTest, a msgraph.ApplicationTemplate) (applicationTemplate *msgraph.ApplicationTemplate) {
-	applicationTemplate, status, err := c.client.Instantiate(c.connection.Context, a)
+func testApplicationTemplatesClient_Instantiate(t *testing.T, c *test.Test, a msgraph.ApplicationTemplate) (applicationTemplate *msgraph.ApplicationTemplate) {
+	applicationTemplate, status, err := c.ApplicationTemplatesClient.Instantiate(c.Connection.Context, a)
 	if err != nil {
 		t.Fatalf("ApplicationTemplatesClient.Instantiate(): %v", err)
 	}

--- a/msgraph/application_templates_test.go
+++ b/msgraph/application_templates_test.go
@@ -13,7 +13,8 @@ import (
 const testApplicationTemplateId = "4601ed45-8ff3-4599-8377-b6649007e876" // Marketo
 
 func TestApplicationTemplatesClient(t *testing.T) {
-	c := test.NewTest()
+	c := test.NewTest(t)
+	defer c.CancelFunc()
 
 	testApplicationTemplatesClient_List(t, c, odata.Query{})
 	testApplicationTemplatesClient_List(t, c, odata.Query{Filter: fmt.Sprintf("categories/any(c:contains(c, '%s'))", msgraph.ApplicationTemplateCategoryEducation)})
@@ -30,7 +31,7 @@ func TestApplicationTemplatesClient(t *testing.T) {
 }
 
 func testApplicationTemplatesClient_List(t *testing.T, c *test.Test, o odata.Query) (applicationTemplates []msgraph.ApplicationTemplate) {
-	result, _, err := c.ApplicationTemplatesClient.List(c.Connection.Context, o)
+	result, _, err := c.ApplicationTemplatesClient.List(c.Context, o)
 	if err != nil {
 		t.Fatalf("ApplicationTemplatesClient.List(): %v", err)
 	}
@@ -48,7 +49,7 @@ func testApplicationTemplatesClient_List(t *testing.T, c *test.Test, o odata.Que
 }
 
 func testApplicationTemplatesClient_Get(t *testing.T, c *test.Test, id string) (applicationTemplate *msgraph.ApplicationTemplate) {
-	applicationTemplate, status, err := c.ApplicationTemplatesClient.Get(c.Connection.Context, id, odata.Query{})
+	applicationTemplate, status, err := c.ApplicationTemplatesClient.Get(c.Context, id, odata.Query{})
 	if err != nil {
 		t.Fatalf("ApplicationTemplatesClient.Get(): %v", err)
 	}
@@ -65,7 +66,7 @@ func testApplicationTemplatesClient_Get(t *testing.T, c *test.Test, id string) (
 }
 
 func testApplicationTemplatesClient_Instantiate(t *testing.T, c *test.Test, a msgraph.ApplicationTemplate) (applicationTemplate *msgraph.ApplicationTemplate) {
-	applicationTemplate, status, err := c.ApplicationTemplatesClient.Instantiate(c.Connection.Context, a)
+	applicationTemplate, status, err := c.ApplicationTemplatesClient.Instantiate(c.Context, a)
 	if err != nil {
 		t.Fatalf("ApplicationTemplatesClient.Instantiate(): %v", err)
 	}

--- a/msgraph/applications_test.go
+++ b/msgraph/applications_test.go
@@ -13,7 +13,8 @@ import (
 )
 
 func TestApplicationsClient(t *testing.T) {
-	c := test.NewTest()
+	c := test.NewTest(t)
+	defer c.CancelFunc()
 
 	user := testUsersClient_Create(t, c, msgraph.User{
 		AccountEnabled:    utils.BoolPtr(true),
@@ -75,7 +76,8 @@ func TestApplicationsClient(t *testing.T) {
 }
 
 func TestApplicationsClient_groupMembershipClaims(t *testing.T) {
-	c := test.NewTest()
+	c := test.NewTest(t)
+	defer c.CancelFunc()
 
 	app := testApplicationsClient_Create(t, c, msgraph.Application{
 		DisplayName:           utils.StringPtr(fmt.Sprintf("test-application-%s", c.RandomString)),
@@ -85,7 +87,7 @@ func TestApplicationsClient_groupMembershipClaims(t *testing.T) {
 }
 
 func testApplicationsClient_Create(t *testing.T, c *test.Test, a msgraph.Application) (application *msgraph.Application) {
-	application, status, err := c.ApplicationsClient.Create(c.Connection.Context, a)
+	application, status, err := c.ApplicationsClient.Create(c.Context, a)
 	if err != nil {
 		t.Fatalf("ApplicationsClient.Create(): %v", err)
 	}
@@ -102,7 +104,7 @@ func testApplicationsClient_Create(t *testing.T, c *test.Test, a msgraph.Applica
 }
 
 func testApplicationsClient_Update(t *testing.T, c *test.Test, a msgraph.Application) {
-	status, err := c.ApplicationsClient.Update(c.Connection.Context, a)
+	status, err := c.ApplicationsClient.Update(c.Context, a)
 	if err != nil {
 		t.Fatalf("ApplicationsClient.Update(): %v", err)
 	}
@@ -112,7 +114,7 @@ func testApplicationsClient_Update(t *testing.T, c *test.Test, a msgraph.Applica
 }
 
 func testApplicationsClient_List(t *testing.T, c *test.Test) (applications *[]msgraph.Application) {
-	applications, _, err := c.ApplicationsClient.List(c.Connection.Context, odata.Query{})
+	applications, _, err := c.ApplicationsClient.List(c.Context, odata.Query{})
 	if err != nil {
 		t.Fatalf("ApplicationsClient.List(): %v", err)
 	}
@@ -123,7 +125,7 @@ func testApplicationsClient_List(t *testing.T, c *test.Test) (applications *[]ms
 }
 
 func testApplicationsClient_Get(t *testing.T, c *test.Test, id string) (application *msgraph.Application) {
-	application, status, err := c.ApplicationsClient.Get(c.Connection.Context, id, odata.Query{})
+	application, status, err := c.ApplicationsClient.Get(c.Context, id, odata.Query{})
 	if err != nil {
 		t.Fatalf("ApplicationsClient.Get(): %v", err)
 	}
@@ -137,7 +139,7 @@ func testApplicationsClient_Get(t *testing.T, c *test.Test, id string) (applicat
 }
 
 func testApplicationsClient_CreateExtension(t *testing.T, c *test.Test, applicationExtension msgraph.ApplicationExtension, id string) string {
-	extension, status, err := c.ApplicationsClient.CreateExtension(c.Connection.Context, applicationExtension, id)
+	extension, status, err := c.ApplicationsClient.CreateExtension(c.Context, applicationExtension, id)
 	if err != nil {
 		t.Fatalf("ApplicationsClient.CreateExtension(): %v", err)
 	}
@@ -154,7 +156,7 @@ func testApplicationsClient_CreateExtension(t *testing.T, c *test.Test, applicat
 }
 
 func testApplicationsClient_ListExtension(t *testing.T, c *test.Test, id string) {
-	extension, status, err := c.ApplicationsClient.ListExtensions(c.Connection.Context, id, odata.Query{})
+	extension, status, err := c.ApplicationsClient.ListExtensions(c.Context, id, odata.Query{})
 	if err != nil {
 		t.Fatalf("ApplicationsClient.ListExtensions(): %v", err)
 	}
@@ -167,7 +169,7 @@ func testApplicationsClient_ListExtension(t *testing.T, c *test.Test, id string)
 }
 
 func testApplicationsClient_DeleteExtension(t *testing.T, c *test.Test, extensionId, id string) {
-	status, err := c.ApplicationsClient.DeleteExtension(c.Connection.Context, id, extensionId)
+	status, err := c.ApplicationsClient.DeleteExtension(c.Context, id, extensionId)
 	if err != nil {
 		t.Fatalf("ApplicationsClient.DeleteExtension(): %v", err)
 	}
@@ -177,7 +179,7 @@ func testApplicationsClient_DeleteExtension(t *testing.T, c *test.Test, extensio
 }
 
 func testApplicationsClient_GetDeleted(t *testing.T, c *test.Test, id string) (application *msgraph.Application) {
-	application, status, err := c.ApplicationsClient.GetDeleted(c.Connection.Context, id, odata.Query{})
+	application, status, err := c.ApplicationsClient.GetDeleted(c.Context, id, odata.Query{})
 	if err != nil {
 		t.Fatalf("ApplicationsClient.GetDeleted(): %v", err)
 	}
@@ -191,7 +193,7 @@ func testApplicationsClient_GetDeleted(t *testing.T, c *test.Test, id string) (a
 }
 
 func testApplicationsClient_Delete(t *testing.T, c *test.Test, id string) {
-	status, err := c.ApplicationsClient.Delete(c.Connection.Context, id)
+	status, err := c.ApplicationsClient.Delete(c.Context, id)
 	if err != nil {
 		t.Fatalf("ApplicationsClient.Delete(): %v", err)
 	}
@@ -201,7 +203,7 @@ func testApplicationsClient_Delete(t *testing.T, c *test.Test, id string) {
 }
 
 func testApplicationsClient_DeletePermanently(t *testing.T, c *test.Test, id string) {
-	status, err := c.ApplicationsClient.DeletePermanently(c.Connection.Context, id)
+	status, err := c.ApplicationsClient.DeletePermanently(c.Context, id)
 	if err != nil {
 		t.Fatalf("ApplicationsClient.DeletePermanently(): %v", err)
 	}
@@ -211,7 +213,7 @@ func testApplicationsClient_DeletePermanently(t *testing.T, c *test.Test, id str
 }
 
 func testApplicationsClient_RestoreDeleted(t *testing.T, c *test.Test, id string) {
-	application, status, err := c.ApplicationsClient.RestoreDeleted(c.Connection.Context, id)
+	application, status, err := c.ApplicationsClient.RestoreDeleted(c.Context, id)
 	if err != nil {
 		t.Fatalf("ApplicationsClient.RestoreDeleted(): %v", err)
 	}
@@ -230,7 +232,7 @@ func testApplicationsClient_RestoreDeleted(t *testing.T, c *test.Test, id string
 }
 
 func testApplicationsClient_ListOwners(t *testing.T, c *test.Test, id string) (owners *[]string) {
-	owners, status, err := c.ApplicationsClient.ListOwners(c.Connection.Context, id)
+	owners, status, err := c.ApplicationsClient.ListOwners(c.Context, id)
 	if err != nil {
 		t.Fatalf("ApplicationsClient.ListOwners(): %v", err)
 	}
@@ -247,7 +249,7 @@ func testApplicationsClient_ListOwners(t *testing.T, c *test.Test, id string) (o
 }
 
 func testApplicationsClient_GetOwner(t *testing.T, c *test.Test, appId string, ownerId string) (owner *string) {
-	owner, status, err := c.ApplicationsClient.GetOwner(c.Connection.Context, appId, ownerId)
+	owner, status, err := c.ApplicationsClient.GetOwner(c.Context, appId, ownerId)
 	if err != nil {
 		t.Fatalf("ApplicationsClient.GetOwner(): %v", err)
 	}
@@ -261,7 +263,7 @@ func testApplicationsClient_GetOwner(t *testing.T, c *test.Test, appId string, o
 }
 
 func testApplicationsClient_AddOwners(t *testing.T, c *test.Test, a *msgraph.Application) {
-	status, err := c.ApplicationsClient.AddOwners(c.Connection.Context, a)
+	status, err := c.ApplicationsClient.AddOwners(c.Context, a)
 	if err != nil {
 		t.Fatalf("ApplicationsClient.AddOwners(): %v", err)
 	}
@@ -271,7 +273,7 @@ func testApplicationsClient_AddOwners(t *testing.T, c *test.Test, a *msgraph.App
 }
 
 func testApplicationsClient_RemoveOwners(t *testing.T, c *test.Test, appId string, ownerIds *[]string) {
-	status, err := c.ApplicationsClient.RemoveOwners(c.Connection.Context, appId, ownerIds)
+	status, err := c.ApplicationsClient.RemoveOwners(c.Context, appId, ownerIds)
 	if err != nil {
 		t.Fatalf("ApplicationsClient.RemoveOwners(): %v", err)
 	}
@@ -284,7 +286,7 @@ func testApplicationsClient_AddPassword(t *testing.T, c *test.Test, a *msgraph.A
 	pwd := msgraph.PasswordCredential{
 		DisplayName: utils.StringPtr("test password"),
 	}
-	newPwd, status, err := c.ApplicationsClient.AddPassword(c.Connection.Context, *a.ID, pwd)
+	newPwd, status, err := c.ApplicationsClient.AddPassword(c.Context, *a.ID, pwd)
 	if err != nil {
 		t.Fatalf("ApplicationsClient.AddPassword(): %v", err)
 	}
@@ -301,7 +303,7 @@ func testApplicationsClient_AddPassword(t *testing.T, c *test.Test, a *msgraph.A
 }
 
 func testApplicationsClient_RemovePassword(t *testing.T, c *test.Test, a *msgraph.Application, p *msgraph.PasswordCredential) {
-	status, err := c.ApplicationsClient.RemovePassword(c.Connection.Context, *a.ID, *p.KeyId)
+	status, err := c.ApplicationsClient.RemovePassword(c.Context, *a.ID, *p.KeyId)
 	if err != nil {
 		t.Fatalf("ApplicationsClient.RemovePassword(): %v", err)
 	}
@@ -311,7 +313,7 @@ func testApplicationsClient_RemovePassword(t *testing.T, c *test.Test, a *msgrap
 }
 
 func testApplicationsClient_ListDeleted(t *testing.T, c *test.Test, expectedId string) (deletedApps *[]msgraph.Application) {
-	deletedApps, status, err := c.ApplicationsClient.ListDeleted(c.Connection.Context, odata.Query{
+	deletedApps, status, err := c.ApplicationsClient.ListDeleted(c.Context, odata.Query{
 		Filter: fmt.Sprintf("id eq '%s'", expectedId),
 		Top:    10,
 	})
@@ -345,7 +347,7 @@ func testApplicationsClient_UploadLogo(t *testing.T, c *test.Test, a *msgraph.Ap
 	if err != nil {
 		t.Fatalf("reading testlogo.png: %v", err)
 	}
-	status, err := c.ApplicationsClient.UploadLogo(c.Connection.Context, *a.ID, "image/png", b)
+	status, err := c.ApplicationsClient.UploadLogo(c.Context, *a.ID, "image/png", b)
 	if err != nil {
 		t.Fatalf("ApplicationsClient.UploadLogo(): %v", err)
 	}

--- a/msgraph/applications_test.go
+++ b/msgraph/applications_test.go
@@ -6,68 +6,29 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/manicminer/hamilton/auth"
 	"github.com/manicminer/hamilton/internal/test"
 	"github.com/manicminer/hamilton/internal/utils"
 	"github.com/manicminer/hamilton/msgraph"
 	"github.com/manicminer/hamilton/odata"
 )
 
-type ApplicationsClientTest struct {
-	connection   *test.Connection
-	client       *msgraph.ApplicationsClient
-	randomString string
-}
-
 func TestApplicationsClient(t *testing.T) {
-	rs := test.RandomString()
-	c := ApplicationsClientTest{
-		connection:   test.NewConnection(auth.MsGraph, auth.TokenVersion2),
-		randomString: rs,
-	}
-	c.client = msgraph.NewApplicationsClient(c.connection.AuthConfig.TenantID)
-	c.client.BaseClient.Authorizer = c.connection.Authorizer
-	c.client.BaseClient.Endpoint = c.connection.AuthConfig.Environment.MsGraph.Endpoint
+	c := test.NewTest()
 
-	token, err := c.connection.Authorizer.Token()
-	if err != nil {
-		t.Fatalf("could not acquire access token: %v", err)
-	}
-	claims, err := auth.ParseClaims(token)
-	if err != nil {
-		t.Fatalf("could not parse claims: %v", err)
-	}
-
-	u := UsersClientTest{
-		connection:   test.NewConnection(auth.MsGraph, auth.TokenVersion2),
-		randomString: rs,
-	}
-	u.client = msgraph.NewUsersClient(u.connection.AuthConfig.TenantID)
-	u.client.BaseClient.Authorizer = u.connection.Authorizer
-	u.client.BaseClient.Endpoint = u.connection.AuthConfig.Environment.MsGraph.Endpoint
-
-	user := testUsersClient_Create(t, u, msgraph.User{
+	user := testUsersClient_Create(t, c, msgraph.User{
 		AccountEnabled:    utils.BoolPtr(true),
 		DisplayName:       utils.StringPtr("test-user-applicationowner"),
-		MailNickname:      utils.StringPtr(fmt.Sprintf("test-user-applicationowner-%s", c.randomString)),
-		UserPrincipalName: utils.StringPtr(fmt.Sprintf("test-user-applicationowner-%s@%s", c.randomString, c.connection.DomainName)),
+		MailNickname:      utils.StringPtr(fmt.Sprintf("test-user-applicationowner-%s", c.RandomString)),
+		UserPrincipalName: utils.StringPtr(fmt.Sprintf("test-user-applicationowner-%s@%s", c.RandomString, c.Connection.DomainName)),
 		PasswordProfile: &msgraph.UserPasswordProfile{
-			Password: utils.StringPtr(fmt.Sprintf("IrPa55w0rd%s", c.randomString)),
+			Password: utils.StringPtr(fmt.Sprintf("IrPa55w0rd%s", c.RandomString)),
 		},
 	})
 
-	o := DirectoryObjectsClientTest{
-		connection:   test.NewConnection(auth.MsGraph, auth.TokenVersion2),
-		randomString: rs,
-	}
-	o.client = msgraph.NewDirectoryObjectsClient(o.connection.AuthConfig.TenantID)
-	o.client.BaseClient.Authorizer = o.connection.Authorizer
-	o.client.BaseClient.Endpoint = o.connection.AuthConfig.Environment.MsGraph.Endpoint
-
-	self := testDirectoryObjectsClient_Get(t, o, claims.ObjectId)
+	self := testDirectoryObjectsClient_Get(t, c, c.Claims.ObjectId)
 
 	app := testApplicationsClient_Create(t, c, msgraph.Application{
-		DisplayName: utils.StringPtr(fmt.Sprintf("test-application-%s", c.randomString)),
+		DisplayName: utils.StringPtr(fmt.Sprintf("test-application-%s", c.RandomString)),
 		GroupMembershipClaims: &[]msgraph.GroupMembershipClaim{
 			msgraph.GroupMembershipClaimApplicationGroup,
 			msgraph.GroupMembershipClaimDirectoryRole,
@@ -75,8 +36,10 @@ func TestApplicationsClient(t *testing.T) {
 		},
 		Owners: &msgraph.Owners{*self},
 	})
+
 	testApplicationsClient_Get(t, c, *app.ID)
-	app.DisplayName = utils.StringPtr(fmt.Sprintf("test-app-updated-%s", c.randomString))
+
+	app.DisplayName = utils.StringPtr(fmt.Sprintf("test-app-updated-%s", c.RandomString))
 	targetObject := []msgraph.ApplicationExtensionTargetObject{
 		msgraph.ApplicationExtensionTargetObjectUser,
 	}
@@ -88,15 +51,20 @@ func TestApplicationsClient(t *testing.T) {
 	extensionId := testApplicationsClient_CreateExtension(t, c, newExtension, *app.ID)
 	testApplicationsClient_ListExtension(t, c, *app.ID)
 	testApplicationsClient_DeleteExtension(t, c, extensionId, *app.ID)
+
 	testApplicationsClient_Update(t, c, *app)
+
 	owners := testApplicationsClient_ListOwners(t, c, *app.ID)
 	testApplicationsClient_GetOwner(t, c, *app.ID, (*owners)[0])
 	testApplicationsClient_RemoveOwners(t, c, *app.ID, owners)
 	app.Owners = &msgraph.Owners{user.DirectoryObject}
 	testApplicationsClient_AddOwners(t, c, app)
+
 	pwd := testApplicationsClient_AddPassword(t, c, app)
 	testApplicationsClient_RemovePassword(t, c, app, pwd)
+
 	testApplicationsClient_UploadLogo(t, c, app)
+
 	testApplicationsClient_List(t, c)
 	testApplicationsClient_Delete(t, c, *app.ID)
 	testApplicationsClient_ListDeleted(t, c, *app.ID)
@@ -107,23 +75,17 @@ func TestApplicationsClient(t *testing.T) {
 }
 
 func TestApplicationsClient_groupMembershipClaims(t *testing.T) {
-	c := ApplicationsClientTest{
-		connection:   test.NewConnection(auth.MsGraph, auth.TokenVersion2),
-		randomString: test.RandomString(),
-	}
-	c.client = msgraph.NewApplicationsClient(c.connection.AuthConfig.TenantID)
-	c.client.BaseClient.Authorizer = c.connection.Authorizer
-	c.client.BaseClient.Endpoint = c.connection.AuthConfig.Environment.MsGraph.Endpoint
+	c := test.NewTest()
 
 	app := testApplicationsClient_Create(t, c, msgraph.Application{
-		DisplayName:           utils.StringPtr(fmt.Sprintf("test-application-%s", c.randomString)),
+		DisplayName:           utils.StringPtr(fmt.Sprintf("test-application-%s", c.RandomString)),
 		GroupMembershipClaims: &[]msgraph.GroupMembershipClaim{"SecurityGroup", "ApplicationGroup"},
 	})
 	testApplicationsClient_Delete(t, c, *app.ID)
 }
 
-func testApplicationsClient_Create(t *testing.T, c ApplicationsClientTest, a msgraph.Application) (application *msgraph.Application) {
-	application, status, err := c.client.Create(c.connection.Context, a)
+func testApplicationsClient_Create(t *testing.T, c *test.Test, a msgraph.Application) (application *msgraph.Application) {
+	application, status, err := c.ApplicationsClient.Create(c.Connection.Context, a)
 	if err != nil {
 		t.Fatalf("ApplicationsClient.Create(): %v", err)
 	}
@@ -139,8 +101,8 @@ func testApplicationsClient_Create(t *testing.T, c ApplicationsClientTest, a msg
 	return
 }
 
-func testApplicationsClient_Update(t *testing.T, c ApplicationsClientTest, a msgraph.Application) {
-	status, err := c.client.Update(c.connection.Context, a)
+func testApplicationsClient_Update(t *testing.T, c *test.Test, a msgraph.Application) {
+	status, err := c.ApplicationsClient.Update(c.Connection.Context, a)
 	if err != nil {
 		t.Fatalf("ApplicationsClient.Update(): %v", err)
 	}
@@ -149,8 +111,8 @@ func testApplicationsClient_Update(t *testing.T, c ApplicationsClientTest, a msg
 	}
 }
 
-func testApplicationsClient_List(t *testing.T, c ApplicationsClientTest) (applications *[]msgraph.Application) {
-	applications, _, err := c.client.List(c.connection.Context, odata.Query{})
+func testApplicationsClient_List(t *testing.T, c *test.Test) (applications *[]msgraph.Application) {
+	applications, _, err := c.ApplicationsClient.List(c.Connection.Context, odata.Query{})
 	if err != nil {
 		t.Fatalf("ApplicationsClient.List(): %v", err)
 	}
@@ -160,8 +122,8 @@ func testApplicationsClient_List(t *testing.T, c ApplicationsClientTest) (applic
 	return
 }
 
-func testApplicationsClient_Get(t *testing.T, c ApplicationsClientTest, id string) (application *msgraph.Application) {
-	application, status, err := c.client.Get(c.connection.Context, id, odata.Query{})
+func testApplicationsClient_Get(t *testing.T, c *test.Test, id string) (application *msgraph.Application) {
+	application, status, err := c.ApplicationsClient.Get(c.Connection.Context, id, odata.Query{})
 	if err != nil {
 		t.Fatalf("ApplicationsClient.Get(): %v", err)
 	}
@@ -174,8 +136,8 @@ func testApplicationsClient_Get(t *testing.T, c ApplicationsClientTest, id strin
 	return
 }
 
-func testApplicationsClient_CreateExtension(t *testing.T, c ApplicationsClientTest, applicationExtension msgraph.ApplicationExtension, id string) string {
-	extension, status, err := c.client.CreateExtension(c.connection.Context, applicationExtension, id)
+func testApplicationsClient_CreateExtension(t *testing.T, c *test.Test, applicationExtension msgraph.ApplicationExtension, id string) string {
+	extension, status, err := c.ApplicationsClient.CreateExtension(c.Connection.Context, applicationExtension, id)
 	if err != nil {
 		t.Fatalf("ApplicationsClient.CreateExtension(): %v", err)
 	}
@@ -191,8 +153,8 @@ func testApplicationsClient_CreateExtension(t *testing.T, c ApplicationsClientTe
 	return *extension.Id
 }
 
-func testApplicationsClient_ListExtension(t *testing.T, c ApplicationsClientTest, id string) {
-	extension, status, err := c.client.ListExtensions(c.connection.Context, id, odata.Query{})
+func testApplicationsClient_ListExtension(t *testing.T, c *test.Test, id string) {
+	extension, status, err := c.ApplicationsClient.ListExtensions(c.Connection.Context, id, odata.Query{})
 	if err != nil {
 		t.Fatalf("ApplicationsClient.ListExtensions(): %v", err)
 	}
@@ -204,8 +166,8 @@ func testApplicationsClient_ListExtension(t *testing.T, c ApplicationsClientTest
 	}
 }
 
-func testApplicationsClient_DeleteExtension(t *testing.T, c ApplicationsClientTest, extensionId, id string) {
-	status, err := c.client.DeleteExtension(c.connection.Context, id, extensionId)
+func testApplicationsClient_DeleteExtension(t *testing.T, c *test.Test, extensionId, id string) {
+	status, err := c.ApplicationsClient.DeleteExtension(c.Connection.Context, id, extensionId)
 	if err != nil {
 		t.Fatalf("ApplicationsClient.DeleteExtension(): %v", err)
 	}
@@ -214,8 +176,8 @@ func testApplicationsClient_DeleteExtension(t *testing.T, c ApplicationsClientTe
 	}
 }
 
-func testApplicationsClient_GetDeleted(t *testing.T, c ApplicationsClientTest, id string) (application *msgraph.Application) {
-	application, status, err := c.client.GetDeleted(c.connection.Context, id, odata.Query{})
+func testApplicationsClient_GetDeleted(t *testing.T, c *test.Test, id string) (application *msgraph.Application) {
+	application, status, err := c.ApplicationsClient.GetDeleted(c.Connection.Context, id, odata.Query{})
 	if err != nil {
 		t.Fatalf("ApplicationsClient.GetDeleted(): %v", err)
 	}
@@ -228,8 +190,8 @@ func testApplicationsClient_GetDeleted(t *testing.T, c ApplicationsClientTest, i
 	return
 }
 
-func testApplicationsClient_Delete(t *testing.T, c ApplicationsClientTest, id string) {
-	status, err := c.client.Delete(c.connection.Context, id)
+func testApplicationsClient_Delete(t *testing.T, c *test.Test, id string) {
+	status, err := c.ApplicationsClient.Delete(c.Connection.Context, id)
 	if err != nil {
 		t.Fatalf("ApplicationsClient.Delete(): %v", err)
 	}
@@ -238,8 +200,8 @@ func testApplicationsClient_Delete(t *testing.T, c ApplicationsClientTest, id st
 	}
 }
 
-func testApplicationsClient_DeletePermanently(t *testing.T, c ApplicationsClientTest, id string) {
-	status, err := c.client.DeletePermanently(c.connection.Context, id)
+func testApplicationsClient_DeletePermanently(t *testing.T, c *test.Test, id string) {
+	status, err := c.ApplicationsClient.DeletePermanently(c.Connection.Context, id)
 	if err != nil {
 		t.Fatalf("ApplicationsClient.DeletePermanently(): %v", err)
 	}
@@ -248,8 +210,8 @@ func testApplicationsClient_DeletePermanently(t *testing.T, c ApplicationsClient
 	}
 }
 
-func testApplicationsClient_RestoreDeleted(t *testing.T, c ApplicationsClientTest, id string) {
-	application, status, err := c.client.RestoreDeleted(c.connection.Context, id)
+func testApplicationsClient_RestoreDeleted(t *testing.T, c *test.Test, id string) {
+	application, status, err := c.ApplicationsClient.RestoreDeleted(c.Connection.Context, id)
 	if err != nil {
 		t.Fatalf("ApplicationsClient.RestoreDeleted(): %v", err)
 	}
@@ -267,8 +229,8 @@ func testApplicationsClient_RestoreDeleted(t *testing.T, c ApplicationsClientTes
 	}
 }
 
-func testApplicationsClient_ListOwners(t *testing.T, c ApplicationsClientTest, id string) (owners *[]string) {
-	owners, status, err := c.client.ListOwners(c.connection.Context, id)
+func testApplicationsClient_ListOwners(t *testing.T, c *test.Test, id string) (owners *[]string) {
+	owners, status, err := c.ApplicationsClient.ListOwners(c.Connection.Context, id)
 	if err != nil {
 		t.Fatalf("ApplicationsClient.ListOwners(): %v", err)
 	}
@@ -284,8 +246,8 @@ func testApplicationsClient_ListOwners(t *testing.T, c ApplicationsClientTest, i
 	return
 }
 
-func testApplicationsClient_GetOwner(t *testing.T, c ApplicationsClientTest, appId string, ownerId string) (owner *string) {
-	owner, status, err := c.client.GetOwner(c.connection.Context, appId, ownerId)
+func testApplicationsClient_GetOwner(t *testing.T, c *test.Test, appId string, ownerId string) (owner *string) {
+	owner, status, err := c.ApplicationsClient.GetOwner(c.Connection.Context, appId, ownerId)
 	if err != nil {
 		t.Fatalf("ApplicationsClient.GetOwner(): %v", err)
 	}
@@ -298,8 +260,8 @@ func testApplicationsClient_GetOwner(t *testing.T, c ApplicationsClientTest, app
 	return
 }
 
-func testApplicationsClient_AddOwners(t *testing.T, c ApplicationsClientTest, a *msgraph.Application) {
-	status, err := c.client.AddOwners(c.connection.Context, a)
+func testApplicationsClient_AddOwners(t *testing.T, c *test.Test, a *msgraph.Application) {
+	status, err := c.ApplicationsClient.AddOwners(c.Connection.Context, a)
 	if err != nil {
 		t.Fatalf("ApplicationsClient.AddOwners(): %v", err)
 	}
@@ -308,8 +270,8 @@ func testApplicationsClient_AddOwners(t *testing.T, c ApplicationsClientTest, a 
 	}
 }
 
-func testApplicationsClient_RemoveOwners(t *testing.T, c ApplicationsClientTest, appId string, ownerIds *[]string) {
-	status, err := c.client.RemoveOwners(c.connection.Context, appId, ownerIds)
+func testApplicationsClient_RemoveOwners(t *testing.T, c *test.Test, appId string, ownerIds *[]string) {
+	status, err := c.ApplicationsClient.RemoveOwners(c.Connection.Context, appId, ownerIds)
 	if err != nil {
 		t.Fatalf("ApplicationsClient.RemoveOwners(): %v", err)
 	}
@@ -318,11 +280,11 @@ func testApplicationsClient_RemoveOwners(t *testing.T, c ApplicationsClientTest,
 	}
 }
 
-func testApplicationsClient_AddPassword(t *testing.T, c ApplicationsClientTest, a *msgraph.Application) *msgraph.PasswordCredential {
+func testApplicationsClient_AddPassword(t *testing.T, c *test.Test, a *msgraph.Application) *msgraph.PasswordCredential {
 	pwd := msgraph.PasswordCredential{
 		DisplayName: utils.StringPtr("test password"),
 	}
-	newPwd, status, err := c.client.AddPassword(c.connection.Context, *a.ID, pwd)
+	newPwd, status, err := c.ApplicationsClient.AddPassword(c.Connection.Context, *a.ID, pwd)
 	if err != nil {
 		t.Fatalf("ApplicationsClient.AddPassword(): %v", err)
 	}
@@ -338,8 +300,8 @@ func testApplicationsClient_AddPassword(t *testing.T, c ApplicationsClientTest, 
 	return newPwd
 }
 
-func testApplicationsClient_RemovePassword(t *testing.T, c ApplicationsClientTest, a *msgraph.Application, p *msgraph.PasswordCredential) {
-	status, err := c.client.RemovePassword(c.connection.Context, *a.ID, *p.KeyId)
+func testApplicationsClient_RemovePassword(t *testing.T, c *test.Test, a *msgraph.Application, p *msgraph.PasswordCredential) {
+	status, err := c.ApplicationsClient.RemovePassword(c.Connection.Context, *a.ID, *p.KeyId)
 	if err != nil {
 		t.Fatalf("ApplicationsClient.RemovePassword(): %v", err)
 	}
@@ -348,8 +310,8 @@ func testApplicationsClient_RemovePassword(t *testing.T, c ApplicationsClientTes
 	}
 }
 
-func testApplicationsClient_ListDeleted(t *testing.T, c ApplicationsClientTest, expectedId string) (deletedApps *[]msgraph.Application) {
-	deletedApps, status, err := c.client.ListDeleted(c.connection.Context, odata.Query{
+func testApplicationsClient_ListDeleted(t *testing.T, c *test.Test, expectedId string) (deletedApps *[]msgraph.Application) {
+	deletedApps, status, err := c.ApplicationsClient.ListDeleted(c.Connection.Context, odata.Query{
 		Filter: fmt.Sprintf("id eq '%s'", expectedId),
 		Top:    10,
 	})
@@ -378,12 +340,12 @@ func testApplicationsClient_ListDeleted(t *testing.T, c ApplicationsClientTest, 
 	return
 }
 
-func testApplicationsClient_UploadLogo(t *testing.T, c ApplicationsClientTest, a *msgraph.Application) {
+func testApplicationsClient_UploadLogo(t *testing.T, c *test.Test, a *msgraph.Application) {
 	b, err := os.ReadFile(filepath.Join("..", "internal", "test", "testlogo.png"))
 	if err != nil {
 		t.Fatalf("reading testlogo.png: %v", err)
 	}
-	status, err := c.client.UploadLogo(c.connection.Context, *a.ID, "image/png", b)
+	status, err := c.ApplicationsClient.UploadLogo(c.Connection.Context, *a.ID, "image/png", b)
 	if err != nil {
 		t.Fatalf("ApplicationsClient.UploadLogo(): %v", err)
 	}

--- a/msgraph/authentication_methods.go
+++ b/msgraph/authentication_methods.go
@@ -407,8 +407,9 @@ func (c *AuthenticationMethodsClient) CreateTemporaryAccessPassMethod(ctx contex
 	}
 
 	resp, status, _, err := c.BaseClient.Post(ctx, PostHttpRequestInput{
-		Body:             body,
-		ValidStatusCodes: []int{http.StatusCreated},
+		Body:                   body,
+		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
+		ValidStatusCodes:       []int{http.StatusCreated},
 		Uri: Uri{
 			Entity:      fmt.Sprintf("/users/%s/authentication/temporaryAccessPassMethods", userID),
 			HasTenantId: true,
@@ -515,8 +516,9 @@ func (c *AuthenticationMethodsClient) CreatePhoneMethod(ctx context.Context, use
 	}
 
 	resp, status, _, err := c.BaseClient.Post(ctx, PostHttpRequestInput{
-		Body:             body,
-		ValidStatusCodes: []int{http.StatusCreated},
+		Body:                   body,
+		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
+		ValidStatusCodes:       []int{http.StatusCreated},
 		Uri: Uri{
 			Entity:      fmt.Sprintf("/users/%s/authentication/phoneMethods", userID),
 			HasTenantId: true,
@@ -731,8 +733,9 @@ func (c *AuthenticationMethodsClient) CreateEmailMethod(ctx context.Context, use
 	}
 
 	resp, status, _, err := c.BaseClient.Post(ctx, PostHttpRequestInput{
-		Body:             body,
-		ValidStatusCodes: []int{http.StatusCreated},
+		Body:                   body,
+		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
+		ValidStatusCodes:       []int{http.StatusCreated},
 		Uri: Uri{
 			Entity:      fmt.Sprintf("/users/%s/authentication/emailMethods", userID),
 			HasTenantId: true,

--- a/msgraph/authentication_methods_test.go
+++ b/msgraph/authentication_methods_test.go
@@ -12,7 +12,8 @@ import (
 )
 
 func TestAuthenticationMethodsClient(t *testing.T) {
-	c := test.NewTest()
+	c := test.NewTest(t)
+	defer c.CancelFunc()
 
 	user := testUsersClient_Create(t, c, msgraph.User{
 		AccountEnabled:    utils.BoolPtr(true),
@@ -51,7 +52,7 @@ func TestAuthenticationMethodsClient(t *testing.T) {
 }
 
 func testAuthMethods_List(t *testing.T, c *test.Test, userID string) (authMethods *[]msgraph.AuthenticationMethod) {
-	authMethods, status, err := c.AuthenticationMethodsClient.List(c.Connection.Context, userID, odata.Query{})
+	authMethods, status, err := c.AuthenticationMethodsClient.List(c.Context, userID, odata.Query{})
 	if status < 200 || status >= 300 {
 		t.Fatalf("AuthenticationMethodsClientTest.List(): invalid status: %d", status)
 	}
@@ -67,7 +68,7 @@ func testAuthMethods_List(t *testing.T, c *test.Test, userID string) (authMethod
 }
 
 func testAuthMethods_ListFido2Methods(t *testing.T, c *test.Test, userID string) (fido2Methods *[]msgraph.Fido2AuthenticationMethod) {
-	fido2Methods, status, err := c.AuthenticationMethodsClient.ListFido2Methods(c.Connection.Context, userID, odata.Query{})
+	fido2Methods, status, err := c.AuthenticationMethodsClient.ListFido2Methods(c.Context, userID, odata.Query{})
 	if status < 200 || status >= 300 {
 		t.Fatalf("AuthenticationMethodsClientTest.ListFido2Methods(): invalid status: %d", status)
 	}
@@ -83,7 +84,7 @@ func testAuthMethods_ListFido2Methods(t *testing.T, c *test.Test, userID string)
 }
 
 func testAuthMethods_ListMicrosoftAuthenticatorMethods(t *testing.T, c *test.Test, userID string) (msAuthMethods *[]msgraph.MicrosoftAuthenticatorAuthenticationMethod) {
-	msAuthMethods, status, err := c.AuthenticationMethodsClient.ListMicrosoftAuthenticatorMethods(c.Connection.Context, userID, odata.Query{})
+	msAuthMethods, status, err := c.AuthenticationMethodsClient.ListMicrosoftAuthenticatorMethods(c.Context, userID, odata.Query{})
 	if status < 200 || status >= 300 {
 		t.Fatalf("AuthenticationMethodsClientTest.ListMicrosoftAuthenticatorMethods(): invalid status: %d", status)
 	}
@@ -99,7 +100,7 @@ func testAuthMethods_ListMicrosoftAuthenticatorMethods(t *testing.T, c *test.Tes
 }
 
 func testAuthMethods_ListWindowsHelloMethods(t *testing.T, c *test.Test, userID string) (windowsHelloMethods *[]msgraph.WindowsHelloForBusinessAuthenticationMethod) {
-	windowsHelloMethods, status, err := c.AuthenticationMethodsClient.ListWindowsHelloMethods(c.Connection.Context, userID, odata.Query{})
+	windowsHelloMethods, status, err := c.AuthenticationMethodsClient.ListWindowsHelloMethods(c.Context, userID, odata.Query{})
 	if status < 200 || status >= 300 {
 		t.Fatalf("AuthenticationMethodsClientTest.ListWindowsHelloMethods(): invalid status: %d", status)
 	}
@@ -123,7 +124,7 @@ func testAuthMethods_CreateTemporaryAccessPassMethod(t *testing.T, c *test.Test,
 		IsUsableOnce:      utils.BoolPtr(true),
 	}
 
-	tempAccessPass, status, err := c.AuthenticationMethodsClient.CreateTemporaryAccessPassMethod(c.Connection.Context, userID, tempPass)
+	tempAccessPass, status, err := c.AuthenticationMethodsClient.CreateTemporaryAccessPassMethod(c.Context, userID, tempPass)
 	if status < 200 || status >= 300 {
 		t.Fatalf("AuthenticationMethodsClientTest.CreateTemporaryAccessPassMethod(): invalid status: %d", status)
 	}
@@ -139,7 +140,7 @@ func testAuthMethods_CreateTemporaryAccessPassMethod(t *testing.T, c *test.Test,
 }
 
 func testAuthMethods_GetTemporaryAccessPassMethod(t *testing.T, c *test.Test, userID, ID string) (tempAccessPass *msgraph.TemporaryAccessPassAuthenticationMethod) {
-	tempAccessPass, status, err := c.AuthenticationMethodsClient.GetTemporaryAccessPassMethod(c.Connection.Context, userID, ID, odata.Query{})
+	tempAccessPass, status, err := c.AuthenticationMethodsClient.GetTemporaryAccessPassMethod(c.Context, userID, ID, odata.Query{})
 	if status < 200 || status >= 300 {
 		t.Fatalf("AuthenticationMethodsClientTest.GetTemporaryAccessPassMethod(): invalid status: %d", status)
 	}
@@ -155,7 +156,7 @@ func testAuthMethods_GetTemporaryAccessPassMethod(t *testing.T, c *test.Test, us
 }
 
 func testAuthMethods_ListTemporaryAccessPassMethods(t *testing.T, c *test.Test, userID string) (tempAccessPasses *[]msgraph.TemporaryAccessPassAuthenticationMethod) {
-	tempAccessPasses, status, err := c.AuthenticationMethodsClient.ListTemporaryAccessPassMethods(c.Connection.Context, userID, odata.Query{})
+	tempAccessPasses, status, err := c.AuthenticationMethodsClient.ListTemporaryAccessPassMethods(c.Context, userID, odata.Query{})
 	if status < 200 || status >= 300 {
 		t.Fatalf("AuthenticationMethodsClientTest.ListTemporaryAccessPassMethod(): invalid status: %d", status)
 	}
@@ -172,7 +173,7 @@ func testAuthMethods_ListTemporaryAccessPassMethods(t *testing.T, c *test.Test, 
 
 func testAuthMethods_DeleteTemporaryAccessPassMethod(t *testing.T, c *test.Test, userID, ID string) {
 
-	status, err := c.AuthenticationMethodsClient.DeleteTemporaryAccessPassMethod(c.Connection.Context, userID, ID)
+	status, err := c.AuthenticationMethodsClient.DeleteTemporaryAccessPassMethod(c.Context, userID, ID)
 	if status < 200 || status >= 300 {
 		t.Fatalf("AuthenticationMethodsClientTest.DeleteTemporaryAccessPassMethod(): invalid status: %d", status)
 	}
@@ -188,7 +189,7 @@ func testAuthMethods_CreatePhoneMethod(t *testing.T, c *test.Test, userID string
 		PhoneNumber: utils.StringPtr("+44 07777777777"),
 		PhoneType:   &phoneType,
 	}
-	phoneAuthMethod, status, err := c.AuthenticationMethodsClient.CreatePhoneMethod(c.Connection.Context, userID, phoneAuth)
+	phoneAuthMethod, status, err := c.AuthenticationMethodsClient.CreatePhoneMethod(c.Context, userID, phoneAuth)
 	if status < 200 || status >= 300 {
 		t.Fatalf("AuthenticationMethodsClientTest.CreatePhoneMethod(): invalid status: %d", status)
 	}
@@ -204,7 +205,7 @@ func testAuthMethods_CreatePhoneMethod(t *testing.T, c *test.Test, userID string
 }
 
 func testAuthMethods_GetPhoneMethod(t *testing.T, c *test.Test, userID, ID string) (phoneAuthMethod *msgraph.PhoneAuthenticationMethod) {
-	phoneAuthMethod, status, err := c.AuthenticationMethodsClient.GetPhoneMethod(c.Connection.Context, userID, ID, odata.Query{})
+	phoneAuthMethod, status, err := c.AuthenticationMethodsClient.GetPhoneMethod(c.Context, userID, ID, odata.Query{})
 	if status < 200 || status >= 300 {
 		t.Fatalf("AuthenticationMethodsClientTest.GetPhoneMethod(): invalid status: %d", status)
 	}
@@ -220,7 +221,7 @@ func testAuthMethods_GetPhoneMethod(t *testing.T, c *test.Test, userID, ID strin
 }
 
 func testAuthMethods_ListPhoneMethods(t *testing.T, c *test.Test, userID string) (phoneAuthMethods *[]msgraph.PhoneAuthenticationMethod) {
-	phoneAuthMethods, status, err := c.AuthenticationMethodsClient.ListPhoneMethods(c.Connection.Context, userID, odata.Query{})
+	phoneAuthMethods, status, err := c.AuthenticationMethodsClient.ListPhoneMethods(c.Context, userID, odata.Query{})
 	if status < 200 || status >= 300 {
 		t.Fatalf("AuthenticationMethodsClientTest.ListPhoneMethods(): invalid status: %d", status)
 	}
@@ -236,7 +237,7 @@ func testAuthMethods_ListPhoneMethods(t *testing.T, c *test.Test, userID string)
 }
 
 func testAuthMethods_UpdatePhoneMethod(t *testing.T, c *test.Test, userID string, phone msgraph.PhoneAuthenticationMethod) {
-	status, err := c.AuthenticationMethodsClient.UpdatePhoneMethod(c.Connection.Context, userID, phone)
+	status, err := c.AuthenticationMethodsClient.UpdatePhoneMethod(c.Context, userID, phone)
 	if status < 200 || status >= 300 {
 		t.Fatalf("AuthenticationMethodsClientTest.UpdatePhoneMethod(): invalid status: %d", status)
 	}
@@ -247,7 +248,7 @@ func testAuthMethods_UpdatePhoneMethod(t *testing.T, c *test.Test, userID string
 }
 
 func testAuthMethods_EnablePhoneSMS(t *testing.T, c *test.Test, userID, ID string) {
-	status, err := c.AuthenticationMethodsClient.EnablePhoneSMS(c.Connection.Context, userID, ID)
+	status, err := c.AuthenticationMethodsClient.EnablePhoneSMS(c.Context, userID, ID)
 	if status < 200 || status >= 300 {
 		t.Fatalf("AuthenticationMethodsClientTest.EnablePhoneSMS(): invalid status: %d", status)
 	}
@@ -258,7 +259,7 @@ func testAuthMethods_EnablePhoneSMS(t *testing.T, c *test.Test, userID, ID strin
 }
 
 func testAuthMethods_DisablePhoneSMS(t *testing.T, c *test.Test, userID, ID string) {
-	status, err := c.AuthenticationMethodsClient.DisablePhoneSMS(c.Connection.Context, userID, ID)
+	status, err := c.AuthenticationMethodsClient.DisablePhoneSMS(c.Context, userID, ID)
 	if status < 200 || status >= 300 {
 		t.Fatalf("AuthenticationMethodsClientTest.DisablePhoneSMS(): invalid status: %d", status)
 	}
@@ -269,7 +270,7 @@ func testAuthMethods_DisablePhoneSMS(t *testing.T, c *test.Test, userID, ID stri
 }
 
 func testAuthMethods_DeletePhoneMethod(t *testing.T, c *test.Test, userID, ID string) {
-	status, err := c.AuthenticationMethodsClient.DeletePhoneMethod(c.Connection.Context, userID, ID)
+	status, err := c.AuthenticationMethodsClient.DeletePhoneMethod(c.Context, userID, ID)
 	if status < 200 || status >= 300 {
 		t.Fatalf("AuthenticationMethodsClientTest.DeletePhoneMethod(): invalid status: %d", status)
 	}
@@ -283,7 +284,7 @@ func testAuthMethods_CreateEmailMethod(t *testing.T, c *test.Test, userID string
 	email := msgraph.EmailAuthenticationMethod{
 		EmailAddress: utils.StringPtr("test-user-authenticationmethods@testdomain.com"),
 	}
-	emailMethod, status, err := c.AuthenticationMethodsClient.CreateEmailMethod(c.Connection.Context, userID, email)
+	emailMethod, status, err := c.AuthenticationMethodsClient.CreateEmailMethod(c.Context, userID, email)
 	if status < 200 || status >= 300 {
 		t.Fatalf("AuthenticationMethodsClientTest.CreateEmailMethod(): invalid status: %d", status)
 	}
@@ -299,7 +300,7 @@ func testAuthMethods_CreateEmailMethod(t *testing.T, c *test.Test, userID string
 }
 
 func testAuthMethods_GetEmailMethod(t *testing.T, c *test.Test, userID, ID string) (emailMethod *msgraph.EmailAuthenticationMethod) {
-	emailMethod, status, err := c.AuthenticationMethodsClient.GetEmailMethod(c.Connection.Context, userID, ID, odata.Query{})
+	emailMethod, status, err := c.AuthenticationMethodsClient.GetEmailMethod(c.Context, userID, ID, odata.Query{})
 	if status < 200 || status >= 300 {
 		t.Fatalf("AuthenticationMethodsClientTest.GetEmailMethod(): invalid status: %d", status)
 	}
@@ -315,7 +316,7 @@ func testAuthMethods_GetEmailMethod(t *testing.T, c *test.Test, userID, ID strin
 }
 
 func testAuthMethods_ListEmailMethods(t *testing.T, c *test.Test, userID string) (emailMethods *[]msgraph.EmailAuthenticationMethod) {
-	emailMethods, status, err := c.AuthenticationMethodsClient.ListEmailMethods(c.Connection.Context, userID, odata.Query{})
+	emailMethods, status, err := c.AuthenticationMethodsClient.ListEmailMethods(c.Context, userID, odata.Query{})
 	if status < 200 || status >= 300 {
 		t.Fatalf("AuthenticationMethodsClientTest.ListEmailMethods(): invalid status: %d", status)
 	}
@@ -331,7 +332,7 @@ func testAuthMethods_ListEmailMethods(t *testing.T, c *test.Test, userID string)
 }
 
 func testAuthMethods_UpdateEmailMethod(t *testing.T, c *test.Test, userID string, email msgraph.EmailAuthenticationMethod) {
-	status, err := c.AuthenticationMethodsClient.UpdateEmailMethod(c.Connection.Context, userID, email)
+	status, err := c.AuthenticationMethodsClient.UpdateEmailMethod(c.Context, userID, email)
 	if status < 200 || status >= 300 {
 		t.Fatalf("AuthenticationMethodsClientTest.UpdateEmailMethod(): invalid status: %d", status)
 	}
@@ -342,7 +343,7 @@ func testAuthMethods_UpdateEmailMethod(t *testing.T, c *test.Test, userID string
 }
 
 func testAuthMethods_DeleteEmailMethod(t *testing.T, c *test.Test, userID, ID string) {
-	status, err := c.AuthenticationMethodsClient.DeleteEmailMethod(c.Connection.Context, userID, ID)
+	status, err := c.AuthenticationMethodsClient.DeleteEmailMethod(c.Context, userID, ID)
 	if status < 200 || status >= 300 {
 		t.Fatalf("AuthenticationMethodsClientTest.DeleteEmailMethod(): invalid status: %d", status)
 	}
@@ -353,7 +354,7 @@ func testAuthMethods_DeleteEmailMethod(t *testing.T, c *test.Test, userID, ID st
 }
 
 func testAuthMetods_ListPasswordMethods(t *testing.T, c *test.Test, userID string) (passwordMethods *[]msgraph.PasswordAuthenticationMethod) {
-	passwordMethods, status, err := c.AuthenticationMethodsClient.ListPasswordMethods(c.Connection.Context, userID, odata.Query{})
+	passwordMethods, status, err := c.AuthenticationMethodsClient.ListPasswordMethods(c.Context, userID, odata.Query{})
 	if status < 200 || status >= 300 {
 		t.Fatalf("AuthenticationMethodsClientTest.ListPasswordMethods(): invalid status: %d", status)
 	}

--- a/msgraph/authentication_methods_test.go
+++ b/msgraph/authentication_methods_test.go
@@ -5,46 +5,22 @@ import (
 	"testing"
 	"time"
 
-	"github.com/manicminer/hamilton/auth"
 	"github.com/manicminer/hamilton/internal/test"
 	"github.com/manicminer/hamilton/internal/utils"
 	"github.com/manicminer/hamilton/msgraph"
 	"github.com/manicminer/hamilton/odata"
 )
 
-type AuthenticationMethodsClientTest struct {
-	connection   *test.Connection
-	client       *msgraph.AuthenticationMethodsClient
-	randomString string
-}
-
 func TestAuthenticationMethodsClient(t *testing.T) {
-	rs := test.RandomString()
-	c := AuthenticationMethodsClientTest{
-		connection:   test.NewConnection(auth.MsGraph, auth.TokenVersion2),
-		randomString: rs,
-	}
+	c := test.NewTest()
 
-	c.client = msgraph.NewAuthenticationMethodsClient(c.connection.AuthConfig.TenantID)
-	c.client.BaseClient.Authorizer = c.connection.Authorizer
-	c.client.BaseClient.Endpoint = c.connection.AuthConfig.Environment.MsGraph.Endpoint
-
-	u := UsersClientTest{
-		connection:   test.NewConnection(auth.MsGraph, auth.TokenVersion2),
-		randomString: rs,
-	}
-
-	u.client = msgraph.NewUsersClient(u.connection.AuthConfig.TenantID)
-	u.client.BaseClient.Authorizer = u.connection.Authorizer
-	u.client.BaseClient.Endpoint = u.connection.AuthConfig.Environment.MsGraph.Endpoint
-
-	user := testUsersClient_Create(t, u, msgraph.User{
+	user := testUsersClient_Create(t, c, msgraph.User{
 		AccountEnabled:    utils.BoolPtr(true),
 		DisplayName:       utils.StringPtr("test-user-authenticationmethods"),
-		MailNickname:      utils.StringPtr(fmt.Sprintf("test-user-authenticationmethods-%s", c.randomString)),
-		UserPrincipalName: utils.StringPtr(fmt.Sprintf("test-user-authenticationmethods-%s@%s", c.randomString, c.connection.DomainName)),
+		MailNickname:      utils.StringPtr(fmt.Sprintf("test-user-authenticationmethods-%s", c.RandomString)),
+		UserPrincipalName: utils.StringPtr(fmt.Sprintf("test-user-authenticationmethods-%s@%s", c.RandomString, c.Connection.DomainName)),
 		PasswordProfile: &msgraph.UserPasswordProfile{
-			Password: utils.StringPtr(fmt.Sprintf("IrPa55w0rd%s", c.randomString)),
+			Password: utils.StringPtr(fmt.Sprintf("IrPa55w0rd%s", c.RandomString)),
 		},
 	})
 
@@ -71,11 +47,11 @@ func TestAuthenticationMethodsClient(t *testing.T) {
 	testAuthMethods_UpdateEmailMethod(t, c, *user.ID, *emailAuthMethod)
 	testAuthMethods_DeleteEmailMethod(t, c, *user.ID, *emailAuthMethod.ID)
 	_ = testAuthMetods_ListPasswordMethods(t, c, *user.ID)
-	testUsersClient_Delete(t, u, *user.ID)
+	testUsersClient_Delete(t, c, *user.ID)
 }
 
-func testAuthMethods_List(t *testing.T, c AuthenticationMethodsClientTest, userID string) (authMethods *[]msgraph.AuthenticationMethod) {
-	authMethods, status, err := c.client.List(c.connection.Context, userID, odata.Query{})
+func testAuthMethods_List(t *testing.T, c *test.Test, userID string) (authMethods *[]msgraph.AuthenticationMethod) {
+	authMethods, status, err := c.AuthenticationMethodsClient.List(c.Connection.Context, userID, odata.Query{})
 	if status < 200 || status >= 300 {
 		t.Fatalf("AuthenticationMethodsClientTest.List(): invalid status: %d", status)
 	}
@@ -90,8 +66,8 @@ func testAuthMethods_List(t *testing.T, c AuthenticationMethodsClientTest, userI
 	return
 }
 
-func testAuthMethods_ListFido2Methods(t *testing.T, c AuthenticationMethodsClientTest, userID string) (fido2Methods *[]msgraph.Fido2AuthenticationMethod) {
-	fido2Methods, status, err := c.client.ListFido2Methods(c.connection.Context, userID, odata.Query{})
+func testAuthMethods_ListFido2Methods(t *testing.T, c *test.Test, userID string) (fido2Methods *[]msgraph.Fido2AuthenticationMethod) {
+	fido2Methods, status, err := c.AuthenticationMethodsClient.ListFido2Methods(c.Connection.Context, userID, odata.Query{})
 	if status < 200 || status >= 300 {
 		t.Fatalf("AuthenticationMethodsClientTest.ListFido2Methods(): invalid status: %d", status)
 	}
@@ -106,8 +82,8 @@ func testAuthMethods_ListFido2Methods(t *testing.T, c AuthenticationMethodsClien
 	return
 }
 
-func testAuthMethods_ListMicrosoftAuthenticatorMethods(t *testing.T, c AuthenticationMethodsClientTest, userID string) (msAuthMethods *[]msgraph.MicrosoftAuthenticatorAuthenticationMethod) {
-	msAuthMethods, status, err := c.client.ListMicrosoftAuthenticatorMethods(c.connection.Context, userID, odata.Query{})
+func testAuthMethods_ListMicrosoftAuthenticatorMethods(t *testing.T, c *test.Test, userID string) (msAuthMethods *[]msgraph.MicrosoftAuthenticatorAuthenticationMethod) {
+	msAuthMethods, status, err := c.AuthenticationMethodsClient.ListMicrosoftAuthenticatorMethods(c.Connection.Context, userID, odata.Query{})
 	if status < 200 || status >= 300 {
 		t.Fatalf("AuthenticationMethodsClientTest.ListMicrosoftAuthenticatorMethods(): invalid status: %d", status)
 	}
@@ -122,8 +98,8 @@ func testAuthMethods_ListMicrosoftAuthenticatorMethods(t *testing.T, c Authentic
 	return
 }
 
-func testAuthMethods_ListWindowsHelloMethods(t *testing.T, c AuthenticationMethodsClientTest, userID string) (windowsHelloMethods *[]msgraph.WindowsHelloForBusinessAuthenticationMethod) {
-	windowsHelloMethods, status, err := c.client.ListWindowsHelloMethods(c.connection.Context, userID, odata.Query{})
+func testAuthMethods_ListWindowsHelloMethods(t *testing.T, c *test.Test, userID string) (windowsHelloMethods *[]msgraph.WindowsHelloForBusinessAuthenticationMethod) {
+	windowsHelloMethods, status, err := c.AuthenticationMethodsClient.ListWindowsHelloMethods(c.Connection.Context, userID, odata.Query{})
 	if status < 200 || status >= 300 {
 		t.Fatalf("AuthenticationMethodsClientTest.ListWindowsHelloMethods(): invalid status: %d", status)
 	}
@@ -138,7 +114,7 @@ func testAuthMethods_ListWindowsHelloMethods(t *testing.T, c AuthenticationMetho
 	return
 }
 
-func testAuthMethods_CreateTemporaryAccessPassMethod(t *testing.T, c AuthenticationMethodsClientTest, userID string) (tempAccessPass *msgraph.TemporaryAccessPassAuthenticationMethod) {
+func testAuthMethods_CreateTemporaryAccessPassMethod(t *testing.T, c *test.Test, userID string) (tempAccessPass *msgraph.TemporaryAccessPassAuthenticationMethod) {
 	startPassTime := time.Now().UTC()
 	startPassTime.AddDate(0, 0, 1)
 	tempPass := msgraph.TemporaryAccessPassAuthenticationMethod{
@@ -147,7 +123,7 @@ func testAuthMethods_CreateTemporaryAccessPassMethod(t *testing.T, c Authenticat
 		IsUsableOnce:      utils.BoolPtr(true),
 	}
 
-	tempAccessPass, status, err := c.client.CreateTemporaryAccessPassMethod(c.connection.Context, userID, tempPass)
+	tempAccessPass, status, err := c.AuthenticationMethodsClient.CreateTemporaryAccessPassMethod(c.Connection.Context, userID, tempPass)
 	if status < 200 || status >= 300 {
 		t.Fatalf("AuthenticationMethodsClientTest.CreateTemporaryAccessPassMethod(): invalid status: %d", status)
 	}
@@ -162,8 +138,8 @@ func testAuthMethods_CreateTemporaryAccessPassMethod(t *testing.T, c Authenticat
 	return
 }
 
-func testAuthMethods_GetTemporaryAccessPassMethod(t *testing.T, c AuthenticationMethodsClientTest, userID, ID string) (tempAccessPass *msgraph.TemporaryAccessPassAuthenticationMethod) {
-	tempAccessPass, status, err := c.client.GetTemporaryAccessPassMethod(c.connection.Context, userID, ID, odata.Query{})
+func testAuthMethods_GetTemporaryAccessPassMethod(t *testing.T, c *test.Test, userID, ID string) (tempAccessPass *msgraph.TemporaryAccessPassAuthenticationMethod) {
+	tempAccessPass, status, err := c.AuthenticationMethodsClient.GetTemporaryAccessPassMethod(c.Connection.Context, userID, ID, odata.Query{})
 	if status < 200 || status >= 300 {
 		t.Fatalf("AuthenticationMethodsClientTest.GetTemporaryAccessPassMethod(): invalid status: %d", status)
 	}
@@ -178,8 +154,8 @@ func testAuthMethods_GetTemporaryAccessPassMethod(t *testing.T, c Authentication
 	return
 }
 
-func testAuthMethods_ListTemporaryAccessPassMethods(t *testing.T, c AuthenticationMethodsClientTest, userID string) (tempAccessPasses *[]msgraph.TemporaryAccessPassAuthenticationMethod) {
-	tempAccessPasses, status, err := c.client.ListTemporaryAccessPassMethods(c.connection.Context, userID, odata.Query{})
+func testAuthMethods_ListTemporaryAccessPassMethods(t *testing.T, c *test.Test, userID string) (tempAccessPasses *[]msgraph.TemporaryAccessPassAuthenticationMethod) {
+	tempAccessPasses, status, err := c.AuthenticationMethodsClient.ListTemporaryAccessPassMethods(c.Connection.Context, userID, odata.Query{})
 	if status < 200 || status >= 300 {
 		t.Fatalf("AuthenticationMethodsClientTest.ListTemporaryAccessPassMethod(): invalid status: %d", status)
 	}
@@ -194,9 +170,9 @@ func testAuthMethods_ListTemporaryAccessPassMethods(t *testing.T, c Authenticati
 	return
 }
 
-func testAuthMethods_DeleteTemporaryAccessPassMethod(t *testing.T, c AuthenticationMethodsClientTest, userID, ID string) {
+func testAuthMethods_DeleteTemporaryAccessPassMethod(t *testing.T, c *test.Test, userID, ID string) {
 
-	status, err := c.client.DeleteTemporaryAccessPassMethod(c.connection.Context, userID, ID)
+	status, err := c.AuthenticationMethodsClient.DeleteTemporaryAccessPassMethod(c.Connection.Context, userID, ID)
 	if status < 200 || status >= 300 {
 		t.Fatalf("AuthenticationMethodsClientTest.DeleteTemporaryAccessPassMethod(): invalid status: %d", status)
 	}
@@ -206,13 +182,13 @@ func testAuthMethods_DeleteTemporaryAccessPassMethod(t *testing.T, c Authenticat
 	}
 }
 
-func testAuthMethods_CreatePhoneMethod(t *testing.T, c AuthenticationMethodsClientTest, userID string) (phoneAuthMethod *msgraph.PhoneAuthenticationMethod) {
+func testAuthMethods_CreatePhoneMethod(t *testing.T, c *test.Test, userID string) (phoneAuthMethod *msgraph.PhoneAuthenticationMethod) {
 	phoneType := msgraph.AuthenticationPhoneTypeMobile
 	phoneAuth := msgraph.PhoneAuthenticationMethod{
 		PhoneNumber: utils.StringPtr("+44 07777777777"),
 		PhoneType:   &phoneType,
 	}
-	phoneAuthMethod, status, err := c.client.CreatePhoneMethod(c.connection.Context, userID, phoneAuth)
+	phoneAuthMethod, status, err := c.AuthenticationMethodsClient.CreatePhoneMethod(c.Connection.Context, userID, phoneAuth)
 	if status < 200 || status >= 300 {
 		t.Fatalf("AuthenticationMethodsClientTest.CreatePhoneMethod(): invalid status: %d", status)
 	}
@@ -227,8 +203,8 @@ func testAuthMethods_CreatePhoneMethod(t *testing.T, c AuthenticationMethodsClie
 	return
 }
 
-func testAuthMethods_GetPhoneMethod(t *testing.T, c AuthenticationMethodsClientTest, userID, ID string) (phoneAuthMethod *msgraph.PhoneAuthenticationMethod) {
-	phoneAuthMethod, status, err := c.client.GetPhoneMethod(c.connection.Context, userID, ID, odata.Query{})
+func testAuthMethods_GetPhoneMethod(t *testing.T, c *test.Test, userID, ID string) (phoneAuthMethod *msgraph.PhoneAuthenticationMethod) {
+	phoneAuthMethod, status, err := c.AuthenticationMethodsClient.GetPhoneMethod(c.Connection.Context, userID, ID, odata.Query{})
 	if status < 200 || status >= 300 {
 		t.Fatalf("AuthenticationMethodsClientTest.GetPhoneMethod(): invalid status: %d", status)
 	}
@@ -243,8 +219,8 @@ func testAuthMethods_GetPhoneMethod(t *testing.T, c AuthenticationMethodsClientT
 	return
 }
 
-func testAuthMethods_ListPhoneMethods(t *testing.T, c AuthenticationMethodsClientTest, userID string) (phoneAuthMethods *[]msgraph.PhoneAuthenticationMethod) {
-	phoneAuthMethods, status, err := c.client.ListPhoneMethods(c.connection.Context, userID, odata.Query{})
+func testAuthMethods_ListPhoneMethods(t *testing.T, c *test.Test, userID string) (phoneAuthMethods *[]msgraph.PhoneAuthenticationMethod) {
+	phoneAuthMethods, status, err := c.AuthenticationMethodsClient.ListPhoneMethods(c.Connection.Context, userID, odata.Query{})
 	if status < 200 || status >= 300 {
 		t.Fatalf("AuthenticationMethodsClientTest.ListPhoneMethods(): invalid status: %d", status)
 	}
@@ -259,8 +235,8 @@ func testAuthMethods_ListPhoneMethods(t *testing.T, c AuthenticationMethodsClien
 	return
 }
 
-func testAuthMethods_UpdatePhoneMethod(t *testing.T, c AuthenticationMethodsClientTest, userID string, phone msgraph.PhoneAuthenticationMethod) {
-	status, err := c.client.UpdatePhoneMethod(c.connection.Context, userID, phone)
+func testAuthMethods_UpdatePhoneMethod(t *testing.T, c *test.Test, userID string, phone msgraph.PhoneAuthenticationMethod) {
+	status, err := c.AuthenticationMethodsClient.UpdatePhoneMethod(c.Connection.Context, userID, phone)
 	if status < 200 || status >= 300 {
 		t.Fatalf("AuthenticationMethodsClientTest.UpdatePhoneMethod(): invalid status: %d", status)
 	}
@@ -270,8 +246,8 @@ func testAuthMethods_UpdatePhoneMethod(t *testing.T, c AuthenticationMethodsClie
 	}
 }
 
-func testAuthMethods_EnablePhoneSMS(t *testing.T, c AuthenticationMethodsClientTest, userID, ID string) {
-	status, err := c.client.EnablePhoneSMS(c.connection.Context, userID, ID)
+func testAuthMethods_EnablePhoneSMS(t *testing.T, c *test.Test, userID, ID string) {
+	status, err := c.AuthenticationMethodsClient.EnablePhoneSMS(c.Connection.Context, userID, ID)
 	if status < 200 || status >= 300 {
 		t.Fatalf("AuthenticationMethodsClientTest.EnablePhoneSMS(): invalid status: %d", status)
 	}
@@ -281,8 +257,8 @@ func testAuthMethods_EnablePhoneSMS(t *testing.T, c AuthenticationMethodsClientT
 	}
 }
 
-func testAuthMethods_DisablePhoneSMS(t *testing.T, c AuthenticationMethodsClientTest, userID, ID string) {
-	status, err := c.client.DisablePhoneSMS(c.connection.Context, userID, ID)
+func testAuthMethods_DisablePhoneSMS(t *testing.T, c *test.Test, userID, ID string) {
+	status, err := c.AuthenticationMethodsClient.DisablePhoneSMS(c.Connection.Context, userID, ID)
 	if status < 200 || status >= 300 {
 		t.Fatalf("AuthenticationMethodsClientTest.DisablePhoneSMS(): invalid status: %d", status)
 	}
@@ -292,8 +268,8 @@ func testAuthMethods_DisablePhoneSMS(t *testing.T, c AuthenticationMethodsClient
 	}
 }
 
-func testAuthMethods_DeletePhoneMethod(t *testing.T, c AuthenticationMethodsClientTest, userID, ID string) {
-	status, err := c.client.DeletePhoneMethod(c.connection.Context, userID, ID)
+func testAuthMethods_DeletePhoneMethod(t *testing.T, c *test.Test, userID, ID string) {
+	status, err := c.AuthenticationMethodsClient.DeletePhoneMethod(c.Connection.Context, userID, ID)
 	if status < 200 || status >= 300 {
 		t.Fatalf("AuthenticationMethodsClientTest.DeletePhoneMethod(): invalid status: %d", status)
 	}
@@ -303,11 +279,11 @@ func testAuthMethods_DeletePhoneMethod(t *testing.T, c AuthenticationMethodsClie
 	}
 }
 
-func testAuthMethods_CreateEmailMethod(t *testing.T, c AuthenticationMethodsClientTest, userID string) (emailMethod *msgraph.EmailAuthenticationMethod) {
+func testAuthMethods_CreateEmailMethod(t *testing.T, c *test.Test, userID string) (emailMethod *msgraph.EmailAuthenticationMethod) {
 	email := msgraph.EmailAuthenticationMethod{
 		EmailAddress: utils.StringPtr("test-user-authenticationmethods@testdomain.com"),
 	}
-	emailMethod, status, err := c.client.CreateEmailMethod(c.connection.Context, userID, email)
+	emailMethod, status, err := c.AuthenticationMethodsClient.CreateEmailMethod(c.Connection.Context, userID, email)
 	if status < 200 || status >= 300 {
 		t.Fatalf("AuthenticationMethodsClientTest.CreateEmailMethod(): invalid status: %d", status)
 	}
@@ -322,8 +298,8 @@ func testAuthMethods_CreateEmailMethod(t *testing.T, c AuthenticationMethodsClie
 	return
 }
 
-func testAuthMethods_GetEmailMethod(t *testing.T, c AuthenticationMethodsClientTest, userID, ID string) (emailMethod *msgraph.EmailAuthenticationMethod) {
-	emailMethod, status, err := c.client.GetEmailMethod(c.connection.Context, userID, ID, odata.Query{})
+func testAuthMethods_GetEmailMethod(t *testing.T, c *test.Test, userID, ID string) (emailMethod *msgraph.EmailAuthenticationMethod) {
+	emailMethod, status, err := c.AuthenticationMethodsClient.GetEmailMethod(c.Connection.Context, userID, ID, odata.Query{})
 	if status < 200 || status >= 300 {
 		t.Fatalf("AuthenticationMethodsClientTest.GetEmailMethod(): invalid status: %d", status)
 	}
@@ -338,8 +314,8 @@ func testAuthMethods_GetEmailMethod(t *testing.T, c AuthenticationMethodsClientT
 	return
 }
 
-func testAuthMethods_ListEmailMethods(t *testing.T, c AuthenticationMethodsClientTest, userID string) (emailMethods *[]msgraph.EmailAuthenticationMethod) {
-	emailMethods, status, err := c.client.ListEmailMethods(c.connection.Context, userID, odata.Query{})
+func testAuthMethods_ListEmailMethods(t *testing.T, c *test.Test, userID string) (emailMethods *[]msgraph.EmailAuthenticationMethod) {
+	emailMethods, status, err := c.AuthenticationMethodsClient.ListEmailMethods(c.Connection.Context, userID, odata.Query{})
 	if status < 200 || status >= 300 {
 		t.Fatalf("AuthenticationMethodsClientTest.ListEmailMethods(): invalid status: %d", status)
 	}
@@ -354,8 +330,8 @@ func testAuthMethods_ListEmailMethods(t *testing.T, c AuthenticationMethodsClien
 	return
 }
 
-func testAuthMethods_UpdateEmailMethod(t *testing.T, c AuthenticationMethodsClientTest, userID string, email msgraph.EmailAuthenticationMethod) {
-	status, err := c.client.UpdateEmailMethod(c.connection.Context, userID, email)
+func testAuthMethods_UpdateEmailMethod(t *testing.T, c *test.Test, userID string, email msgraph.EmailAuthenticationMethod) {
+	status, err := c.AuthenticationMethodsClient.UpdateEmailMethod(c.Connection.Context, userID, email)
 	if status < 200 || status >= 300 {
 		t.Fatalf("AuthenticationMethodsClientTest.UpdateEmailMethod(): invalid status: %d", status)
 	}
@@ -365,8 +341,8 @@ func testAuthMethods_UpdateEmailMethod(t *testing.T, c AuthenticationMethodsClie
 	}
 }
 
-func testAuthMethods_DeleteEmailMethod(t *testing.T, c AuthenticationMethodsClientTest, userID, ID string) {
-	status, err := c.client.DeleteEmailMethod(c.connection.Context, userID, ID)
+func testAuthMethods_DeleteEmailMethod(t *testing.T, c *test.Test, userID, ID string) {
+	status, err := c.AuthenticationMethodsClient.DeleteEmailMethod(c.Connection.Context, userID, ID)
 	if status < 200 || status >= 300 {
 		t.Fatalf("AuthenticationMethodsClientTest.DeleteEmailMethod(): invalid status: %d", status)
 	}
@@ -376,8 +352,8 @@ func testAuthMethods_DeleteEmailMethod(t *testing.T, c AuthenticationMethodsClie
 	}
 }
 
-func testAuthMetods_ListPasswordMethods(t *testing.T, c AuthenticationMethodsClientTest, userID string) (passwordMethods *[]msgraph.PasswordAuthenticationMethod) {
-	passwordMethods, status, err := c.client.ListPasswordMethods(c.connection.Context, userID, odata.Query{})
+func testAuthMetods_ListPasswordMethods(t *testing.T, c *test.Test, userID string) (passwordMethods *[]msgraph.PasswordAuthenticationMethod) {
+	passwordMethods, status, err := c.AuthenticationMethodsClient.ListPasswordMethods(c.Connection.Context, userID, odata.Query{})
 	if status < 200 || status >= 300 {
 		t.Fatalf("AuthenticationMethodsClientTest.ListPasswordMethods(): invalid status: %d", status)
 	}

--- a/msgraph/conditionalaccesspolicy.go
+++ b/msgraph/conditionalaccesspolicy.go
@@ -11,20 +11,20 @@ import (
 	"github.com/manicminer/hamilton/odata"
 )
 
-// ConditionalAccessPolicyClient performs operations on ConditionalAccessPolicy.
-type ConditionalAccessPolicyClient struct {
+// ConditionalAccessPoliciesClient performs operations on ConditionalAccessPolicy.
+type ConditionalAccessPoliciesClient struct {
 	BaseClient Client
 }
 
-// NewConditionalAccessPolicyClient returns a new ConditionalAccessPolicyClient
-func NewConditionalAccessPolicyClient(tenantId string) *ConditionalAccessPolicyClient {
-	return &ConditionalAccessPolicyClient{
+// NewConditionalAccessPoliciesClient returns a new ConditionalAccessPoliciesClient
+func NewConditionalAccessPoliciesClient(tenantId string) *ConditionalAccessPoliciesClient {
+	return &ConditionalAccessPoliciesClient{
 		BaseClient: NewClient(VersionBeta, tenantId),
 	}
 }
 
 // List returns a list of ConditionalAccessPolicy, optionally queried using OData.
-func (c *ConditionalAccessPolicyClient) List(ctx context.Context, query odata.Query) (*[]ConditionalAccessPolicy, int, error) {
+func (c *ConditionalAccessPoliciesClient) List(ctx context.Context, query odata.Query) (*[]ConditionalAccessPolicy, int, error) {
 	resp, status, _, err := c.BaseClient.Get(ctx, GetHttpRequestInput{
 		DisablePaging:    query.Top > 0,
 		OData:            query,
@@ -35,7 +35,7 @@ func (c *ConditionalAccessPolicyClient) List(ctx context.Context, query odata.Qu
 		},
 	})
 	if err != nil {
-		return nil, status, fmt.Errorf("ConditionalAccessPolicyClient.BaseClient.Get(): %v", err)
+		return nil, status, fmt.Errorf("ConditionalAccessPoliciesClient.BaseClient.Get(): %v", err)
 	}
 
 	defer resp.Body.Close()
@@ -55,7 +55,7 @@ func (c *ConditionalAccessPolicyClient) List(ctx context.Context, query odata.Qu
 }
 
 // Create creates a new ConditionalAccessPolicy.
-func (c *ConditionalAccessPolicyClient) Create(ctx context.Context, conditionalAccessPolicy ConditionalAccessPolicy) (*ConditionalAccessPolicy, int, error) {
+func (c *ConditionalAccessPoliciesClient) Create(ctx context.Context, conditionalAccessPolicy ConditionalAccessPolicy) (*ConditionalAccessPolicy, int, error) {
 	var status int
 	body, err := json.Marshal(conditionalAccessPolicy)
 	if err != nil {
@@ -71,7 +71,7 @@ func (c *ConditionalAccessPolicyClient) Create(ctx context.Context, conditionalA
 		},
 	})
 	if err != nil {
-		return nil, status, fmt.Errorf("ConditionalAccessPolicyClient.BaseClient.Post(): %v", err)
+		return nil, status, fmt.Errorf("ConditionalAccessPoliciesClient.BaseClient.Post(): %v", err)
 	}
 
 	defer resp.Body.Close()
@@ -89,7 +89,7 @@ func (c *ConditionalAccessPolicyClient) Create(ctx context.Context, conditionalA
 }
 
 // Get retrieves a ConditionalAccessPolicy.
-func (c *ConditionalAccessPolicyClient) Get(ctx context.Context, id string, query odata.Query) (*ConditionalAccessPolicy, int, error) {
+func (c *ConditionalAccessPoliciesClient) Get(ctx context.Context, id string, query odata.Query) (*ConditionalAccessPolicy, int, error) {
 	resp, status, _, err := c.BaseClient.Get(ctx, GetHttpRequestInput{
 		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
 		OData:                  query,
@@ -100,7 +100,7 @@ func (c *ConditionalAccessPolicyClient) Get(ctx context.Context, id string, quer
 		},
 	})
 	if err != nil {
-		return nil, status, fmt.Errorf("ConditionalAccessPolicyClient.BaseClient.Get(): %v", err)
+		return nil, status, fmt.Errorf("ConditionalAccessPoliciesClient.BaseClient.Get(): %v", err)
 	}
 
 	defer resp.Body.Close()
@@ -118,7 +118,7 @@ func (c *ConditionalAccessPolicyClient) Get(ctx context.Context, id string, quer
 }
 
 // Update amends an existing ConditionalAccessPolicy.
-func (c *ConditionalAccessPolicyClient) Update(ctx context.Context, conditionalAccessPolicy ConditionalAccessPolicy) (int, error) {
+func (c *ConditionalAccessPoliciesClient) Update(ctx context.Context, conditionalAccessPolicy ConditionalAccessPolicy) (int, error) {
 	var status int
 
 	if conditionalAccessPolicy.ID == nil {
@@ -140,14 +140,14 @@ func (c *ConditionalAccessPolicyClient) Update(ctx context.Context, conditionalA
 		},
 	})
 	if err != nil {
-		return status, fmt.Errorf("ConditionalAccessPolicyClient.BaseClient.Patch(): %v", err)
+		return status, fmt.Errorf("ConditionalAccessPoliciesClient.BaseClient.Patch(): %v", err)
 	}
 
 	return status, nil
 }
 
 // Delete removes a ConditionalAccessPolicy.
-func (c *ConditionalAccessPolicyClient) Delete(ctx context.Context, id string) (int, error) {
+func (c *ConditionalAccessPoliciesClient) Delete(ctx context.Context, id string) (int, error) {
 	_, status, _, err := c.BaseClient.Delete(ctx, DeleteHttpRequestInput{
 		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
 		ValidStatusCodes:       []int{http.StatusNoContent},
@@ -157,7 +157,7 @@ func (c *ConditionalAccessPolicyClient) Delete(ctx context.Context, id string) (
 		},
 	})
 	if err != nil {
-		return status, fmt.Errorf("ConditionalAccessPolicyClient.BaseClient.Delete(): %v", err)
+		return status, fmt.Errorf("ConditionalAccessPoliciesClient.BaseClient.Delete(): %v", err)
 	}
 
 	return status, nil

--- a/msgraph/conditionalaccesspolicy_test.go
+++ b/msgraph/conditionalaccesspolicy_test.go
@@ -12,7 +12,8 @@ import (
 )
 
 func TestConditionalAccessPolicyClient(t *testing.T) {
-	c := test.NewTest()
+	c := test.NewTest(t)
+	defer c.CancelFunc()
 
 	testAppId := environments.PublishedApis["Office365ExchangeOnline"]
 	testIncGroup := testGroup_Create(t, c, "test-conditionalAccessPolicy-inc")
@@ -60,7 +61,7 @@ func TestConditionalAccessPolicyClient(t *testing.T) {
 }
 
 func testConditionalAccessPolicysClient_Create(t *testing.T, c *test.Test, a msgraph.ConditionalAccessPolicy) (conditionalAccessPolicy *msgraph.ConditionalAccessPolicy) {
-	conditionalAccessPolicy, status, err := c.ConditionalAccessPoliciesClient.Create(c.Connection.Context, a)
+	conditionalAccessPolicy, status, err := c.ConditionalAccessPoliciesClient.Create(c.Context, a)
 	if err != nil {
 		t.Fatalf("ConditionalAccessPolicyClient.Create(): %v", err)
 	}
@@ -77,7 +78,7 @@ func testConditionalAccessPolicysClient_Create(t *testing.T, c *test.Test, a msg
 }
 
 func testConditionalAccessPolicysClient_Get(t *testing.T, c *test.Test, id string) (policy *msgraph.ConditionalAccessPolicy) {
-	policy, status, err := c.ConditionalAccessPoliciesClient.Get(c.Connection.Context, id, odata.Query{})
+	policy, status, err := c.ConditionalAccessPoliciesClient.Get(c.Context, id, odata.Query{})
 	if err != nil {
 		t.Fatalf("ConditionalAccessPolicyClient.Get(): %v", err)
 	}
@@ -91,7 +92,7 @@ func testConditionalAccessPolicysClient_Get(t *testing.T, c *test.Test, id strin
 }
 
 func testConditionalAccessPolicysClient_Update(t *testing.T, c *test.Test, policy msgraph.ConditionalAccessPolicy) {
-	status, err := c.ConditionalAccessPoliciesClient.Update(c.Connection.Context, policy)
+	status, err := c.ConditionalAccessPoliciesClient.Update(c.Context, policy)
 	if err != nil {
 		t.Fatalf("ConditionalAccessPolicyClient.Update(): %v", err)
 	}
@@ -101,7 +102,7 @@ func testConditionalAccessPolicysClient_Update(t *testing.T, c *test.Test, polic
 }
 
 func testConditionalAccessPolicysClient_List(t *testing.T, c *test.Test) (policies *[]msgraph.ConditionalAccessPolicy) {
-	policies, _, err := c.ConditionalAccessPoliciesClient.List(c.Connection.Context, odata.Query{Top: 10})
+	policies, _, err := c.ConditionalAccessPoliciesClient.List(c.Context, odata.Query{Top: 10})
 	if err != nil {
 		t.Fatalf("ConditionalAccessPolicyClient.List(): %v", err)
 	}
@@ -112,7 +113,7 @@ func testConditionalAccessPolicysClient_List(t *testing.T, c *test.Test) (polici
 }
 
 func testConditionalAccessPolicysClient_Delete(t *testing.T, c *test.Test, id string) {
-	status, err := c.ConditionalAccessPoliciesClient.Delete(c.Connection.Context, id)
+	status, err := c.ConditionalAccessPoliciesClient.Delete(c.Context, id)
 	if err != nil {
 		t.Fatalf("ConditionalAccessPolicyClient.Delete(): %v", err)
 	}
@@ -122,7 +123,7 @@ func testConditionalAccessPolicysClient_Delete(t *testing.T, c *test.Test, id st
 }
 
 func testGroup_Create(t *testing.T, c *test.Test, prefix string) (group *msgraph.Group) {
-	group, _, err := c.GroupsClient.Create(c.Connection.Context, msgraph.Group{
+	group, _, err := c.GroupsClient.Create(c.Context, msgraph.Group{
 		DisplayName:     utils.StringPtr(fmt.Sprintf("%s-%s", prefix, c.RandomString)),
 		MailEnabled:     utils.BoolPtr(false),
 		MailNickname:    utils.StringPtr(fmt.Sprintf("%s-%s", prefix, c.RandomString)),
@@ -136,14 +137,14 @@ func testGroup_Create(t *testing.T, c *test.Test, prefix string) (group *msgraph
 }
 
 func testGroup_Delete(t *testing.T, c *test.Test, group *msgraph.Group) {
-	_, err := c.GroupsClient.Delete(c.Connection.Context, *group.ID)
+	_, err := c.GroupsClient.Delete(c.Context, *group.ID)
 	if err != nil {
 		t.Fatalf("GroupsClient.Delete() - Could not delete test group: %v", err)
 	}
 }
 
 func testUser_Create(t *testing.T, c *test.Test) (user *msgraph.User) {
-	user, _, err := c.UsersClient.Create(c.Connection.Context, msgraph.User{
+	user, _, err := c.UsersClient.Create(c.Context, msgraph.User{
 		AccountEnabled:    utils.BoolPtr(true),
 		DisplayName:       utils.StringPtr("test-user-conditionalAccessPolicy"),
 		MailNickname:      utils.StringPtr(fmt.Sprintf("test-user-%s", c.RandomString)),
@@ -160,7 +161,7 @@ func testUser_Create(t *testing.T, c *test.Test) (user *msgraph.User) {
 }
 
 func testUser_Delete(t *testing.T, c *test.Test, user *msgraph.User) {
-	_, err := c.UsersClient.Delete(c.Connection.Context, *user.ID)
+	_, err := c.UsersClient.Delete(c.Context, *user.ID)
 	if err != nil {
 		t.Fatalf("UsersClient.Delete() - Could not delete test user: %v", err)
 	}

--- a/msgraph/conditionalaccesspolicy_test.go
+++ b/msgraph/conditionalaccesspolicy_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/manicminer/hamilton/auth"
 	"github.com/manicminer/hamilton/environments"
 	"github.com/manicminer/hamilton/internal/test"
 	"github.com/manicminer/hamilton/internal/utils"
@@ -12,40 +11,16 @@ import (
 	"github.com/manicminer/hamilton/odata"
 )
 
-type ConditionalAccessPolicyTest struct {
-	connection   *test.Connection
-	policyClient *msgraph.ConditionalAccessPolicyClient
-	groupsClient *msgraph.GroupsClient
-	usersClient  *msgraph.UsersClient
-	randomString string
-}
-
 func TestConditionalAccessPolicyClient(t *testing.T) {
-	c := ConditionalAccessPolicyTest{
-		connection:   test.NewConnection(auth.MsGraph, auth.TokenVersion2),
-		randomString: test.RandomString(),
-	}
+	c := test.NewTest()
 
-	c.policyClient = msgraph.NewConditionalAccessPolicyClient(c.connection.AuthConfig.TenantID)
-	c.policyClient.BaseClient.Authorizer = c.connection.Authorizer
-	c.policyClient.BaseClient.Endpoint = c.connection.AuthConfig.Environment.MsGraph.Endpoint
-
-	c.groupsClient = msgraph.NewGroupsClient(c.connection.AuthConfig.TenantID)
-	c.groupsClient.BaseClient.Authorizer = c.connection.Authorizer
-	c.groupsClient.BaseClient.Endpoint = c.connection.AuthConfig.Environment.MsGraph.Endpoint
-
-	c.usersClient = msgraph.NewUsersClient(c.connection.AuthConfig.TenantID)
-	c.usersClient.BaseClient.Authorizer = c.connection.Authorizer
-	c.usersClient.BaseClient.Endpoint = c.connection.AuthConfig.Environment.MsGraph.Endpoint
-
-	testAppId := string(environments.PublishedApis["Office365ExchangeOnline"])
+	testAppId := environments.PublishedApis["Office365ExchangeOnline"]
 	testIncGroup := testGroup_Create(t, c, "test-conditionalAccessPolicy-inc")
 	testExcGroup := testGroup_Create(t, c, "test-conditionalAccessPolicy-exc")
 	testUser := testUser_Create(t, c)
 
-	// act
 	policy := testConditionalAccessPolicysClient_Create(t, c, msgraph.ConditionalAccessPolicy{
-		DisplayName: utils.StringPtr(fmt.Sprintf("test-policy-%s", c.randomString)),
+		DisplayName: utils.StringPtr(fmt.Sprintf("test-policy-%s", c.RandomString)),
 		State:       utils.StringPtr("enabled"),
 		Conditions: &msgraph.ConditionalAccessConditionSet{
 			ClientAppTypes: &[]string{"mobileAppsAndDesktopClients", "browser"},
@@ -71,7 +46,7 @@ func TestConditionalAccessPolicyClient(t *testing.T) {
 
 	updatePolicy := msgraph.ConditionalAccessPolicy{
 		ID:          policy.ID,
-		DisplayName: utils.StringPtr(fmt.Sprintf("test-policy-updated-%s", c.randomString)),
+		DisplayName: utils.StringPtr(fmt.Sprintf("test-policy-updated-%s", c.RandomString)),
 	}
 	testConditionalAccessPolicysClient_Update(t, c, updatePolicy)
 
@@ -79,14 +54,13 @@ func TestConditionalAccessPolicyClient(t *testing.T) {
 	testConditionalAccessPolicysClient_Get(t, c, *policy.ID)
 	testConditionalAccessPolicysClient_Delete(t, c, *policy.ID)
 
-	// cleanup
 	testGroup_Delete(t, c, testIncGroup)
 	testGroup_Delete(t, c, testExcGroup)
 	testUser_Delete(t, c, testUser)
 }
 
-func testConditionalAccessPolicysClient_Create(t *testing.T, c ConditionalAccessPolicyTest, a msgraph.ConditionalAccessPolicy) (conditionalAccessPolicy *msgraph.ConditionalAccessPolicy) {
-	conditionalAccessPolicy, status, err := c.policyClient.Create(c.connection.Context, a)
+func testConditionalAccessPolicysClient_Create(t *testing.T, c *test.Test, a msgraph.ConditionalAccessPolicy) (conditionalAccessPolicy *msgraph.ConditionalAccessPolicy) {
+	conditionalAccessPolicy, status, err := c.ConditionalAccessPoliciesClient.Create(c.Connection.Context, a)
 	if err != nil {
 		t.Fatalf("ConditionalAccessPolicyClient.Create(): %v", err)
 	}
@@ -102,8 +76,8 @@ func testConditionalAccessPolicysClient_Create(t *testing.T, c ConditionalAccess
 	return
 }
 
-func testConditionalAccessPolicysClient_Get(t *testing.T, c ConditionalAccessPolicyTest, id string) (policy *msgraph.ConditionalAccessPolicy) {
-	policy, status, err := c.policyClient.Get(c.connection.Context, id, odata.Query{})
+func testConditionalAccessPolicysClient_Get(t *testing.T, c *test.Test, id string) (policy *msgraph.ConditionalAccessPolicy) {
+	policy, status, err := c.ConditionalAccessPoliciesClient.Get(c.Connection.Context, id, odata.Query{})
 	if err != nil {
 		t.Fatalf("ConditionalAccessPolicyClient.Get(): %v", err)
 	}
@@ -116,8 +90,8 @@ func testConditionalAccessPolicysClient_Get(t *testing.T, c ConditionalAccessPol
 	return
 }
 
-func testConditionalAccessPolicysClient_Update(t *testing.T, c ConditionalAccessPolicyTest, policy msgraph.ConditionalAccessPolicy) {
-	status, err := c.policyClient.Update(c.connection.Context, policy)
+func testConditionalAccessPolicysClient_Update(t *testing.T, c *test.Test, policy msgraph.ConditionalAccessPolicy) {
+	status, err := c.ConditionalAccessPoliciesClient.Update(c.Connection.Context, policy)
 	if err != nil {
 		t.Fatalf("ConditionalAccessPolicyClient.Update(): %v", err)
 	}
@@ -126,8 +100,8 @@ func testConditionalAccessPolicysClient_Update(t *testing.T, c ConditionalAccess
 	}
 }
 
-func testConditionalAccessPolicysClient_List(t *testing.T, c ConditionalAccessPolicyTest) (policies *[]msgraph.ConditionalAccessPolicy) {
-	policies, _, err := c.policyClient.List(c.connection.Context, odata.Query{Top: 10})
+func testConditionalAccessPolicysClient_List(t *testing.T, c *test.Test) (policies *[]msgraph.ConditionalAccessPolicy) {
+	policies, _, err := c.ConditionalAccessPoliciesClient.List(c.Connection.Context, odata.Query{Top: 10})
 	if err != nil {
 		t.Fatalf("ConditionalAccessPolicyClient.List(): %v", err)
 	}
@@ -137,8 +111,8 @@ func testConditionalAccessPolicysClient_List(t *testing.T, c ConditionalAccessPo
 	return
 }
 
-func testConditionalAccessPolicysClient_Delete(t *testing.T, c ConditionalAccessPolicyTest, id string) {
-	status, err := c.policyClient.Delete(c.connection.Context, id)
+func testConditionalAccessPolicysClient_Delete(t *testing.T, c *test.Test, id string) {
+	status, err := c.ConditionalAccessPoliciesClient.Delete(c.Connection.Context, id)
 	if err != nil {
 		t.Fatalf("ConditionalAccessPolicyClient.Delete(): %v", err)
 	}
@@ -147,11 +121,11 @@ func testConditionalAccessPolicysClient_Delete(t *testing.T, c ConditionalAccess
 	}
 }
 
-func testGroup_Create(t *testing.T, c ConditionalAccessPolicyTest, prefix string) (group *msgraph.Group) {
-	group, _, err := c.groupsClient.Create(c.connection.Context, msgraph.Group{
-		DisplayName:     utils.StringPtr(fmt.Sprintf("%s-%s", prefix, c.randomString)),
+func testGroup_Create(t *testing.T, c *test.Test, prefix string) (group *msgraph.Group) {
+	group, _, err := c.GroupsClient.Create(c.Connection.Context, msgraph.Group{
+		DisplayName:     utils.StringPtr(fmt.Sprintf("%s-%s", prefix, c.RandomString)),
 		MailEnabled:     utils.BoolPtr(false),
-		MailNickname:    utils.StringPtr(fmt.Sprintf("%s-%s", prefix, c.randomString)),
+		MailNickname:    utils.StringPtr(fmt.Sprintf("%s-%s", prefix, c.RandomString)),
 		SecurityEnabled: utils.BoolPtr(true),
 	})
 
@@ -161,21 +135,21 @@ func testGroup_Create(t *testing.T, c ConditionalAccessPolicyTest, prefix string
 	return
 }
 
-func testGroup_Delete(t *testing.T, c ConditionalAccessPolicyTest, group *msgraph.Group) {
-	_, err := c.groupsClient.Delete(c.connection.Context, *group.ID)
+func testGroup_Delete(t *testing.T, c *test.Test, group *msgraph.Group) {
+	_, err := c.GroupsClient.Delete(c.Connection.Context, *group.ID)
 	if err != nil {
 		t.Fatalf("GroupsClient.Delete() - Could not delete test group: %v", err)
 	}
 }
 
-func testUser_Create(t *testing.T, c ConditionalAccessPolicyTest) (user *msgraph.User) {
-	user, _, err := c.usersClient.Create(c.connection.Context, msgraph.User{
+func testUser_Create(t *testing.T, c *test.Test) (user *msgraph.User) {
+	user, _, err := c.UsersClient.Create(c.Connection.Context, msgraph.User{
 		AccountEnabled:    utils.BoolPtr(true),
 		DisplayName:       utils.StringPtr("test-user-conditionalAccessPolicy"),
-		MailNickname:      utils.StringPtr(fmt.Sprintf("test-user-%s", c.randomString)),
-		UserPrincipalName: utils.StringPtr(fmt.Sprintf("test-user-%s@%s", c.randomString, c.connection.DomainName)),
+		MailNickname:      utils.StringPtr(fmt.Sprintf("test-user-%s", c.RandomString)),
+		UserPrincipalName: utils.StringPtr(fmt.Sprintf("test-user-%s@%s", c.RandomString, c.Connection.DomainName)),
 		PasswordProfile: &msgraph.UserPasswordProfile{
-			Password: utils.StringPtr(fmt.Sprintf("IrPa55w0rd%s", c.randomString)),
+			Password: utils.StringPtr(fmt.Sprintf("IrPa55w0rd%s", c.RandomString)),
 		},
 	})
 
@@ -185,8 +159,8 @@ func testUser_Create(t *testing.T, c ConditionalAccessPolicyTest) (user *msgraph
 	return
 }
 
-func testUser_Delete(t *testing.T, c ConditionalAccessPolicyTest, user *msgraph.User) {
-	_, err := c.usersClient.Delete(c.connection.Context, *user.ID)
+func testUser_Delete(t *testing.T, c *test.Test, user *msgraph.User) {
+	_, err := c.UsersClient.Delete(c.Connection.Context, *user.ID)
 	if err != nil {
 		t.Fatalf("UsersClient.Delete() - Could not delete test user: %v", err)
 	}

--- a/msgraph/directory_audit_reports_test.go
+++ b/msgraph/directory_audit_reports_test.go
@@ -3,31 +3,20 @@ package msgraph_test
 import (
 	"testing"
 
-	"github.com/manicminer/hamilton/auth"
 	"github.com/manicminer/hamilton/internal/test"
 	"github.com/manicminer/hamilton/msgraph"
 	"github.com/manicminer/hamilton/odata"
 )
 
-type DirectoryAuditReportsClientTest struct {
-	connection *test.Connection
-	client     *msgraph.DirectoryAuditReportsClient
-}
-
 func TestDirectoryAuditReportsTest(t *testing.T) {
-	c := DirectoryAuditReportsClientTest{
-		connection: test.NewConnection(auth.MsGraph, auth.TokenVersion2),
-	}
-	c.client = msgraph.NewDirectoryAuditReportsClient(c.connection.AuthConfig.TenantID)
-	c.client.BaseClient.Authorizer = c.connection.Authorizer
-	c.client.BaseClient.Endpoint = c.connection.AuthConfig.Environment.MsGraph.Endpoint
+	c := test.NewTest()
 
 	auditLogs := testDirectoryAuditReports_List(t, c)
 	testDirectoryAuditReports_Get(t, c, *(*auditLogs)[0].Id)
 }
 
-func testDirectoryAuditReports_List(t *testing.T, c DirectoryAuditReportsClientTest) (dirLogs *[]msgraph.DirectoryAudit) {
-	dirLogs, status, err := c.client.List(c.connection.Context, odata.Query{Top: 10})
+func testDirectoryAuditReports_List(t *testing.T, c *test.Test) (dirLogs *[]msgraph.DirectoryAudit) {
+	dirLogs, status, err := c.DirectoryAuditReportsClient.List(c.Connection.Context, odata.Query{Top: 10})
 
 	if status < 200 || status >= 300 {
 		t.Fatalf("DirectoryAuditReportsClient.List(): invalid status: %d", status)
@@ -43,8 +32,8 @@ func testDirectoryAuditReports_List(t *testing.T, c DirectoryAuditReportsClientT
 	return dirLogs
 }
 
-func testDirectoryAuditReports_Get(t *testing.T, c DirectoryAuditReportsClientTest, id string) (dirLog *msgraph.DirectoryAudit) {
-	dirLog, status, err := c.client.Get(c.connection.Context, id, odata.Query{})
+func testDirectoryAuditReports_Get(t *testing.T, c *test.Test, id string) (dirLog *msgraph.DirectoryAudit) {
+	dirLog, status, err := c.DirectoryAuditReportsClient.Get(c.Connection.Context, id, odata.Query{})
 	if err != nil {
 		t.Fatalf("DirectoryAuditReportsClient.Get(): %v", err)
 	}

--- a/msgraph/directory_audit_reports_test.go
+++ b/msgraph/directory_audit_reports_test.go
@@ -9,14 +9,15 @@ import (
 )
 
 func TestDirectoryAuditReportsTest(t *testing.T) {
-	c := test.NewTest()
+	c := test.NewTest(t)
+	defer c.CancelFunc()
 
 	auditLogs := testDirectoryAuditReports_List(t, c)
 	testDirectoryAuditReports_Get(t, c, *(*auditLogs)[0].Id)
 }
 
 func testDirectoryAuditReports_List(t *testing.T, c *test.Test) (dirLogs *[]msgraph.DirectoryAudit) {
-	dirLogs, status, err := c.DirectoryAuditReportsClient.List(c.Connection.Context, odata.Query{Top: 10})
+	dirLogs, status, err := c.DirectoryAuditReportsClient.List(c.Context, odata.Query{Top: 10})
 
 	if status < 200 || status >= 300 {
 		t.Fatalf("DirectoryAuditReportsClient.List(): invalid status: %d", status)
@@ -33,7 +34,7 @@ func testDirectoryAuditReports_List(t *testing.T, c *test.Test) (dirLogs *[]msgr
 }
 
 func testDirectoryAuditReports_Get(t *testing.T, c *test.Test, id string) (dirLog *msgraph.DirectoryAudit) {
-	dirLog, status, err := c.DirectoryAuditReportsClient.Get(c.Connection.Context, id, odata.Query{})
+	dirLog, status, err := c.DirectoryAuditReportsClient.Get(c.Context, id, odata.Query{})
 	if err != nil {
 		t.Fatalf("DirectoryAuditReportsClient.Get(): %v", err)
 	}

--- a/msgraph/directory_objects_test.go
+++ b/msgraph/directory_objects_test.go
@@ -11,7 +11,8 @@ import (
 )
 
 func TestDirectoryObjectsClient(t *testing.T) {
-	c := test.NewTest()
+	c := test.NewTest(t)
+	defer c.CancelFunc()
 
 	user := testUsersClient_Create(t, c, msgraph.User{
 		AccountEnabled:    utils.BoolPtr(true),
@@ -53,7 +54,7 @@ func TestDirectoryObjectsClient(t *testing.T) {
 }
 
 func testDirectoryObjectsClient_Get(t *testing.T, c *test.Test, id string) (directoryObject *msgraph.DirectoryObject) {
-	directoryObject, status, err := c.DirectoryObjectsClient.Get(c.Connection.Context, id, odata.Query{})
+	directoryObject, status, err := c.DirectoryObjectsClient.Get(c.Context, id, odata.Query{})
 	if err != nil {
 		t.Fatalf("DirectoryObjectsClient.Get(): %v", err)
 	}
@@ -70,7 +71,7 @@ func testDirectoryObjectsClient_Get(t *testing.T, c *test.Test, id string) (dire
 }
 
 func testDirectoryObjectsClient_GetByIds(t *testing.T, c *test.Test, ids []string, types []odata.ShortType) (directoryObjects *[]msgraph.DirectoryObject) {
-	directoryObjects, status, err := c.DirectoryObjectsClient.GetByIds(c.Connection.Context, ids, types)
+	directoryObjects, status, err := c.DirectoryObjectsClient.GetByIds(c.Context, ids, types)
 	if err != nil {
 		t.Fatalf("DirectoryObjectsClient.GetByIds(): %v", err)
 	}
@@ -87,7 +88,7 @@ func testDirectoryObjectsClient_GetByIds(t *testing.T, c *test.Test, ids []strin
 }
 
 func testDirectoryObjectsClient_GetMemberGroups(t *testing.T, c *test.Test, id string, securityEnabledOnly bool, expected []string) (directoryObjects *[]msgraph.DirectoryObject) {
-	directoryObjects, status, err := c.DirectoryObjectsClient.GetMemberGroups(c.Connection.Context, id, securityEnabledOnly)
+	directoryObjects, status, err := c.DirectoryObjectsClient.GetMemberGroups(c.Context, id, securityEnabledOnly)
 	if err != nil {
 		t.Fatalf("DirectoryObjectsClient.GetMemberGroups(): %v", err)
 	}
@@ -120,7 +121,7 @@ func testDirectoryObjectsClient_GetMemberGroups(t *testing.T, c *test.Test, id s
 }
 
 func testDirectoryObjectsClient_GetMemberObjects(t *testing.T, c *test.Test, id string, securityEnabledOnly bool, expected []string) (directoryObjects *[]msgraph.DirectoryObject) {
-	directoryObjects, status, err := c.DirectoryObjectsClient.GetMemberObjects(c.Connection.Context, id, securityEnabledOnly)
+	directoryObjects, status, err := c.DirectoryObjectsClient.GetMemberObjects(c.Context, id, securityEnabledOnly)
 	if err != nil {
 		t.Fatalf("DirectoryObjectsClient.GetMemberObjects(): %v", err)
 	}
@@ -153,7 +154,7 @@ func testDirectoryObjectsClient_GetMemberObjects(t *testing.T, c *test.Test, id 
 }
 
 func testDirectoryObjectsClient_Delete(t *testing.T, c *test.Test, id string) {
-	status, err := c.DirectoryObjectsClient.Delete(c.Connection.Context, id)
+	status, err := c.DirectoryObjectsClient.Delete(c.Context, id)
 	if err != nil {
 		t.Fatalf("DirectoryObjectsClient.Delete(): %v", err)
 	}

--- a/msgraph/directory_objects_test.go
+++ b/msgraph/directory_objects_test.go
@@ -4,75 +4,45 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/manicminer/hamilton/auth"
 	"github.com/manicminer/hamilton/internal/test"
 	"github.com/manicminer/hamilton/internal/utils"
 	"github.com/manicminer/hamilton/msgraph"
 	"github.com/manicminer/hamilton/odata"
 )
 
-type DirectoryObjectsClientTest struct {
-	connection   *test.Connection
-	client       *msgraph.DirectoryObjectsClient
-	randomString string
-}
-
 func TestDirectoryObjectsClient(t *testing.T) {
-	rs := test.RandomString()
-	c := DirectoryObjectsClientTest{
-		connection:   test.NewConnection(auth.MsGraph, auth.TokenVersion2),
-		randomString: rs,
-	}
-	c.client = msgraph.NewDirectoryObjectsClient(c.connection.AuthConfig.TenantID)
-	c.client.BaseClient.Authorizer = c.connection.Authorizer
-	c.client.BaseClient.Endpoint = c.connection.AuthConfig.Environment.MsGraph.Endpoint
+	c := test.NewTest()
 
-	g := GroupsClientTest{
-		connection:   test.NewConnection(auth.MsGraph, auth.TokenVersion2),
-		randomString: rs,
-	}
-	g.client = msgraph.NewGroupsClient(g.connection.AuthConfig.TenantID)
-	g.client.BaseClient.Authorizer = g.connection.Authorizer
-	g.client.BaseClient.Endpoint = g.connection.AuthConfig.Environment.MsGraph.Endpoint
-
-	u := UsersClientTest{
-		connection:   test.NewConnection(auth.MsGraph, auth.TokenVersion2),
-		randomString: rs,
-	}
-	u.client = msgraph.NewUsersClient(u.connection.AuthConfig.TenantID)
-	u.client.BaseClient.Authorizer = u.connection.Authorizer
-	u.client.BaseClient.Endpoint = u.connection.AuthConfig.Environment.MsGraph.Endpoint
-
-	user := testUsersClient_Create(t, u, msgraph.User{
+	user := testUsersClient_Create(t, c, msgraph.User{
 		AccountEnabled:    utils.BoolPtr(true),
 		DisplayName:       utils.StringPtr("test-user"),
-		MailNickname:      utils.StringPtr(fmt.Sprintf("test-user-directoryobject-%s", c.randomString)),
-		UserPrincipalName: utils.StringPtr(fmt.Sprintf("test-user-directoryobject-%s@%s", c.randomString, c.connection.DomainName)),
+		MailNickname:      utils.StringPtr(fmt.Sprintf("test-user-directoryobject-%s", c.RandomString)),
+		UserPrincipalName: utils.StringPtr(fmt.Sprintf("test-user-directoryobject-%s@%s", c.RandomString, c.Connection.DomainName)),
 		PasswordProfile: &msgraph.UserPasswordProfile{
-			Password: utils.StringPtr(fmt.Sprintf("IrPa55w0rd%s", c.randomString)),
+			Password: utils.StringPtr(fmt.Sprintf("IrPa55w0rd%s", c.RandomString)),
 		},
 	})
 
 	newGroup1 := msgraph.Group{
 		DisplayName:     utils.StringPtr("test-group-directoryobject-member"),
 		MailEnabled:     utils.BoolPtr(false),
-		MailNickname:    utils.StringPtr(fmt.Sprintf("test-group-directoryobject-member-%s", c.randomString)),
+		MailNickname:    utils.StringPtr(fmt.Sprintf("test-group-directoryobject-member-%s", c.RandomString)),
 		SecurityEnabled: utils.BoolPtr(true),
 	}
 	newGroup1.Members = &msgraph.Members{user.DirectoryObject}
-	group1 := testGroupsClient_Create(t, g, newGroup1)
+	group1 := testGroupsClient_Create(t, c, newGroup1)
 
 	newGroup2 := msgraph.Group{
 		DisplayName:     utils.StringPtr("test-group-directoryobject"),
 		MailEnabled:     utils.BoolPtr(false),
-		MailNickname:    utils.StringPtr(fmt.Sprintf("test-group-directoryobject-%s", c.randomString)),
+		MailNickname:    utils.StringPtr(fmt.Sprintf("test-group-directoryobject-%s", c.RandomString)),
 		SecurityEnabled: utils.BoolPtr(true),
 		Members: &msgraph.Members{
 			group1.DirectoryObject,
 			user.DirectoryObject,
 		},
 	}
-	group2 := testGroupsClient_Create(t, g, newGroup2)
+	group2 := testGroupsClient_Create(t, c, newGroup2)
 
 	testDirectoryObjectsClient_Get(t, c, *user.ID)
 	testDirectoryObjectsClient_Get(t, c, *group1.ID)
@@ -82,8 +52,8 @@ func TestDirectoryObjectsClient(t *testing.T) {
 	testDirectoryObjectsClient_Delete(t, c, *group1.ID)
 }
 
-func testDirectoryObjectsClient_Get(t *testing.T, c DirectoryObjectsClientTest, id string) (directoryObject *msgraph.DirectoryObject) {
-	directoryObject, status, err := c.client.Get(c.connection.Context, id, odata.Query{})
+func testDirectoryObjectsClient_Get(t *testing.T, c *test.Test, id string) (directoryObject *msgraph.DirectoryObject) {
+	directoryObject, status, err := c.DirectoryObjectsClient.Get(c.Connection.Context, id, odata.Query{})
 	if err != nil {
 		t.Fatalf("DirectoryObjectsClient.Get(): %v", err)
 	}
@@ -99,8 +69,8 @@ func testDirectoryObjectsClient_Get(t *testing.T, c DirectoryObjectsClientTest, 
 	return
 }
 
-func testDirectoryObjectsClient_GetByIds(t *testing.T, c DirectoryObjectsClientTest, ids []string, types []odata.ShortType) (directoryObjects *[]msgraph.DirectoryObject) {
-	directoryObjects, status, err := c.client.GetByIds(c.connection.Context, ids, types)
+func testDirectoryObjectsClient_GetByIds(t *testing.T, c *test.Test, ids []string, types []odata.ShortType) (directoryObjects *[]msgraph.DirectoryObject) {
+	directoryObjects, status, err := c.DirectoryObjectsClient.GetByIds(c.Connection.Context, ids, types)
 	if err != nil {
 		t.Fatalf("DirectoryObjectsClient.GetByIds(): %v", err)
 	}
@@ -116,8 +86,8 @@ func testDirectoryObjectsClient_GetByIds(t *testing.T, c DirectoryObjectsClientT
 	return
 }
 
-func testDirectoryObjectsClient_GetMemberGroups(t *testing.T, c DirectoryObjectsClientTest, id string, securityEnabledOnly bool, expected []string) (directoryObjects *[]msgraph.DirectoryObject) {
-	directoryObjects, status, err := c.client.GetMemberGroups(c.connection.Context, id, securityEnabledOnly)
+func testDirectoryObjectsClient_GetMemberGroups(t *testing.T, c *test.Test, id string, securityEnabledOnly bool, expected []string) (directoryObjects *[]msgraph.DirectoryObject) {
+	directoryObjects, status, err := c.DirectoryObjectsClient.GetMemberGroups(c.Connection.Context, id, securityEnabledOnly)
 	if err != nil {
 		t.Fatalf("DirectoryObjectsClient.GetMemberGroups(): %v", err)
 	}
@@ -149,8 +119,8 @@ func testDirectoryObjectsClient_GetMemberGroups(t *testing.T, c DirectoryObjects
 	return
 }
 
-func testDirectoryObjectsClient_GetMemberObjects(t *testing.T, c DirectoryObjectsClientTest, id string, securityEnabledOnly bool, expected []string) (directoryObjects *[]msgraph.DirectoryObject) {
-	directoryObjects, status, err := c.client.GetMemberObjects(c.connection.Context, id, securityEnabledOnly)
+func testDirectoryObjectsClient_GetMemberObjects(t *testing.T, c *test.Test, id string, securityEnabledOnly bool, expected []string) (directoryObjects *[]msgraph.DirectoryObject) {
+	directoryObjects, status, err := c.DirectoryObjectsClient.GetMemberObjects(c.Connection.Context, id, securityEnabledOnly)
 	if err != nil {
 		t.Fatalf("DirectoryObjectsClient.GetMemberObjects(): %v", err)
 	}
@@ -182,8 +152,8 @@ func testDirectoryObjectsClient_GetMemberObjects(t *testing.T, c DirectoryObject
 	return
 }
 
-func testDirectoryObjectsClient_Delete(t *testing.T, c DirectoryObjectsClientTest, id string) {
-	status, err := c.client.Delete(c.connection.Context, id)
+func testDirectoryObjectsClient_Delete(t *testing.T, c *test.Test, id string) {
+	status, err := c.DirectoryObjectsClient.Delete(c.Connection.Context, id)
 	if err != nil {
 		t.Fatalf("DirectoryObjectsClient.Delete(): %v", err)
 	}

--- a/msgraph/directory_role_templates_test.go
+++ b/msgraph/directory_role_templates_test.go
@@ -9,7 +9,8 @@ import (
 )
 
 func TestDirectoryRoleTemplatesClient(t *testing.T) {
-	c := test.NewTest()
+	c := test.NewTest(t)
+	defer c.CancelFunc()
 
 	// list all directory roles available in the tenant
 	directoryRoleTemplates := testDirectoryRoleTemplatesClient_List(t, c)
@@ -27,7 +28,7 @@ func TestDirectoryRoleTemplatesClient(t *testing.T) {
 }
 
 func testDirectoryRoleTemplatesClient_List(t *testing.T, c *test.Test) (directoryRoleTemplates *[]msgraph.DirectoryRoleTemplate) {
-	directoryRoleTemplates, _, err := c.DirectoryRoleTemplatesClient.List(c.Connection.Context)
+	directoryRoleTemplates, _, err := c.DirectoryRoleTemplatesClient.List(c.Context)
 	if err != nil {
 		t.Fatalf("DirectoryRoleTemplatesClient.List(): %v", err)
 	}
@@ -38,7 +39,7 @@ func testDirectoryRoleTemplatesClient_List(t *testing.T, c *test.Test) (director
 }
 
 func testDirectoryRoleTemplatesClient_Get(t *testing.T, c *test.Test, id string) (directoryRoleTemplate *msgraph.DirectoryRoleTemplate) {
-	directoryRoleTemplate, status, err := c.DirectoryRoleTemplatesClient.Get(c.Connection.Context, id)
+	directoryRoleTemplate, status, err := c.DirectoryRoleTemplatesClient.Get(c.Context, id)
 	if err != nil {
 		t.Fatalf("DirectoryRoleTemplatesClient.Get(): %v", err)
 	}
@@ -53,7 +54,7 @@ func testDirectoryRoleTemplatesClient_Get(t *testing.T, c *test.Test, id string)
 
 func testDirectoryRolesClient_Activate(t *testing.T, c *test.Test, roleTemplateId string) (directoryRole *msgraph.DirectoryRole) {
 	// list all activated directory roles in the tenant
-	directoryRoles, _, err := c.DirectoryRolesClient.List(c.Connection.Context)
+	directoryRoles, _, err := c.DirectoryRolesClient.List(c.Context)
 	if err != nil {
 		t.Fatalf("DirectoryRolesClient.List(): %v", err)
 	}
@@ -74,7 +75,7 @@ func testDirectoryRolesClient_Activate(t *testing.T, c *test.Test, roleTemplateI
 
 	// attempt to activate directory role if not already present in the directory
 	if dirRole := findDirRoleByRoleTemplateId(*directoryRoles, roleTemplateId); dirRole == nil {
-		directoryRole, status, err := c.DirectoryRolesClient.Activate(c.Connection.Context, roleTemplateId)
+		directoryRole, status, err := c.DirectoryRolesClient.Activate(c.Context, roleTemplateId)
 		if err != nil {
 			t.Fatalf("DirectoryRolesClient.Activate(): %v", err)
 		}
@@ -87,7 +88,7 @@ func testDirectoryRolesClient_Activate(t *testing.T, c *test.Test, roleTemplateI
 	}
 
 	// attempt to activate directory role a second time to test the API error handling
-	directoryRole, status, err := c.DirectoryRolesClient.Activate(c.Connection.Context, roleTemplateId)
+	directoryRole, status, err := c.DirectoryRolesClient.Activate(c.Context, roleTemplateId)
 	if err != nil {
 		t.Fatalf("DirectoryRolesClient.Activate() [attempt 2]: %v", err)
 	}

--- a/msgraph/directory_roles_test.go
+++ b/msgraph/directory_roles_test.go
@@ -10,7 +10,8 @@ import (
 )
 
 func TestDirectoryRolesClient(t *testing.T) {
-	c := test.NewTest()
+	c := test.NewTest(t)
+	defer c.CancelFunc()
 
 	// list directory roles; usually at least few directory roles are activated within a tenant
 	directoryRoles := testDirectoryRolesClient_List(t, c)
@@ -44,7 +45,7 @@ func TestDirectoryRolesClient(t *testing.T) {
 }
 
 func testDirectoryRolesClient_List(t *testing.T, c *test.Test) (directoryRoles *[]msgraph.DirectoryRole) {
-	directoryRoles, _, err := c.DirectoryRolesClient.List(c.Connection.Context)
+	directoryRoles, _, err := c.DirectoryRolesClient.List(c.Context)
 	if err != nil {
 		t.Fatalf("DirectoryRolesClient.List(): %v", err)
 	}
@@ -55,7 +56,7 @@ func testDirectoryRolesClient_List(t *testing.T, c *test.Test) (directoryRoles *
 }
 
 func testDirectoryRolesClient_Get(t *testing.T, c *test.Test, id string) (directoryRole *msgraph.DirectoryRole) {
-	directoryRole, status, err := c.DirectoryRolesClient.Get(c.Connection.Context, id)
+	directoryRole, status, err := c.DirectoryRolesClient.Get(c.Context, id)
 	if err != nil {
 		t.Fatalf("DirectoryRolesClient.Get(): %v", err)
 	}
@@ -69,7 +70,7 @@ func testDirectoryRolesClient_Get(t *testing.T, c *test.Test, id string) (direct
 }
 
 func testDirectoryRolesClient_GetByTemplateId(t *testing.T, c *test.Test, templateId string) (directoryRole *msgraph.DirectoryRole) {
-	directoryRole, status, err := c.DirectoryRolesClient.GetByTemplateId(c.Connection.Context, templateId)
+	directoryRole, status, err := c.DirectoryRolesClient.GetByTemplateId(c.Context, templateId)
 	if err != nil {
 		t.Fatalf("DirectoryRolesClient.Get(): %v", err)
 	}
@@ -83,7 +84,7 @@ func testDirectoryRolesClient_GetByTemplateId(t *testing.T, c *test.Test, templa
 }
 
 func testDirectoryRolesClient_ListMembers(t *testing.T, c *test.Test, id string) (members *[]string) {
-	members, status, err := c.DirectoryRolesClient.ListMembers(c.Connection.Context, id)
+	members, status, err := c.DirectoryRolesClient.ListMembers(c.Context, id)
 	if err != nil {
 		t.Fatalf("DirectoryRolesClient.ListMembers(): %v", err)
 	}
@@ -100,7 +101,7 @@ func testDirectoryRolesClient_ListMembers(t *testing.T, c *test.Test, id string)
 }
 
 func testDirectoryRolesClient_GetMember(t *testing.T, c *test.Test, dirRoleId string, memberId string) (member *string) {
-	member, status, err := c.DirectoryRolesClient.GetMember(c.Connection.Context, dirRoleId, memberId)
+	member, status, err := c.DirectoryRolesClient.GetMember(c.Context, dirRoleId, memberId)
 	if err != nil {
 		t.Fatalf("DirectoryRolesClient.GetMember(): %v", err)
 	}
@@ -114,7 +115,7 @@ func testDirectoryRolesClient_GetMember(t *testing.T, c *test.Test, dirRoleId st
 }
 
 func testDirectoryRolesClient_RemoveMembers(t *testing.T, c *test.Test, dirRoleId string, memberIds *[]string) {
-	status, err := c.DirectoryRolesClient.RemoveMembers(c.Connection.Context, dirRoleId, memberIds)
+	status, err := c.DirectoryRolesClient.RemoveMembers(c.Context, dirRoleId, memberIds)
 	if err != nil {
 		t.Fatalf("DirectoryRolesClient.RemoveMembers(): %v", err)
 	}
@@ -124,7 +125,7 @@ func testDirectoryRolesClient_RemoveMembers(t *testing.T, c *test.Test, dirRoleI
 }
 
 func testDirectoryRolesClient_AddMembers(t *testing.T, c *test.Test, dirRole *msgraph.DirectoryRole) {
-	status, err := c.DirectoryRolesClient.AddMembers(c.Connection.Context, dirRole)
+	status, err := c.DirectoryRolesClient.AddMembers(c.Context, dirRole)
 	if err != nil {
 		t.Fatalf("DirectoryRolesClient.AddMembers(): %v", err)
 	}

--- a/msgraph/domains_test.go
+++ b/msgraph/domains_test.go
@@ -3,33 +3,20 @@ package msgraph_test
 import (
 	"testing"
 
-	"github.com/manicminer/hamilton/auth"
 	"github.com/manicminer/hamilton/internal/test"
 	"github.com/manicminer/hamilton/msgraph"
 	"github.com/manicminer/hamilton/odata"
 )
 
-type DomainsClientTest struct {
-	connection   *test.Connection
-	client       *msgraph.DomainsClient
-	randomString string
-}
-
 func TestDomainsClient(t *testing.T) {
-	c := DomainsClientTest{
-		connection:   test.NewConnection(auth.MsGraph, auth.TokenVersion2),
-		randomString: test.RandomString(),
-	}
-	c.client = msgraph.NewDomainsClient(c.connection.AuthConfig.TenantID)
-	c.client.BaseClient.Authorizer = c.connection.Authorizer
-	c.client.BaseClient.Endpoint = c.connection.AuthConfig.Environment.MsGraph.Endpoint
+	c := test.NewTest()
 
 	domains := testDomainsClient_List(t, c)
 	testDomainsClient_Get(t, c, *(*domains)[0].ID)
 }
 
-func testDomainsClient_List(t *testing.T, c DomainsClientTest) (domains *[]msgraph.Domain) {
-	domains, _, err := c.client.List(c.connection.Context, odata.Query{})
+func testDomainsClient_List(t *testing.T, c *test.Test) (domains *[]msgraph.Domain) {
+	domains, _, err := c.DomainsClient.List(c.Connection.Context, odata.Query{})
 	if err != nil {
 		t.Fatalf("DomainsClient.List(): %v", err)
 	}
@@ -39,8 +26,8 @@ func testDomainsClient_List(t *testing.T, c DomainsClientTest) (domains *[]msgra
 	return
 }
 
-func testDomainsClient_Get(t *testing.T, c DomainsClientTest, id string) (domain *msgraph.Domain) {
-	domain, status, err := c.client.Get(c.connection.Context, id, odata.Query{})
+func testDomainsClient_Get(t *testing.T, c *test.Test, id string) (domain *msgraph.Domain) {
+	domain, status, err := c.DomainsClient.Get(c.Connection.Context, id, odata.Query{})
 	if err != nil {
 		t.Fatalf("DomainsClient.Get(): %v", err)
 	}

--- a/msgraph/domains_test.go
+++ b/msgraph/domains_test.go
@@ -9,14 +9,15 @@ import (
 )
 
 func TestDomainsClient(t *testing.T) {
-	c := test.NewTest()
+	c := test.NewTest(t)
+	defer c.CancelFunc()
 
 	domains := testDomainsClient_List(t, c)
 	testDomainsClient_Get(t, c, *(*domains)[0].ID)
 }
 
 func testDomainsClient_List(t *testing.T, c *test.Test) (domains *[]msgraph.Domain) {
-	domains, _, err := c.DomainsClient.List(c.Connection.Context, odata.Query{})
+	domains, _, err := c.DomainsClient.List(c.Context, odata.Query{})
 	if err != nil {
 		t.Fatalf("DomainsClient.List(): %v", err)
 	}
@@ -27,7 +28,7 @@ func testDomainsClient_List(t *testing.T, c *test.Test) (domains *[]msgraph.Doma
 }
 
 func testDomainsClient_Get(t *testing.T, c *test.Test, id string) (domain *msgraph.Domain) {
-	domain, status, err := c.DomainsClient.Get(c.Connection.Context, id, odata.Query{})
+	domain, status, err := c.DomainsClient.Get(c.Context, id, odata.Query{})
 	if err != nil {
 		t.Fatalf("DomainsClient.Get(): %v", err)
 	}

--- a/msgraph/groups_test.go
+++ b/msgraph/groups_test.go
@@ -4,60 +4,21 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/manicminer/hamilton/auth"
 	"github.com/manicminer/hamilton/internal/test"
 	"github.com/manicminer/hamilton/internal/utils"
 	"github.com/manicminer/hamilton/msgraph"
 	"github.com/manicminer/hamilton/odata"
 )
 
-type GroupsClientTest struct {
-	connection   *test.Connection
-	client       *msgraph.GroupsClient
-	randomString string
-}
-
 func TestGroupsClient(t *testing.T) {
-	rs := test.RandomString()
-	c := GroupsClientTest{
-		connection:   test.NewConnection(auth.MsGraph, auth.TokenVersion2),
-		randomString: rs,
-	}
-	c.client = msgraph.NewGroupsClient(c.connection.AuthConfig.TenantID)
-	c.client.BaseClient.Authorizer = c.connection.Authorizer
-	c.client.BaseClient.Endpoint = c.connection.AuthConfig.Environment.MsGraph.Endpoint
+	c := test.NewTest()
 
-	token, err := c.connection.Authorizer.Token()
-	if err != nil {
-		t.Fatalf("could not acquire access token: %v", err)
-	}
-	claims, err := auth.ParseClaims(token)
-	if err != nil {
-		t.Fatalf("could not parse claims: %v", err)
-	}
-
-	u := UsersClientTest{
-		connection:   test.NewConnection(auth.MsGraph, auth.TokenVersion2),
-		randomString: rs,
-	}
-	u.client = msgraph.NewUsersClient(u.connection.AuthConfig.TenantID)
-	u.client.BaseClient.Authorizer = u.connection.Authorizer
-	u.client.BaseClient.Endpoint = u.connection.AuthConfig.Environment.MsGraph.Endpoint
-
-	o := DirectoryObjectsClientTest{
-		connection:   test.NewConnection(auth.MsGraph, auth.TokenVersion2),
-		randomString: rs,
-	}
-	o.client = msgraph.NewDirectoryObjectsClient(o.connection.AuthConfig.TenantID)
-	o.client.BaseClient.Authorizer = o.connection.Authorizer
-	o.client.BaseClient.Endpoint = o.connection.AuthConfig.Environment.MsGraph.Endpoint
-
-	self := testDirectoryObjectsClient_Get(t, o, claims.ObjectId)
+	self := testDirectoryObjectsClient_Get(t, c, c.Claims.ObjectId)
 
 	newGroup := msgraph.Group{
 		DisplayName:     utils.StringPtr("test-group"),
 		MailEnabled:     utils.BoolPtr(false),
-		MailNickname:    utils.StringPtr(fmt.Sprintf("test-group-%s", c.randomString)),
+		MailNickname:    utils.StringPtr(fmt.Sprintf("test-group-%s", c.RandomString)),
 		SecurityEnabled: utils.BoolPtr(true),
 		Owners:          &msgraph.Owners{*self},
 		Members:         &msgraph.Members{*self},
@@ -71,36 +32,36 @@ func TestGroupsClient(t *testing.T) {
 	members := testGroupsClient_ListMembers(t, c, *group.ID)
 	testGroupsClient_GetMember(t, c, *group.ID, (*members)[0])
 
-	group.DisplayName = utils.StringPtr(fmt.Sprintf("test-updated-group-%s", c.randomString))
+	group.DisplayName = utils.StringPtr(fmt.Sprintf("test-updated-group-%s", c.RandomString))
 	testGroupsClient_Update(t, c, *group)
 
-	user := testUsersClient_Create(t, u, msgraph.User{
+	user := testUsersClient_Create(t, c, msgraph.User{
 		AccountEnabled:    utils.BoolPtr(true),
 		DisplayName:       utils.StringPtr("test-user"),
-		MailNickname:      utils.StringPtr(fmt.Sprintf("test-user-%s", c.randomString)),
-		UserPrincipalName: utils.StringPtr(fmt.Sprintf("test-user-%s@%s", c.randomString, c.connection.DomainName)),
+		MailNickname:      utils.StringPtr(fmt.Sprintf("test-user-%s", c.RandomString)),
+		UserPrincipalName: utils.StringPtr(fmt.Sprintf("test-user-%s@%s", c.RandomString, c.Connection.DomainName)),
 		PasswordProfile: &msgraph.UserPasswordProfile{
-			Password: utils.StringPtr(fmt.Sprintf("IrPa55w0rd%s", c.randomString)),
+			Password: utils.StringPtr(fmt.Sprintf("IrPa55w0rd%s", c.RandomString)),
 		},
 	})
 
 	group.Owners = &msgraph.Owners{user.DirectoryObject}
 	testGroupsClient_AddOwners(t, c, group)
-	testGroupsClient_RemoveOwners(t, c, *group.ID, &([]string{claims.ObjectId}))
+	testGroupsClient_RemoveOwners(t, c, *group.ID, &([]string{c.Claims.ObjectId}))
 
 	group.Members = &msgraph.Members{user.DirectoryObject}
 	testGroupsClient_AddMembers(t, c, group)
-	testGroupsClient_RemoveMembers(t, c, *group.ID, &([]string{claims.ObjectId}))
+	testGroupsClient_RemoveMembers(t, c, *group.ID, &([]string{c.Claims.ObjectId}))
 
 	testGroupsClient_List(t, c)
 	testGroupsClient_Delete(t, c, *group.ID)
-	testUsersClient_Delete(t, u, *user.ID)
+	testUsersClient_Delete(t, c, *user.ID)
 
 	newGroup365 := msgraph.Group{
 		DisplayName:     utils.StringPtr("test-group-365"),
 		GroupTypes:      []msgraph.GroupType{msgraph.GroupTypeUnified},
 		MailEnabled:     utils.BoolPtr(true),
-		MailNickname:    utils.StringPtr(fmt.Sprintf("test-365-group-%s", c.randomString)),
+		MailNickname:    utils.StringPtr(fmt.Sprintf("test-365-group-%s", c.RandomString)),
 		SecurityEnabled: utils.BoolPtr(true),
 	}
 	group365 := testGroupsClient_Create(t, c, newGroup365)
@@ -112,8 +73,8 @@ func TestGroupsClient(t *testing.T) {
 	testGroupsClient_DeletePermanently(t, c, *group365.ID)
 }
 
-func testGroupsClient_Create(t *testing.T, c GroupsClientTest, g msgraph.Group) (group *msgraph.Group) {
-	group, status, err := c.client.Create(c.connection.Context, g)
+func testGroupsClient_Create(t *testing.T, c *test.Test, g msgraph.Group) (group *msgraph.Group) {
+	group, status, err := c.GroupsClient.Create(c.Connection.Context, g)
 	if err != nil {
 		t.Fatalf("GroupsClient.Create(): %v", err)
 	}
@@ -129,8 +90,8 @@ func testGroupsClient_Create(t *testing.T, c GroupsClientTest, g msgraph.Group) 
 	return
 }
 
-func testGroupsClient_Update(t *testing.T, c GroupsClientTest, g msgraph.Group) {
-	status, err := c.client.Update(c.connection.Context, g)
+func testGroupsClient_Update(t *testing.T, c *test.Test, g msgraph.Group) {
+	status, err := c.GroupsClient.Update(c.Connection.Context, g)
 	if err != nil {
 		t.Fatalf("GroupsClient.Update(): %v", err)
 	}
@@ -139,8 +100,8 @@ func testGroupsClient_Update(t *testing.T, c GroupsClientTest, g msgraph.Group) 
 	}
 }
 
-func testGroupsClient_List(t *testing.T, c GroupsClientTest) (groups *[]msgraph.Group) {
-	groups, _, err := c.client.List(c.connection.Context, odata.Query{Top: 10})
+func testGroupsClient_List(t *testing.T, c *test.Test) (groups *[]msgraph.Group) {
+	groups, _, err := c.GroupsClient.List(c.Connection.Context, odata.Query{Top: 10})
 	if err != nil {
 		t.Fatalf("GroupsClient.List(): %v", err)
 	}
@@ -150,8 +111,8 @@ func testGroupsClient_List(t *testing.T, c GroupsClientTest) (groups *[]msgraph.
 	return
 }
 
-func testGroupsClient_Get(t *testing.T, c GroupsClientTest, id string) (group *msgraph.Group) {
-	group, status, err := c.client.Get(c.connection.Context, id, odata.Query{})
+func testGroupsClient_Get(t *testing.T, c *test.Test, id string) (group *msgraph.Group) {
+	group, status, err := c.GroupsClient.Get(c.Connection.Context, id, odata.Query{})
 	if err != nil {
 		t.Fatalf("GroupsClient.Get(): %v", err)
 	}
@@ -164,8 +125,8 @@ func testGroupsClient_Get(t *testing.T, c GroupsClientTest, id string) (group *m
 	return
 }
 
-func testGroupsClient_Delete(t *testing.T, c GroupsClientTest, id string) {
-	status, err := c.client.Delete(c.connection.Context, id)
+func testGroupsClient_Delete(t *testing.T, c *test.Test, id string) {
+	status, err := c.GroupsClient.Delete(c.Connection.Context, id)
 	if err != nil {
 		t.Fatalf("GroupsClient.Delete(): %v", err)
 	}
@@ -174,8 +135,8 @@ func testGroupsClient_Delete(t *testing.T, c GroupsClientTest, id string) {
 	}
 }
 
-func testGroupsClient_DeletePermanently(t *testing.T, c GroupsClientTest, id string) {
-	status, err := c.client.DeletePermanently(c.connection.Context, id)
+func testGroupsClient_DeletePermanently(t *testing.T, c *test.Test, id string) {
+	status, err := c.GroupsClient.DeletePermanently(c.Connection.Context, id)
 	if err != nil {
 		t.Fatalf("GroupsClient.DeletePermanently(): %v", err)
 	}
@@ -184,8 +145,8 @@ func testGroupsClient_DeletePermanently(t *testing.T, c GroupsClientTest, id str
 	}
 }
 
-func testGroupsClient_ListOwners(t *testing.T, c GroupsClientTest, id string) (owners *[]string) {
-	owners, status, err := c.client.ListOwners(c.connection.Context, id)
+func testGroupsClient_ListOwners(t *testing.T, c *test.Test, id string) (owners *[]string) {
+	owners, status, err := c.GroupsClient.ListOwners(c.Connection.Context, id)
 	if err != nil {
 		t.Fatalf("GroupsClient.ListOwners(): %v", err)
 	}
@@ -201,8 +162,8 @@ func testGroupsClient_ListOwners(t *testing.T, c GroupsClientTest, id string) (o
 	return
 }
 
-func testGroupsClient_GetOwner(t *testing.T, c GroupsClientTest, groupId string, ownerId string) (owner *string) {
-	owner, status, err := c.client.GetOwner(c.connection.Context, groupId, ownerId)
+func testGroupsClient_GetOwner(t *testing.T, c *test.Test, groupId string, ownerId string) (owner *string) {
+	owner, status, err := c.GroupsClient.GetOwner(c.Connection.Context, groupId, ownerId)
 	if err != nil {
 		t.Fatalf("GroupsClient.GetOwner(): %v", err)
 	}
@@ -215,8 +176,8 @@ func testGroupsClient_GetOwner(t *testing.T, c GroupsClientTest, groupId string,
 	return
 }
 
-func testGroupsClient_AddOwners(t *testing.T, c GroupsClientTest, g *msgraph.Group) {
-	status, err := c.client.AddOwners(c.connection.Context, g)
+func testGroupsClient_AddOwners(t *testing.T, c *test.Test, g *msgraph.Group) {
+	status, err := c.GroupsClient.AddOwners(c.Connection.Context, g)
 	if err != nil {
 		t.Fatalf("GroupsClient.AddOwners(): %v", err)
 	}
@@ -225,8 +186,8 @@ func testGroupsClient_AddOwners(t *testing.T, c GroupsClientTest, g *msgraph.Gro
 	}
 }
 
-func testGroupsClient_RemoveOwners(t *testing.T, c GroupsClientTest, groupId string, ownerIds *[]string) {
-	status, err := c.client.RemoveOwners(c.connection.Context, groupId, ownerIds)
+func testGroupsClient_RemoveOwners(t *testing.T, c *test.Test, groupId string, ownerIds *[]string) {
+	status, err := c.GroupsClient.RemoveOwners(c.Connection.Context, groupId, ownerIds)
 	if err != nil {
 		t.Fatalf("GroupsClient.RemoveOwners(): %v", err)
 	}
@@ -235,8 +196,8 @@ func testGroupsClient_RemoveOwners(t *testing.T, c GroupsClientTest, groupId str
 	}
 }
 
-func testGroupsClient_ListMembers(t *testing.T, c GroupsClientTest, id string) (members *[]string) {
-	members, status, err := c.client.ListMembers(c.connection.Context, id)
+func testGroupsClient_ListMembers(t *testing.T, c *test.Test, id string) (members *[]string) {
+	members, status, err := c.GroupsClient.ListMembers(c.Connection.Context, id)
 	if err != nil {
 		t.Fatalf("GroupsClient.ListMembers(): %v", err)
 	}
@@ -252,8 +213,8 @@ func testGroupsClient_ListMembers(t *testing.T, c GroupsClientTest, id string) (
 	return
 }
 
-func testGroupsClient_GetMember(t *testing.T, c GroupsClientTest, groupId string, memberId string) (member *string) {
-	member, status, err := c.client.GetMember(c.connection.Context, groupId, memberId)
+func testGroupsClient_GetMember(t *testing.T, c *test.Test, groupId string, memberId string) (member *string) {
+	member, status, err := c.GroupsClient.GetMember(c.Connection.Context, groupId, memberId)
 	if err != nil {
 		t.Fatalf("GroupsClient.GetMember(): %v", err)
 	}
@@ -266,8 +227,8 @@ func testGroupsClient_GetMember(t *testing.T, c GroupsClientTest, groupId string
 	return
 }
 
-func testGroupsClient_AddMembers(t *testing.T, c GroupsClientTest, g *msgraph.Group) {
-	status, err := c.client.AddMembers(c.connection.Context, g)
+func testGroupsClient_AddMembers(t *testing.T, c *test.Test, g *msgraph.Group) {
+	status, err := c.GroupsClient.AddMembers(c.Connection.Context, g)
 	if err != nil {
 		t.Fatalf("GroupsClient.AddMembers(): %v", err)
 	}
@@ -276,8 +237,8 @@ func testGroupsClient_AddMembers(t *testing.T, c GroupsClientTest, g *msgraph.Gr
 	}
 }
 
-func testGroupsClient_RemoveMembers(t *testing.T, c GroupsClientTest, groupId string, memberIds *[]string) {
-	status, err := c.client.RemoveMembers(c.connection.Context, groupId, memberIds)
+func testGroupsClient_RemoveMembers(t *testing.T, c *test.Test, groupId string, memberIds *[]string) {
+	status, err := c.GroupsClient.RemoveMembers(c.Connection.Context, groupId, memberIds)
 	if err != nil {
 		t.Fatalf("GroupsClient.RemoveMembers(): %v", err)
 	}
@@ -286,8 +247,8 @@ func testGroupsClient_RemoveMembers(t *testing.T, c GroupsClientTest, groupId st
 	}
 }
 
-func testGroupsClient_GetDeleted(t *testing.T, c GroupsClientTest, id string) (group *msgraph.Group) {
-	group, status, err := c.client.GetDeleted(c.connection.Context, id, odata.Query{})
+func testGroupsClient_GetDeleted(t *testing.T, c *test.Test, id string) (group *msgraph.Group) {
+	group, status, err := c.GroupsClient.GetDeleted(c.Connection.Context, id, odata.Query{})
 	if err != nil {
 		t.Fatalf("GroupsClient.GetDeleted(): %v", err)
 	}
@@ -300,8 +261,8 @@ func testGroupsClient_GetDeleted(t *testing.T, c GroupsClientTest, id string) (g
 	return
 }
 
-func testGroupsClient_ListDeleted(t *testing.T, c GroupsClientTest, expectedId string) (deletedGroups *[]msgraph.Group) {
-	deletedGroups, status, err := c.client.ListDeleted(c.connection.Context, odata.Query{
+func testGroupsClient_ListDeleted(t *testing.T, c *test.Test, expectedId string) (deletedGroups *[]msgraph.Group) {
+	deletedGroups, status, err := c.GroupsClient.ListDeleted(c.Connection.Context, odata.Query{
 		Filter: fmt.Sprintf("id eq '%s'", expectedId),
 		Top:    10,
 	})
@@ -330,8 +291,8 @@ func testGroupsClient_ListDeleted(t *testing.T, c GroupsClientTest, expectedId s
 	return
 }
 
-func testGroupsClient_RestoreDeleted(t *testing.T, c GroupsClientTest, id string) {
-	group, status, err := c.client.RestoreDeleted(c.connection.Context, id)
+func testGroupsClient_RestoreDeleted(t *testing.T, c *test.Test, id string) {
+	group, status, err := c.GroupsClient.RestoreDeleted(c.Connection.Context, id)
 	if err != nil {
 		t.Fatalf("GroupsClient.RestoreDeleted(): %v", err)
 	}

--- a/msgraph/groups_test.go
+++ b/msgraph/groups_test.go
@@ -11,7 +11,8 @@ import (
 )
 
 func TestGroupsClient(t *testing.T) {
-	c := test.NewTest()
+	c := test.NewTest(t)
+	defer c.CancelFunc()
 
 	self := testDirectoryObjectsClient_Get(t, c, c.Claims.ObjectId)
 
@@ -74,7 +75,7 @@ func TestGroupsClient(t *testing.T) {
 }
 
 func testGroupsClient_Create(t *testing.T, c *test.Test, g msgraph.Group) (group *msgraph.Group) {
-	group, status, err := c.GroupsClient.Create(c.Connection.Context, g)
+	group, status, err := c.GroupsClient.Create(c.Context, g)
 	if err != nil {
 		t.Fatalf("GroupsClient.Create(): %v", err)
 	}
@@ -91,7 +92,7 @@ func testGroupsClient_Create(t *testing.T, c *test.Test, g msgraph.Group) (group
 }
 
 func testGroupsClient_Update(t *testing.T, c *test.Test, g msgraph.Group) {
-	status, err := c.GroupsClient.Update(c.Connection.Context, g)
+	status, err := c.GroupsClient.Update(c.Context, g)
 	if err != nil {
 		t.Fatalf("GroupsClient.Update(): %v", err)
 	}
@@ -101,7 +102,7 @@ func testGroupsClient_Update(t *testing.T, c *test.Test, g msgraph.Group) {
 }
 
 func testGroupsClient_List(t *testing.T, c *test.Test) (groups *[]msgraph.Group) {
-	groups, _, err := c.GroupsClient.List(c.Connection.Context, odata.Query{Top: 10})
+	groups, _, err := c.GroupsClient.List(c.Context, odata.Query{Top: 10})
 	if err != nil {
 		t.Fatalf("GroupsClient.List(): %v", err)
 	}
@@ -112,7 +113,7 @@ func testGroupsClient_List(t *testing.T, c *test.Test) (groups *[]msgraph.Group)
 }
 
 func testGroupsClient_Get(t *testing.T, c *test.Test, id string) (group *msgraph.Group) {
-	group, status, err := c.GroupsClient.Get(c.Connection.Context, id, odata.Query{})
+	group, status, err := c.GroupsClient.Get(c.Context, id, odata.Query{})
 	if err != nil {
 		t.Fatalf("GroupsClient.Get(): %v", err)
 	}
@@ -126,7 +127,7 @@ func testGroupsClient_Get(t *testing.T, c *test.Test, id string) (group *msgraph
 }
 
 func testGroupsClient_Delete(t *testing.T, c *test.Test, id string) {
-	status, err := c.GroupsClient.Delete(c.Connection.Context, id)
+	status, err := c.GroupsClient.Delete(c.Context, id)
 	if err != nil {
 		t.Fatalf("GroupsClient.Delete(): %v", err)
 	}
@@ -136,7 +137,7 @@ func testGroupsClient_Delete(t *testing.T, c *test.Test, id string) {
 }
 
 func testGroupsClient_DeletePermanently(t *testing.T, c *test.Test, id string) {
-	status, err := c.GroupsClient.DeletePermanently(c.Connection.Context, id)
+	status, err := c.GroupsClient.DeletePermanently(c.Context, id)
 	if err != nil {
 		t.Fatalf("GroupsClient.DeletePermanently(): %v", err)
 	}
@@ -146,7 +147,7 @@ func testGroupsClient_DeletePermanently(t *testing.T, c *test.Test, id string) {
 }
 
 func testGroupsClient_ListOwners(t *testing.T, c *test.Test, id string) (owners *[]string) {
-	owners, status, err := c.GroupsClient.ListOwners(c.Connection.Context, id)
+	owners, status, err := c.GroupsClient.ListOwners(c.Context, id)
 	if err != nil {
 		t.Fatalf("GroupsClient.ListOwners(): %v", err)
 	}
@@ -163,7 +164,7 @@ func testGroupsClient_ListOwners(t *testing.T, c *test.Test, id string) (owners 
 }
 
 func testGroupsClient_GetOwner(t *testing.T, c *test.Test, groupId string, ownerId string) (owner *string) {
-	owner, status, err := c.GroupsClient.GetOwner(c.Connection.Context, groupId, ownerId)
+	owner, status, err := c.GroupsClient.GetOwner(c.Context, groupId, ownerId)
 	if err != nil {
 		t.Fatalf("GroupsClient.GetOwner(): %v", err)
 	}
@@ -177,7 +178,7 @@ func testGroupsClient_GetOwner(t *testing.T, c *test.Test, groupId string, owner
 }
 
 func testGroupsClient_AddOwners(t *testing.T, c *test.Test, g *msgraph.Group) {
-	status, err := c.GroupsClient.AddOwners(c.Connection.Context, g)
+	status, err := c.GroupsClient.AddOwners(c.Context, g)
 	if err != nil {
 		t.Fatalf("GroupsClient.AddOwners(): %v", err)
 	}
@@ -187,7 +188,7 @@ func testGroupsClient_AddOwners(t *testing.T, c *test.Test, g *msgraph.Group) {
 }
 
 func testGroupsClient_RemoveOwners(t *testing.T, c *test.Test, groupId string, ownerIds *[]string) {
-	status, err := c.GroupsClient.RemoveOwners(c.Connection.Context, groupId, ownerIds)
+	status, err := c.GroupsClient.RemoveOwners(c.Context, groupId, ownerIds)
 	if err != nil {
 		t.Fatalf("GroupsClient.RemoveOwners(): %v", err)
 	}
@@ -197,7 +198,7 @@ func testGroupsClient_RemoveOwners(t *testing.T, c *test.Test, groupId string, o
 }
 
 func testGroupsClient_ListMembers(t *testing.T, c *test.Test, id string) (members *[]string) {
-	members, status, err := c.GroupsClient.ListMembers(c.Connection.Context, id)
+	members, status, err := c.GroupsClient.ListMembers(c.Context, id)
 	if err != nil {
 		t.Fatalf("GroupsClient.ListMembers(): %v", err)
 	}
@@ -214,7 +215,7 @@ func testGroupsClient_ListMembers(t *testing.T, c *test.Test, id string) (member
 }
 
 func testGroupsClient_GetMember(t *testing.T, c *test.Test, groupId string, memberId string) (member *string) {
-	member, status, err := c.GroupsClient.GetMember(c.Connection.Context, groupId, memberId)
+	member, status, err := c.GroupsClient.GetMember(c.Context, groupId, memberId)
 	if err != nil {
 		t.Fatalf("GroupsClient.GetMember(): %v", err)
 	}
@@ -228,7 +229,7 @@ func testGroupsClient_GetMember(t *testing.T, c *test.Test, groupId string, memb
 }
 
 func testGroupsClient_AddMembers(t *testing.T, c *test.Test, g *msgraph.Group) {
-	status, err := c.GroupsClient.AddMembers(c.Connection.Context, g)
+	status, err := c.GroupsClient.AddMembers(c.Context, g)
 	if err != nil {
 		t.Fatalf("GroupsClient.AddMembers(): %v", err)
 	}
@@ -238,7 +239,7 @@ func testGroupsClient_AddMembers(t *testing.T, c *test.Test, g *msgraph.Group) {
 }
 
 func testGroupsClient_RemoveMembers(t *testing.T, c *test.Test, groupId string, memberIds *[]string) {
-	status, err := c.GroupsClient.RemoveMembers(c.Connection.Context, groupId, memberIds)
+	status, err := c.GroupsClient.RemoveMembers(c.Context, groupId, memberIds)
 	if err != nil {
 		t.Fatalf("GroupsClient.RemoveMembers(): %v", err)
 	}
@@ -248,7 +249,7 @@ func testGroupsClient_RemoveMembers(t *testing.T, c *test.Test, groupId string, 
 }
 
 func testGroupsClient_GetDeleted(t *testing.T, c *test.Test, id string) (group *msgraph.Group) {
-	group, status, err := c.GroupsClient.GetDeleted(c.Connection.Context, id, odata.Query{})
+	group, status, err := c.GroupsClient.GetDeleted(c.Context, id, odata.Query{})
 	if err != nil {
 		t.Fatalf("GroupsClient.GetDeleted(): %v", err)
 	}
@@ -262,7 +263,7 @@ func testGroupsClient_GetDeleted(t *testing.T, c *test.Test, id string) (group *
 }
 
 func testGroupsClient_ListDeleted(t *testing.T, c *test.Test, expectedId string) (deletedGroups *[]msgraph.Group) {
-	deletedGroups, status, err := c.GroupsClient.ListDeleted(c.Connection.Context, odata.Query{
+	deletedGroups, status, err := c.GroupsClient.ListDeleted(c.Context, odata.Query{
 		Filter: fmt.Sprintf("id eq '%s'", expectedId),
 		Top:    10,
 	})
@@ -292,7 +293,7 @@ func testGroupsClient_ListDeleted(t *testing.T, c *test.Test, expectedId string)
 }
 
 func testGroupsClient_RestoreDeleted(t *testing.T, c *test.Test, id string) {
-	group, status, err := c.GroupsClient.RestoreDeleted(c.Connection.Context, id)
+	group, status, err := c.GroupsClient.RestoreDeleted(c.Context, id)
 	if err != nil {
 		t.Fatalf("GroupsClient.RestoreDeleted(): %v", err)
 	}

--- a/msgraph/identity_providers_test.go
+++ b/msgraph/identity_providers_test.go
@@ -11,7 +11,8 @@ import (
 )
 
 func TestIdentityProvidersClient(t *testing.T) {
-	c := test.NewTest()
+	c := test.NewTest(t)
+	defer c.CancelFunc()
 
 	providers := testIdentityProvidersClient_List(t, c)
 	for _, provider := range *providers {
@@ -44,7 +45,7 @@ func TestIdentityProvidersClient(t *testing.T) {
 }
 
 func testIdentityProvidersClient_Create(t *testing.T, c *test.Test, p msgraph.IdentityProvider) (provider *msgraph.IdentityProvider) {
-	provider, status, err := c.IdentityProvidersClient.Create(c.Connection.Context, p)
+	provider, status, err := c.IdentityProvidersClient.Create(c.Context, p)
 	if err != nil {
 		t.Fatalf("IdentityProvidersClient.Create(): %v", err)
 	}
@@ -61,7 +62,7 @@ func testIdentityProvidersClient_Create(t *testing.T, c *test.Test, p msgraph.Id
 }
 
 func testIdentityProvidersClient_Update(t *testing.T, c *test.Test, p msgraph.IdentityProvider) {
-	status, err := c.IdentityProvidersClient.Update(c.Connection.Context, p)
+	status, err := c.IdentityProvidersClient.Update(c.Context, p)
 	if err != nil {
 		t.Fatalf("IdentityProvidersClient.Update(): %v", err)
 	}
@@ -71,7 +72,7 @@ func testIdentityProvidersClient_Update(t *testing.T, c *test.Test, p msgraph.Id
 }
 
 func testIdentityProvidersClient_List(t *testing.T, c *test.Test) (providers *[]msgraph.IdentityProvider) {
-	providers, _, err := c.IdentityProvidersClient.List(c.Connection.Context)
+	providers, _, err := c.IdentityProvidersClient.List(c.Context)
 	if err != nil {
 		t.Fatalf("IdentityProvidersClient.List(): %v", err)
 	}
@@ -82,7 +83,7 @@ func testIdentityProvidersClient_List(t *testing.T, c *test.Test) (providers *[]
 }
 
 func testIdentityProvidersClient_Get(t *testing.T, c *test.Test, id string) (provider *msgraph.IdentityProvider) {
-	provider, status, err := c.IdentityProvidersClient.Get(c.Connection.Context, id)
+	provider, status, err := c.IdentityProvidersClient.Get(c.Context, id)
 	if err != nil {
 		t.Fatalf("IdentityProvidersClient.Get(): %v", err)
 	}
@@ -99,7 +100,7 @@ func testIdentityProvidersClient_Get(t *testing.T, c *test.Test, id string) (pro
 }
 
 func testIdentityProvidersClient_Delete(t *testing.T, c *test.Test, id string) {
-	status, err := c.IdentityProvidersClient.Delete(c.Connection.Context, id)
+	status, err := c.IdentityProvidersClient.Delete(c.Context, id)
 	if err != nil {
 		t.Fatalf("IdentityProvidersClient.Delete(): %v", err)
 	}
@@ -109,7 +110,7 @@ func testIdentityProvidersClient_Delete(t *testing.T, c *test.Test, id string) {
 }
 
 func testIdentityProvidersClient_ListAvailableProviderTypes(t *testing.T, c *test.Test) {
-	availableIdentityProviders, _, err := c.IdentityProvidersClient.ListAvailableProviderTypes(c.Connection.Context)
+	availableIdentityProviders, _, err := c.IdentityProvidersClient.ListAvailableProviderTypes(c.Context)
 	if err != nil {
 		t.Fatalf("IdentityProvidersClient.ListAvailableProviderTypes(): %v", err)
 	}

--- a/msgraph/identity_providers_test.go
+++ b/msgraph/identity_providers_test.go
@@ -4,29 +4,14 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/manicminer/hamilton/odata"
-
-	"github.com/manicminer/hamilton/auth"
 	"github.com/manicminer/hamilton/internal/test"
 	"github.com/manicminer/hamilton/internal/utils"
 	"github.com/manicminer/hamilton/msgraph"
+	"github.com/manicminer/hamilton/odata"
 )
 
-type IdentityProvidersClientTest struct {
-	connection   *test.Connection
-	client       *msgraph.IdentityProvidersClient
-	randomString string
-}
-
 func TestIdentityProvidersClient(t *testing.T) {
-	rs := test.RandomString()
-	c := IdentityProvidersClientTest{
-		connection:   test.NewConnection(auth.MsGraph, auth.TokenVersion2),
-		randomString: rs,
-	}
-	c.client = msgraph.NewIdentityProvidersClient(c.connection.AuthConfig.TenantID)
-	c.client.BaseClient.Authorizer = c.connection.Authorizer
-	c.client.BaseClient.Endpoint = c.connection.AuthConfig.Environment.MsGraph.Endpoint
+	c := test.NewTest()
 
 	providers := testIdentityProvidersClient_List(t, c)
 	for _, provider := range *providers {
@@ -58,8 +43,8 @@ func TestIdentityProvidersClient(t *testing.T) {
 	testIdentityProvidersClient_Delete(t, c, *identityProvider.ID)
 }
 
-func testIdentityProvidersClient_Create(t *testing.T, c IdentityProvidersClientTest, p msgraph.IdentityProvider) (provider *msgraph.IdentityProvider) {
-	provider, status, err := c.client.Create(c.connection.Context, p)
+func testIdentityProvidersClient_Create(t *testing.T, c *test.Test, p msgraph.IdentityProvider) (provider *msgraph.IdentityProvider) {
+	provider, status, err := c.IdentityProvidersClient.Create(c.Connection.Context, p)
 	if err != nil {
 		t.Fatalf("IdentityProvidersClient.Create(): %v", err)
 	}
@@ -75,8 +60,8 @@ func testIdentityProvidersClient_Create(t *testing.T, c IdentityProvidersClientT
 	return
 }
 
-func testIdentityProvidersClient_Update(t *testing.T, c IdentityProvidersClientTest, p msgraph.IdentityProvider) {
-	status, err := c.client.Update(c.connection.Context, p)
+func testIdentityProvidersClient_Update(t *testing.T, c *test.Test, p msgraph.IdentityProvider) {
+	status, err := c.IdentityProvidersClient.Update(c.Connection.Context, p)
 	if err != nil {
 		t.Fatalf("IdentityProvidersClient.Update(): %v", err)
 	}
@@ -85,8 +70,8 @@ func testIdentityProvidersClient_Update(t *testing.T, c IdentityProvidersClientT
 	}
 }
 
-func testIdentityProvidersClient_List(t *testing.T, c IdentityProvidersClientTest) (providers *[]msgraph.IdentityProvider) {
-	providers, _, err := c.client.List(c.connection.Context)
+func testIdentityProvidersClient_List(t *testing.T, c *test.Test) (providers *[]msgraph.IdentityProvider) {
+	providers, _, err := c.IdentityProvidersClient.List(c.Connection.Context)
 	if err != nil {
 		t.Fatalf("IdentityProvidersClient.List(): %v", err)
 	}
@@ -96,8 +81,8 @@ func testIdentityProvidersClient_List(t *testing.T, c IdentityProvidersClientTes
 	return
 }
 
-func testIdentityProvidersClient_Get(t *testing.T, c IdentityProvidersClientTest, id string) (provider *msgraph.IdentityProvider) {
-	provider, status, err := c.client.Get(c.connection.Context, id)
+func testIdentityProvidersClient_Get(t *testing.T, c *test.Test, id string) (provider *msgraph.IdentityProvider) {
+	provider, status, err := c.IdentityProvidersClient.Get(c.Connection.Context, id)
 	if err != nil {
 		t.Fatalf("IdentityProvidersClient.Get(): %v", err)
 	}
@@ -113,8 +98,8 @@ func testIdentityProvidersClient_Get(t *testing.T, c IdentityProvidersClientTest
 	return
 }
 
-func testIdentityProvidersClient_Delete(t *testing.T, c IdentityProvidersClientTest, id string) {
-	status, err := c.client.Delete(c.connection.Context, id)
+func testIdentityProvidersClient_Delete(t *testing.T, c *test.Test, id string) {
+	status, err := c.IdentityProvidersClient.Delete(c.Connection.Context, id)
 	if err != nil {
 		t.Fatalf("IdentityProvidersClient.Delete(): %v", err)
 	}
@@ -123,8 +108,8 @@ func testIdentityProvidersClient_Delete(t *testing.T, c IdentityProvidersClientT
 	}
 }
 
-func testIdentityProvidersClient_ListAvailableProviderTypes(t *testing.T, c IdentityProvidersClientTest) {
-	availableIdentityProviders, _, err := c.client.ListAvailableProviderTypes(c.connection.Context)
+func testIdentityProvidersClient_ListAvailableProviderTypes(t *testing.T, c *test.Test) {
+	availableIdentityProviders, _, err := c.IdentityProvidersClient.ListAvailableProviderTypes(c.Connection.Context)
 	if err != nil {
 		t.Fatalf("IdentityProvidersClient.ListAvailableProviderTypes(): %v", err)
 	}

--- a/msgraph/invitations_test.go
+++ b/msgraph/invitations_test.go
@@ -4,37 +4,23 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/manicminer/hamilton/auth"
 	"github.com/manicminer/hamilton/internal/test"
 	"github.com/manicminer/hamilton/internal/utils"
 	"github.com/manicminer/hamilton/msgraph"
 )
 
-type InvitationsClientTest struct {
-	connection   *test.Connection
-	client       *msgraph.InvitationsClient
-	randomString string
-}
-
 func TestInvitationsClient(t *testing.T) {
-	rs := test.RandomString()
-	c := InvitationsClientTest{
-		connection:   test.NewConnection(auth.MsGraph, auth.TokenVersion2),
-		randomString: rs,
-	}
-	c.client = msgraph.NewInvitationsClient(c.connection.AuthConfig.TenantID)
-	c.client.BaseClient.Authorizer = c.connection.Authorizer
-	c.client.BaseClient.Endpoint = c.connection.AuthConfig.Environment.MsGraph.Endpoint
+	c := test.NewTest()
 
 	testInvitationsClient_Create(t, c, msgraph.Invitation{
 		InvitedUserDisplayName:  utils.StringPtr("test-user-invited"),
-		InvitedUserEmailAddress: utils.StringPtr(fmt.Sprintf("test-user-%s@test.com", c.randomString)),
-		InviteRedirectURL:       utils.StringPtr(fmt.Sprintf("https://myapp-%s.contoso.com", c.randomString)),
+		InvitedUserEmailAddress: utils.StringPtr(fmt.Sprintf("test-user-%s@test.com", c.RandomString)),
+		InviteRedirectURL:       utils.StringPtr(fmt.Sprintf("https://myapp-%s.contoso.com", c.RandomString)),
 	})
 }
 
-func testInvitationsClient_Create(t *testing.T, c InvitationsClientTest, i msgraph.Invitation) (invitation *msgraph.Invitation) {
-	invitation, status, err := c.client.Create(c.connection.Context, i)
+func testInvitationsClient_Create(t *testing.T, c *test.Test, i msgraph.Invitation) (invitation *msgraph.Invitation) {
+	invitation, status, err := c.InvitationsClient.Create(c.Connection.Context, i)
 	if err != nil {
 		t.Fatalf("InvitationsClient.Create(): %v", err)
 	}

--- a/msgraph/invitations_test.go
+++ b/msgraph/invitations_test.go
@@ -10,7 +10,8 @@ import (
 )
 
 func TestInvitationsClient(t *testing.T) {
-	c := test.NewTest()
+	c := test.NewTest(t)
+	defer c.CancelFunc()
 
 	testInvitationsClient_Create(t, c, msgraph.Invitation{
 		InvitedUserDisplayName:  utils.StringPtr("test-user-invited"),
@@ -20,7 +21,7 @@ func TestInvitationsClient(t *testing.T) {
 }
 
 func testInvitationsClient_Create(t *testing.T, c *test.Test, i msgraph.Invitation) (invitation *msgraph.Invitation) {
-	invitation, status, err := c.InvitationsClient.Create(c.Connection.Context, i)
+	invitation, status, err := c.InvitationsClient.Create(c.Context, i)
 	if err != nil {
 		t.Fatalf("InvitationsClient.Create(): %v", err)
 	}

--- a/msgraph/namedlocations_test.go
+++ b/msgraph/namedlocations_test.go
@@ -4,27 +4,14 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/manicminer/hamilton/auth"
 	"github.com/manicminer/hamilton/internal/test"
 	"github.com/manicminer/hamilton/internal/utils"
 	"github.com/manicminer/hamilton/msgraph"
 	"github.com/manicminer/hamilton/odata"
 )
 
-type NamedLocationsClientTest struct {
-	connection   *test.Connection
-	client       *msgraph.NamedLocationsClient
-	randomString string
-}
-
 func TestNamedLocationsClient(t *testing.T) {
-	c := NamedLocationsClientTest{
-		connection:   test.NewConnection(auth.MsGraph, auth.TokenVersion2),
-		randomString: test.RandomString(),
-	}
-	c.client = msgraph.NewNamedLocationsClient(c.connection.AuthConfig.TenantID)
-	c.client.BaseClient.Authorizer = c.connection.Authorizer
-	c.client.BaseClient.Endpoint = c.connection.AuthConfig.Environment.MsGraph.Endpoint
+	c := test.NewTest()
 
 	newIPNamedLocation := msgraph.IPNamedLocation{
 		BaseNamedLocation: &msgraph.BaseNamedLocation{
@@ -51,10 +38,10 @@ func TestNamedLocationsClient(t *testing.T) {
 	ipNamedLocation := testNamedLocationsClient_CreateIP(t, c, newIPNamedLocation)
 	countryNamedLocation := testNamedLocationsClient_CreateCountry(t, c, newCountryNamedLocation)
 
-	ipNamedLocation.DisplayName = utils.StringPtr(fmt.Sprintf("test-updated-ipnl-%s", c.randomString))
+	ipNamedLocation.DisplayName = utils.StringPtr(fmt.Sprintf("test-updated-ipnl-%s", c.RandomString))
 	ipNamedLocation.CreatedDateTime = nil
 	ipNamedLocation.ModifiedDateTime = nil
-	countryNamedLocation.DisplayName = utils.StringPtr(fmt.Sprintf("test-updated-cnl-%s", c.randomString))
+	countryNamedLocation.DisplayName = utils.StringPtr(fmt.Sprintf("test-updated-cnl-%s", c.RandomString))
 	countryNamedLocation.CreatedDateTime = nil
 	countryNamedLocation.ModifiedDateTime = nil
 
@@ -72,8 +59,8 @@ func TestNamedLocationsClient(t *testing.T) {
 	testNamedLocationsClient_Delete(t, c, *countryNamedLocation.ID)
 }
 
-func testNamedLocationsClient_CreateIP(t *testing.T, c NamedLocationsClientTest, ipnl msgraph.IPNamedLocation) (ipNamedLocation *msgraph.IPNamedLocation) {
-	ipNamedLocation, status, err := c.client.CreateIP(c.connection.Context, ipnl)
+func testNamedLocationsClient_CreateIP(t *testing.T, c *test.Test, ipnl msgraph.IPNamedLocation) (ipNamedLocation *msgraph.IPNamedLocation) {
+	ipNamedLocation, status, err := c.NamedLocationsClient.CreateIP(c.Connection.Context, ipnl)
 	if err != nil {
 		t.Fatalf("NamedLocationsClient.CreateIP(): %v", err)
 	}
@@ -89,8 +76,8 @@ func testNamedLocationsClient_CreateIP(t *testing.T, c NamedLocationsClientTest,
 	return
 }
 
-func testNamedLocationsClient_CreateCountry(t *testing.T, c NamedLocationsClientTest, cnl msgraph.CountryNamedLocation) (countryNamedLocation *msgraph.CountryNamedLocation) {
-	countryNamedLocation, status, err := c.client.CreateCountry(c.connection.Context, cnl)
+func testNamedLocationsClient_CreateCountry(t *testing.T, c *test.Test, cnl msgraph.CountryNamedLocation) (countryNamedLocation *msgraph.CountryNamedLocation) {
+	countryNamedLocation, status, err := c.NamedLocationsClient.CreateCountry(c.Connection.Context, cnl)
 	if err != nil {
 		t.Fatalf("NamedLocationsClient.CreateCountry(): %v", err)
 	}
@@ -106,8 +93,8 @@ func testNamedLocationsClient_CreateCountry(t *testing.T, c NamedLocationsClient
 	return
 }
 
-func testNamedLocationsClient_GetIP(t *testing.T, c NamedLocationsClientTest, id string) (ipNamedLocation *msgraph.IPNamedLocation) {
-	ipNamedLocation, status, err := c.client.GetIP(c.connection.Context, id, odata.Query{})
+func testNamedLocationsClient_GetIP(t *testing.T, c *test.Test, id string) (ipNamedLocation *msgraph.IPNamedLocation) {
+	ipNamedLocation, status, err := c.NamedLocationsClient.GetIP(c.Connection.Context, id, odata.Query{})
 	if err != nil {
 		t.Fatalf("IPNamedLocationsClient.GetIP(): %v", err)
 	}
@@ -120,8 +107,8 @@ func testNamedLocationsClient_GetIP(t *testing.T, c NamedLocationsClientTest, id
 	return
 }
 
-func testNamedLocationsClient_GetCountry(t *testing.T, c NamedLocationsClientTest, id string) (countryNamedLocation *msgraph.CountryNamedLocation) {
-	countryNamedLocation, status, err := c.client.GetCountry(c.connection.Context, id, odata.Query{})
+func testNamedLocationsClient_GetCountry(t *testing.T, c *test.Test, id string) (countryNamedLocation *msgraph.CountryNamedLocation) {
+	countryNamedLocation, status, err := c.NamedLocationsClient.GetCountry(c.Connection.Context, id, odata.Query{})
 	if err != nil {
 		t.Fatalf("NamedLocationsClient.GetCountry(): %v", err)
 	}
@@ -134,8 +121,8 @@ func testNamedLocationsClient_GetCountry(t *testing.T, c NamedLocationsClientTes
 	return
 }
 
-func testNamedLocationsClient_Get(t *testing.T, c NamedLocationsClientTest, id string) (namedLocation *msgraph.NamedLocation) {
-	namedLocation, status, err := c.client.Get(c.connection.Context, id, odata.Query{})
+func testNamedLocationsClient_Get(t *testing.T, c *test.Test, id string) (namedLocation *msgraph.NamedLocation) {
+	namedLocation, status, err := c.NamedLocationsClient.Get(c.Connection.Context, id, odata.Query{})
 	if err != nil {
 		t.Fatalf("NamedLocationsClient.Get(): %v", err)
 	}
@@ -153,8 +140,8 @@ func testNamedLocationsClient_Get(t *testing.T, c NamedLocationsClientTest, id s
 	return
 }
 
-func testNamedLocationsClient_UpdateIP(t *testing.T, c NamedLocationsClientTest, ipnl msgraph.IPNamedLocation) {
-	status, err := c.client.UpdateIP(c.connection.Context, ipnl)
+func testNamedLocationsClient_UpdateIP(t *testing.T, c *test.Test, ipnl msgraph.IPNamedLocation) {
+	status, err := c.NamedLocationsClient.UpdateIP(c.Connection.Context, ipnl)
 	if err != nil {
 		t.Fatalf("NamedLocationsClient.UpdateIP(): %v", err)
 	}
@@ -163,8 +150,8 @@ func testNamedLocationsClient_UpdateIP(t *testing.T, c NamedLocationsClientTest,
 	}
 }
 
-func testNamedLocationsClient_UpdateCountry(t *testing.T, c NamedLocationsClientTest, cnl msgraph.CountryNamedLocation) {
-	status, err := c.client.UpdateCountry(c.connection.Context, cnl)
+func testNamedLocationsClient_UpdateCountry(t *testing.T, c *test.Test, cnl msgraph.CountryNamedLocation) {
+	status, err := c.NamedLocationsClient.UpdateCountry(c.Connection.Context, cnl)
 	if err != nil {
 		t.Fatalf("NamedLocationsClient.UpdateCountry(): %v", err)
 	}
@@ -173,8 +160,8 @@ func testNamedLocationsClient_UpdateCountry(t *testing.T, c NamedLocationsClient
 	}
 }
 
-func testNamedLocationsClient_List(t *testing.T, c NamedLocationsClientTest) (namedLocations *[]msgraph.NamedLocation) {
-	namedLocations, _, err := c.client.List(c.connection.Context, odata.Query{})
+func testNamedLocationsClient_List(t *testing.T, c *test.Test) (namedLocations *[]msgraph.NamedLocation) {
+	namedLocations, _, err := c.NamedLocationsClient.List(c.Connection.Context, odata.Query{})
 	if err != nil {
 		t.Fatalf("NamedLocationsClient.List(): %v", err)
 	}
@@ -191,8 +178,8 @@ func testNamedLocationsClient_List(t *testing.T, c NamedLocationsClientTest) (na
 	return
 }
 
-func testNamedLocationsClient_Delete(t *testing.T, c NamedLocationsClientTest, id string) {
-	status, err := c.client.Delete(c.connection.Context, id)
+func testNamedLocationsClient_Delete(t *testing.T, c *test.Test, id string) {
+	status, err := c.NamedLocationsClient.Delete(c.Connection.Context, id)
 	if err != nil {
 		t.Fatalf("NamedLocationsClient.Delete(): %v", err)
 	}

--- a/msgraph/namedlocations_test.go
+++ b/msgraph/namedlocations_test.go
@@ -11,7 +11,8 @@ import (
 )
 
 func TestNamedLocationsClient(t *testing.T) {
-	c := test.NewTest()
+	c := test.NewTest(t)
+	defer c.CancelFunc()
 
 	newIPNamedLocation := msgraph.IPNamedLocation{
 		BaseNamedLocation: &msgraph.BaseNamedLocation{
@@ -60,7 +61,7 @@ func TestNamedLocationsClient(t *testing.T) {
 }
 
 func testNamedLocationsClient_CreateIP(t *testing.T, c *test.Test, ipnl msgraph.IPNamedLocation) (ipNamedLocation *msgraph.IPNamedLocation) {
-	ipNamedLocation, status, err := c.NamedLocationsClient.CreateIP(c.Connection.Context, ipnl)
+	ipNamedLocation, status, err := c.NamedLocationsClient.CreateIP(c.Context, ipnl)
 	if err != nil {
 		t.Fatalf("NamedLocationsClient.CreateIP(): %v", err)
 	}
@@ -77,7 +78,7 @@ func testNamedLocationsClient_CreateIP(t *testing.T, c *test.Test, ipnl msgraph.
 }
 
 func testNamedLocationsClient_CreateCountry(t *testing.T, c *test.Test, cnl msgraph.CountryNamedLocation) (countryNamedLocation *msgraph.CountryNamedLocation) {
-	countryNamedLocation, status, err := c.NamedLocationsClient.CreateCountry(c.Connection.Context, cnl)
+	countryNamedLocation, status, err := c.NamedLocationsClient.CreateCountry(c.Context, cnl)
 	if err != nil {
 		t.Fatalf("NamedLocationsClient.CreateCountry(): %v", err)
 	}
@@ -94,7 +95,7 @@ func testNamedLocationsClient_CreateCountry(t *testing.T, c *test.Test, cnl msgr
 }
 
 func testNamedLocationsClient_GetIP(t *testing.T, c *test.Test, id string) (ipNamedLocation *msgraph.IPNamedLocation) {
-	ipNamedLocation, status, err := c.NamedLocationsClient.GetIP(c.Connection.Context, id, odata.Query{})
+	ipNamedLocation, status, err := c.NamedLocationsClient.GetIP(c.Context, id, odata.Query{})
 	if err != nil {
 		t.Fatalf("IPNamedLocationsClient.GetIP(): %v", err)
 	}
@@ -108,7 +109,7 @@ func testNamedLocationsClient_GetIP(t *testing.T, c *test.Test, id string) (ipNa
 }
 
 func testNamedLocationsClient_GetCountry(t *testing.T, c *test.Test, id string) (countryNamedLocation *msgraph.CountryNamedLocation) {
-	countryNamedLocation, status, err := c.NamedLocationsClient.GetCountry(c.Connection.Context, id, odata.Query{})
+	countryNamedLocation, status, err := c.NamedLocationsClient.GetCountry(c.Context, id, odata.Query{})
 	if err != nil {
 		t.Fatalf("NamedLocationsClient.GetCountry(): %v", err)
 	}
@@ -122,7 +123,7 @@ func testNamedLocationsClient_GetCountry(t *testing.T, c *test.Test, id string) 
 }
 
 func testNamedLocationsClient_Get(t *testing.T, c *test.Test, id string) (namedLocation *msgraph.NamedLocation) {
-	namedLocation, status, err := c.NamedLocationsClient.Get(c.Connection.Context, id, odata.Query{})
+	namedLocation, status, err := c.NamedLocationsClient.Get(c.Context, id, odata.Query{})
 	if err != nil {
 		t.Fatalf("NamedLocationsClient.Get(): %v", err)
 	}
@@ -141,7 +142,7 @@ func testNamedLocationsClient_Get(t *testing.T, c *test.Test, id string) (namedL
 }
 
 func testNamedLocationsClient_UpdateIP(t *testing.T, c *test.Test, ipnl msgraph.IPNamedLocation) {
-	status, err := c.NamedLocationsClient.UpdateIP(c.Connection.Context, ipnl)
+	status, err := c.NamedLocationsClient.UpdateIP(c.Context, ipnl)
 	if err != nil {
 		t.Fatalf("NamedLocationsClient.UpdateIP(): %v", err)
 	}
@@ -151,7 +152,7 @@ func testNamedLocationsClient_UpdateIP(t *testing.T, c *test.Test, ipnl msgraph.
 }
 
 func testNamedLocationsClient_UpdateCountry(t *testing.T, c *test.Test, cnl msgraph.CountryNamedLocation) {
-	status, err := c.NamedLocationsClient.UpdateCountry(c.Connection.Context, cnl)
+	status, err := c.NamedLocationsClient.UpdateCountry(c.Context, cnl)
 	if err != nil {
 		t.Fatalf("NamedLocationsClient.UpdateCountry(): %v", err)
 	}
@@ -161,7 +162,7 @@ func testNamedLocationsClient_UpdateCountry(t *testing.T, c *test.Test, cnl msgr
 }
 
 func testNamedLocationsClient_List(t *testing.T, c *test.Test) (namedLocations *[]msgraph.NamedLocation) {
-	namedLocations, _, err := c.NamedLocationsClient.List(c.Connection.Context, odata.Query{})
+	namedLocations, _, err := c.NamedLocationsClient.List(c.Context, odata.Query{})
 	if err != nil {
 		t.Fatalf("NamedLocationsClient.List(): %v", err)
 	}
@@ -179,7 +180,7 @@ func testNamedLocationsClient_List(t *testing.T, c *test.Test) (namedLocations *
 }
 
 func testNamedLocationsClient_Delete(t *testing.T, c *test.Test, id string) {
-	status, err := c.NamedLocationsClient.Delete(c.Connection.Context, id)
+	status, err := c.NamedLocationsClient.Delete(c.Context, id)
 	if err != nil {
 		t.Fatalf("NamedLocationsClient.Delete(): %v", err)
 	}

--- a/msgraph/reports_test.go
+++ b/msgraph/reports_test.go
@@ -3,24 +3,13 @@ package msgraph_test
 import (
 	"testing"
 
-	"github.com/manicminer/hamilton/auth"
 	"github.com/manicminer/hamilton/internal/test"
 	"github.com/manicminer/hamilton/msgraph"
 	"github.com/manicminer/hamilton/odata"
 )
 
-type ReportsClientTest struct {
-	connection *test.Connection
-	client     *msgraph.ReportsClient
-}
-
 func TestReports(t *testing.T) {
-	c := ReportsClientTest{
-		connection: test.NewConnection(auth.MsGraph, auth.TokenVersion2),
-	}
-	c.client = msgraph.NewReportsClient(c.connection.AuthConfig.TenantID)
-	c.client.BaseClient.Authorizer = c.connection.Authorizer
-	c.client.BaseClient.Endpoint = c.connection.AuthConfig.Environment.MsGraph.Endpoint
+	c := test.NewTest()
 
 	testReports_GetAuthenticationMethodsUsersRegisteredByFeature(t, c)
 	testReports_GetCredentialUserRegistrationCount(t, c)
@@ -31,8 +20,8 @@ func TestReports(t *testing.T) {
 
 }
 
-func testReports_GetAuthenticationMethodsUsersRegisteredByFeature(t *testing.T, c ReportsClientTest) (report *msgraph.UserRegistrationFeatureSummary) {
-	report, status, err := c.client.GetAuthenticationMethodsUsersRegisteredByFeature(c.connection.Context, odata.Query{})
+func testReports_GetAuthenticationMethodsUsersRegisteredByFeature(t *testing.T, c *test.Test) (report *msgraph.UserRegistrationFeatureSummary) {
+	report, status, err := c.ReportsClient.GetAuthenticationMethodsUsersRegisteredByFeature(c.Connection.Context, odata.Query{})
 	if status < 200 || status >= 300 {
 		t.Fatalf("ReportsClient.GetAuthenticationMethodsUsersRegisteredByFeature(): invalid status: %d", status)
 	}
@@ -47,8 +36,8 @@ func testReports_GetAuthenticationMethodsUsersRegisteredByFeature(t *testing.T, 
 	return
 }
 
-func testReports_GetCredentialUserRegistrationCount(t *testing.T, c ReportsClientTest) (report *[]msgraph.CredentialUserRegistrationCount) {
-	report, status, err := c.client.GetCredentialUserRegistrationCount(c.connection.Context, odata.Query{})
+func testReports_GetCredentialUserRegistrationCount(t *testing.T, c *test.Test) (report *[]msgraph.CredentialUserRegistrationCount) {
+	report, status, err := c.ReportsClient.GetCredentialUserRegistrationCount(c.Connection.Context, odata.Query{})
 	if status < 200 || status >= 300 {
 		t.Fatalf("ReportsClient.GetCredentialUserRegistrationCount(): invalid status: %d", status)
 	}
@@ -63,8 +52,8 @@ func testReports_GetCredentialUserRegistrationCount(t *testing.T, c ReportsClien
 	return
 }
 
-func testReports_GetCredentialUserRegistrationDetails(t *testing.T, c ReportsClientTest) (report *[]msgraph.CredentialUserRegistrationDetails) {
-	report, status, err := c.client.GetCredentialUserRegistrationDetails(c.connection.Context, odata.Query{})
+func testReports_GetCredentialUserRegistrationDetails(t *testing.T, c *test.Test) (report *[]msgraph.CredentialUserRegistrationDetails) {
+	report, status, err := c.ReportsClient.GetCredentialUserRegistrationDetails(c.Connection.Context, odata.Query{})
 	if status < 200 || status >= 300 {
 		t.Fatalf("ReportsClient.GetCredentialUserRegistrationDetails(): invalid status: %d", status)
 	}
@@ -79,8 +68,8 @@ func testReports_GetCredentialUserRegistrationDetails(t *testing.T, c ReportsCli
 	return
 }
 
-func testReports_GetUserCredentialUsageDetails(t *testing.T, c ReportsClientTest) (report *[]msgraph.UserCredentialUsageDetails) {
-	report, status, err := c.client.GetUserCredentialUsageDetails(c.connection.Context, odata.Query{})
+func testReports_GetUserCredentialUsageDetails(t *testing.T, c *test.Test) (report *[]msgraph.UserCredentialUsageDetails) {
+	report, status, err := c.ReportsClient.GetUserCredentialUsageDetails(c.Connection.Context, odata.Query{})
 	if status < 200 || status >= 300 {
 		t.Fatalf("ReportsClient.GetUserCredentialUsageDetails(): invalid status: %d", status)
 	}
@@ -95,8 +84,8 @@ func testReports_GetUserCredentialUsageDetails(t *testing.T, c ReportsClientTest
 	return
 }
 
-func testReports_GetCredentialUsageSummary(t *testing.T, c ReportsClientTest) (report *[]msgraph.CredentialUsageSummary) {
-	report, status, err := c.client.GetCredentialUsageSummary(c.connection.Context, msgraph.CredentialUsageSummaryPeriod1, odata.Query{})
+func testReports_GetCredentialUsageSummary(t *testing.T, c *test.Test) (report *[]msgraph.CredentialUsageSummary) {
+	report, status, err := c.ReportsClient.GetCredentialUsageSummary(c.Connection.Context, msgraph.CredentialUsageSummaryPeriod1, odata.Query{})
 	if status < 200 || status >= 300 {
 		t.Fatalf("ReportsClient.GetCredentialUsageSummary(): invalid status: %d", status)
 	}
@@ -111,8 +100,8 @@ func testReports_GetCredentialUsageSummary(t *testing.T, c ReportsClientTest) (r
 	return
 }
 
-func testReports_GetAuthenticationMethodsUsersRegisteredByMethod(t *testing.T, c ReportsClientTest) (report *msgraph.UserRegistrationMethodSummary) {
-	report, status, err := c.client.GetAuthenticationMethodsUsersRegisteredByMethod(c.connection.Context, odata.Query{})
+func testReports_GetAuthenticationMethodsUsersRegisteredByMethod(t *testing.T, c *test.Test) (report *msgraph.UserRegistrationMethodSummary) {
+	report, status, err := c.ReportsClient.GetAuthenticationMethodsUsersRegisteredByMethod(c.Connection.Context, odata.Query{})
 	if status < 200 || status >= 300 {
 		t.Fatalf("ReportsClient.GetAuthenticationMethodsUsersRegisteredByMethod(): invalid status: %d", status)
 	}

--- a/msgraph/reports_test.go
+++ b/msgraph/reports_test.go
@@ -9,7 +9,8 @@ import (
 )
 
 func TestReports(t *testing.T) {
-	c := test.NewTest()
+	c := test.NewTest(t)
+	defer c.CancelFunc()
 
 	testReports_GetAuthenticationMethodsUsersRegisteredByFeature(t, c)
 	testReports_GetCredentialUserRegistrationCount(t, c)
@@ -21,7 +22,7 @@ func TestReports(t *testing.T) {
 }
 
 func testReports_GetAuthenticationMethodsUsersRegisteredByFeature(t *testing.T, c *test.Test) (report *msgraph.UserRegistrationFeatureSummary) {
-	report, status, err := c.ReportsClient.GetAuthenticationMethodsUsersRegisteredByFeature(c.Connection.Context, odata.Query{})
+	report, status, err := c.ReportsClient.GetAuthenticationMethodsUsersRegisteredByFeature(c.Context, odata.Query{})
 	if status < 200 || status >= 300 {
 		t.Fatalf("ReportsClient.GetAuthenticationMethodsUsersRegisteredByFeature(): invalid status: %d", status)
 	}
@@ -37,7 +38,7 @@ func testReports_GetAuthenticationMethodsUsersRegisteredByFeature(t *testing.T, 
 }
 
 func testReports_GetCredentialUserRegistrationCount(t *testing.T, c *test.Test) (report *[]msgraph.CredentialUserRegistrationCount) {
-	report, status, err := c.ReportsClient.GetCredentialUserRegistrationCount(c.Connection.Context, odata.Query{})
+	report, status, err := c.ReportsClient.GetCredentialUserRegistrationCount(c.Context, odata.Query{})
 	if status < 200 || status >= 300 {
 		t.Fatalf("ReportsClient.GetCredentialUserRegistrationCount(): invalid status: %d", status)
 	}
@@ -53,7 +54,7 @@ func testReports_GetCredentialUserRegistrationCount(t *testing.T, c *test.Test) 
 }
 
 func testReports_GetCredentialUserRegistrationDetails(t *testing.T, c *test.Test) (report *[]msgraph.CredentialUserRegistrationDetails) {
-	report, status, err := c.ReportsClient.GetCredentialUserRegistrationDetails(c.Connection.Context, odata.Query{})
+	report, status, err := c.ReportsClient.GetCredentialUserRegistrationDetails(c.Context, odata.Query{})
 	if status < 200 || status >= 300 {
 		t.Fatalf("ReportsClient.GetCredentialUserRegistrationDetails(): invalid status: %d", status)
 	}
@@ -69,7 +70,7 @@ func testReports_GetCredentialUserRegistrationDetails(t *testing.T, c *test.Test
 }
 
 func testReports_GetUserCredentialUsageDetails(t *testing.T, c *test.Test) (report *[]msgraph.UserCredentialUsageDetails) {
-	report, status, err := c.ReportsClient.GetUserCredentialUsageDetails(c.Connection.Context, odata.Query{})
+	report, status, err := c.ReportsClient.GetUserCredentialUsageDetails(c.Context, odata.Query{})
 	if status < 200 || status >= 300 {
 		t.Fatalf("ReportsClient.GetUserCredentialUsageDetails(): invalid status: %d", status)
 	}
@@ -85,7 +86,7 @@ func testReports_GetUserCredentialUsageDetails(t *testing.T, c *test.Test) (repo
 }
 
 func testReports_GetCredentialUsageSummary(t *testing.T, c *test.Test) (report *[]msgraph.CredentialUsageSummary) {
-	report, status, err := c.ReportsClient.GetCredentialUsageSummary(c.Connection.Context, msgraph.CredentialUsageSummaryPeriod1, odata.Query{})
+	report, status, err := c.ReportsClient.GetCredentialUsageSummary(c.Context, msgraph.CredentialUsageSummaryPeriod1, odata.Query{})
 	if status < 200 || status >= 300 {
 		t.Fatalf("ReportsClient.GetCredentialUsageSummary(): invalid status: %d", status)
 	}
@@ -101,7 +102,7 @@ func testReports_GetCredentialUsageSummary(t *testing.T, c *test.Test) (report *
 }
 
 func testReports_GetAuthenticationMethodsUsersRegisteredByMethod(t *testing.T, c *test.Test) (report *msgraph.UserRegistrationMethodSummary) {
-	report, status, err := c.ReportsClient.GetAuthenticationMethodsUsersRegisteredByMethod(c.Connection.Context, odata.Query{})
+	report, status, err := c.ReportsClient.GetAuthenticationMethodsUsersRegisteredByMethod(c.Context, odata.Query{})
 	if status < 200 || status >= 300 {
 		t.Fatalf("ReportsClient.GetAuthenticationMethodsUsersRegisteredByMethod(): invalid status: %d", status)
 	}

--- a/msgraph/schema_extensions_test.go
+++ b/msgraph/schema_extensions_test.go
@@ -24,7 +24,8 @@ func (e *MyExtensionProperties) UnmarshalJSON(data []byte) error {
 }
 
 func TestSchemaExtensionsClient(t *testing.T) {
-	c := test.NewTest()
+	c := test.NewTest(t)
+	defer c.CancelFunc()
 
 	property1 := msgraph.ExtensionSchemaProperty{
 		Name: utils.StringPtr("property1"),
@@ -137,7 +138,7 @@ func testSchemaExtensionsGroup_Get(t *testing.T, c *test.Test, id string, schema
 	for _, s := range schemaExtensions {
 		sel = append(sel, s.ID)
 	}
-	group, status, err := c.GroupsClient.GetWithSchemaExtensions(c.Connection.Context, id, odata.Query{Select: sel}, &schemaExtensions)
+	group, status, err := c.GroupsClient.GetWithSchemaExtensions(c.Context, id, odata.Query{Select: sel}, &schemaExtensions)
 	if err != nil {
 		t.Fatalf("GroupsClient.Get(): %v", err)
 	}
@@ -228,7 +229,7 @@ func testSchemaExtensionsUser_Get(t *testing.T, c *test.Test, id string, schemaE
 	for _, s := range schemaExtensions {
 		sel = append(sel, s.ID)
 	}
-	user, status, err := c.UsersClient.GetWithSchemaExtensions(c.Connection.Context, id, odata.Query{Select: sel}, &schemaExtensions)
+	user, status, err := c.UsersClient.GetWithSchemaExtensions(c.Context, id, odata.Query{Select: sel}, &schemaExtensions)
 	if err != nil {
 		t.Fatalf("UsersClient.Get(): %v", err)
 	}
@@ -248,7 +249,7 @@ func testSchemaExtensionsUser_Get(t *testing.T, c *test.Test, id string, schemaE
 }
 
 func testSchemaExtensionsClient_Create(t *testing.T, c *test.Test, s msgraph.SchemaExtension) (schema *msgraph.SchemaExtension) {
-	schema, status, err := c.SchemaExtensionsClient.Create(c.Connection.Context, s)
+	schema, status, err := c.SchemaExtensionsClient.Create(c.Context, s)
 	if err != nil {
 		t.Fatalf("ApplicationsClient.Create(): %v", err)
 	}
@@ -265,7 +266,7 @@ func testSchemaExtensionsClient_Create(t *testing.T, c *test.Test, s msgraph.Sch
 }
 
 func testSchemaExtensionsClient_Get(t *testing.T, c *test.Test, id string) (schema *msgraph.SchemaExtension) {
-	schema, status, err := c.SchemaExtensionsClient.Get(c.Connection.Context, id, odata.Query{})
+	schema, status, err := c.SchemaExtensionsClient.Get(c.Context, id, odata.Query{})
 	if err != nil {
 		t.Fatalf("SchemaExtensionsClient.Get(): %v", err)
 	}
@@ -279,7 +280,7 @@ func testSchemaExtensionsClient_Get(t *testing.T, c *test.Test, id string) (sche
 }
 
 func testSchemaExtensionsClient_Update(t *testing.T, c *test.Test, s msgraph.SchemaExtension) {
-	status, err := c.SchemaExtensionsClient.Update(c.Connection.Context, s)
+	status, err := c.SchemaExtensionsClient.Update(c.Context, s)
 	if err != nil {
 		t.Fatalf("SchemaExtensionsClient.Update(): %v", err)
 	}
@@ -289,7 +290,7 @@ func testSchemaExtensionsClient_Update(t *testing.T, c *test.Test, s msgraph.Sch
 }
 
 func testSchemaExtensionsClient_Delete(t *testing.T, c *test.Test, id string) {
-	status, err := c.SchemaExtensionsClient.Delete(c.Connection.Context, id)
+	status, err := c.SchemaExtensionsClient.Delete(c.Context, id)
 	if err != nil {
 		t.Fatalf("SchemaExtensionsClient.Delete(): %v", err)
 	}

--- a/msgraph/schema_extensions_test.go
+++ b/msgraph/schema_extensions_test.go
@@ -6,18 +6,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/manicminer/hamilton/auth"
 	"github.com/manicminer/hamilton/internal/test"
 	"github.com/manicminer/hamilton/internal/utils"
 	"github.com/manicminer/hamilton/msgraph"
 	"github.com/manicminer/hamilton/odata"
 )
-
-type SchemaExtensionsClientTest struct {
-	connection   *test.Connection
-	client       *msgraph.SchemaExtensionsClient
-	randomString string
-}
 
 type MyExtensionProperties struct {
 	Property1 *string `json:"property1,omitempty"`
@@ -31,30 +24,7 @@ func (e *MyExtensionProperties) UnmarshalJSON(data []byte) error {
 }
 
 func TestSchemaExtensionsClient(t *testing.T) {
-	rs := test.RandomString()
-	c := SchemaExtensionsClientTest{
-		connection:   test.NewConnection(auth.MsGraph, auth.TokenVersion2),
-		randomString: rs,
-	}
-	c.client = msgraph.NewSchemaExtensionsClient(c.connection.AuthConfig.TenantID)
-	c.client.BaseClient.Authorizer = c.connection.Authorizer
-	c.client.BaseClient.Endpoint = c.connection.AuthConfig.Environment.MsGraph.Endpoint
-
-	g := GroupsClientTest{
-		connection:   test.NewConnection(auth.MsGraph, auth.TokenVersion2),
-		randomString: rs,
-	}
-	g.client = msgraph.NewGroupsClient(g.connection.AuthConfig.TenantID)
-	g.client.BaseClient.Authorizer = g.connection.Authorizer
-	g.client.BaseClient.Endpoint = g.connection.AuthConfig.Environment.MsGraph.Endpoint
-
-	u := UsersClientTest{
-		connection:   test.NewConnection(auth.MsGraph, auth.TokenVersion2),
-		randomString: rs,
-	}
-	u.client = msgraph.NewUsersClient(u.connection.AuthConfig.TenantID)
-	u.client.BaseClient.Authorizer = u.connection.Authorizer
-	u.client.BaseClient.Endpoint = u.connection.AuthConfig.Environment.MsGraph.Endpoint
+	c := test.NewTest()
 
 	property1 := msgraph.ExtensionSchemaProperty{
 		Name: utils.StringPtr("property1"),
@@ -91,19 +61,19 @@ func TestSchemaExtensionsClient(t *testing.T) {
 	// Replication seems to be a problem with schema extensions, no viable workaround as yet
 	time.Sleep(10 * time.Second)
 
-	testSchemaExtensionsGroup(t, g, schema)
-	testSchemaExtensionsUser(t, u, schema)
+	testSchemaExtensionsGroup(t, c, schema)
+	testSchemaExtensionsUser(t, c, schema)
 
 	testSchemaExtensionsClient_Delete(t, c, *schema.ID)
 }
 
-func testSchemaExtensionsGroup(t *testing.T, g GroupsClientTest, schema *msgraph.SchemaExtension) {
+func testSchemaExtensionsGroup(t *testing.T, c *test.Test, schema *msgraph.SchemaExtension) {
 	// First create a group having schema extension data expressed using msgraph.SchemaExtensionMap
-	group := testGroupsClient_Create(t, g, msgraph.Group{
+	group := testGroupsClient_Create(t, c, msgraph.Group{
 		DisplayName:     utils.StringPtr("test-group"),
 		GroupTypes:      []msgraph.GroupType{msgraph.GroupTypeUnified},
 		MailEnabled:     utils.BoolPtr(true),
-		MailNickname:    utils.StringPtr(fmt.Sprintf("test-365-group-%s", g.randomString)),
+		MailNickname:    utils.StringPtr(fmt.Sprintf("test-365-group-%s", c.RandomString)),
 		SecurityEnabled: utils.BoolPtr(true),
 		SchemaExtensions: &[]msgraph.SchemaExtensionData{
 			{
@@ -117,7 +87,7 @@ func testSchemaExtensionsGroup(t *testing.T, g GroupsClientTest, schema *msgraph
 	})
 
 	// Then retrieve the group and populate using msgraph.SchemaExtensionGraph
-	group = testSchemaExtensionsGroup_Get(t, g, *group.ID, []msgraph.SchemaExtensionData{
+	group = testSchemaExtensionsGroup_Get(t, c, *group.ID, []msgraph.SchemaExtensionData{
 		{
 			ID:         *schema.ID,
 			Properties: &msgraph.SchemaExtensionMap{},
@@ -142,10 +112,10 @@ func testSchemaExtensionsGroup(t *testing.T, g GroupsClientTest, schema *msgraph
 			},
 		},
 	}
-	testGroupsClient_Update(t, g, *group)
+	testGroupsClient_Update(t, c, *group)
 
 	// Finally retrieve the group and populate using MyExtensionProperties
-	group = testSchemaExtensionsGroup_Get(t, g, *group.ID, []msgraph.SchemaExtensionData{
+	group = testSchemaExtensionsGroup_Get(t, c, *group.ID, []msgraph.SchemaExtensionData{
 		{
 			ID:         *schema.ID,
 			Properties: &MyExtensionProperties{},
@@ -159,15 +129,15 @@ func testSchemaExtensionsGroup(t *testing.T, g GroupsClientTest, schema *msgraph
 		t.Fatalf("Unexpected value for Property2 returned: %+v", val)
 	}
 
-	testGroupsClient_Delete(t, g, *group.ID)
+	testGroupsClient_Delete(t, c, *group.ID)
 }
 
-func testSchemaExtensionsGroup_Get(t *testing.T, g GroupsClientTest, id string, schemaExtensions []msgraph.SchemaExtensionData) (group *msgraph.Group) {
+func testSchemaExtensionsGroup_Get(t *testing.T, c *test.Test, id string, schemaExtensions []msgraph.SchemaExtensionData) (group *msgraph.Group) {
 	sel := []string{"id", "displayName"}
 	for _, s := range schemaExtensions {
 		sel = append(sel, s.ID)
 	}
-	group, status, err := g.client.GetWithSchemaExtensions(g.connection.Context, id, odata.Query{Select: sel}, &schemaExtensions)
+	group, status, err := c.GroupsClient.GetWithSchemaExtensions(c.Connection.Context, id, odata.Query{Select: sel}, &schemaExtensions)
 	if err != nil {
 		t.Fatalf("GroupsClient.Get(): %v", err)
 	}
@@ -186,15 +156,15 @@ func testSchemaExtensionsGroup_Get(t *testing.T, g GroupsClientTest, id string, 
 	return
 }
 
-func testSchemaExtensionsUser(t *testing.T, u UsersClientTest, schema *msgraph.SchemaExtension) {
+func testSchemaExtensionsUser(t *testing.T, c *test.Test, schema *msgraph.SchemaExtension) {
 	// First create a user having schema extension data expressed using msgraph.SchemaExtensionMap
-	user := testUsersClient_Create(t, u, msgraph.User{
+	user := testUsersClient_Create(t, c, msgraph.User{
 		AccountEnabled:    utils.BoolPtr(true),
 		DisplayName:       utils.StringPtr("test-user"),
-		MailNickname:      utils.StringPtr(fmt.Sprintf("test-user-%s", u.randomString)),
-		UserPrincipalName: utils.StringPtr(fmt.Sprintf("test-user-%s@%s", u.randomString, u.connection.DomainName)),
+		MailNickname:      utils.StringPtr(fmt.Sprintf("test-user-%s", c.RandomString)),
+		UserPrincipalName: utils.StringPtr(fmt.Sprintf("test-user-%s@%s", c.RandomString, c.Connection.DomainName)),
 		PasswordProfile: &msgraph.UserPasswordProfile{
-			Password: utils.StringPtr(fmt.Sprintf("IrPa55w0rd%s", u.randomString)),
+			Password: utils.StringPtr(fmt.Sprintf("IrPa55w0rd%s", c.RandomString)),
 		},
 		SchemaExtensions: &[]msgraph.SchemaExtensionData{
 			{
@@ -208,7 +178,7 @@ func testSchemaExtensionsUser(t *testing.T, u UsersClientTest, schema *msgraph.S
 	})
 
 	// Then retrieve the user and populate using msgraph.SchemaExtensionGraph
-	user = testSchemaExtensionsUser_Get(t, u, *user.ID, []msgraph.SchemaExtensionData{
+	user = testSchemaExtensionsUser_Get(t, c, *user.ID, []msgraph.SchemaExtensionData{
 		{
 			ID:         *schema.ID,
 			Properties: &msgraph.SchemaExtensionMap{},
@@ -233,10 +203,10 @@ func testSchemaExtensionsUser(t *testing.T, u UsersClientTest, schema *msgraph.S
 			},
 		},
 	}
-	testUsersClient_Update(t, u, *user)
+	testUsersClient_Update(t, c, *user)
 
 	// Finally retrieve the user and populate using MyExtensionProperties
-	user = testSchemaExtensionsUser_Get(t, u, *user.ID, []msgraph.SchemaExtensionData{
+	user = testSchemaExtensionsUser_Get(t, c, *user.ID, []msgraph.SchemaExtensionData{
 		{
 			ID:         *schema.ID,
 			Properties: &MyExtensionProperties{},
@@ -250,15 +220,15 @@ func testSchemaExtensionsUser(t *testing.T, u UsersClientTest, schema *msgraph.S
 		t.Fatalf("Unexpected value for Property2 returned: %+v", val)
 	}
 
-	testUsersClient_Delete(t, u, *user.ID)
+	testUsersClient_Delete(t, c, *user.ID)
 }
 
-func testSchemaExtensionsUser_Get(t *testing.T, u UsersClientTest, id string, schemaExtensions []msgraph.SchemaExtensionData) (user *msgraph.User) {
+func testSchemaExtensionsUser_Get(t *testing.T, c *test.Test, id string, schemaExtensions []msgraph.SchemaExtensionData) (user *msgraph.User) {
 	sel := []string{"id", "displayName"}
 	for _, s := range schemaExtensions {
 		sel = append(sel, s.ID)
 	}
-	user, status, err := u.client.GetWithSchemaExtensions(u.connection.Context, id, odata.Query{Select: sel}, &schemaExtensions)
+	user, status, err := c.UsersClient.GetWithSchemaExtensions(c.Connection.Context, id, odata.Query{Select: sel}, &schemaExtensions)
 	if err != nil {
 		t.Fatalf("UsersClient.Get(): %v", err)
 	}
@@ -277,8 +247,8 @@ func testSchemaExtensionsUser_Get(t *testing.T, u UsersClientTest, id string, sc
 	return
 }
 
-func testSchemaExtensionsClient_Create(t *testing.T, c SchemaExtensionsClientTest, s msgraph.SchemaExtension) (schema *msgraph.SchemaExtension) {
-	schema, status, err := c.client.Create(c.connection.Context, s)
+func testSchemaExtensionsClient_Create(t *testing.T, c *test.Test, s msgraph.SchemaExtension) (schema *msgraph.SchemaExtension) {
+	schema, status, err := c.SchemaExtensionsClient.Create(c.Connection.Context, s)
 	if err != nil {
 		t.Fatalf("ApplicationsClient.Create(): %v", err)
 	}
@@ -294,8 +264,8 @@ func testSchemaExtensionsClient_Create(t *testing.T, c SchemaExtensionsClientTes
 	return
 }
 
-func testSchemaExtensionsClient_Get(t *testing.T, c SchemaExtensionsClientTest, id string) (schema *msgraph.SchemaExtension) {
-	schema, status, err := c.client.Get(c.connection.Context, id, odata.Query{})
+func testSchemaExtensionsClient_Get(t *testing.T, c *test.Test, id string) (schema *msgraph.SchemaExtension) {
+	schema, status, err := c.SchemaExtensionsClient.Get(c.Connection.Context, id, odata.Query{})
 	if err != nil {
 		t.Fatalf("SchemaExtensionsClient.Get(): %v", err)
 	}
@@ -308,8 +278,8 @@ func testSchemaExtensionsClient_Get(t *testing.T, c SchemaExtensionsClientTest, 
 	return
 }
 
-func testSchemaExtensionsClient_Update(t *testing.T, c SchemaExtensionsClientTest, s msgraph.SchemaExtension) {
-	status, err := c.client.Update(c.connection.Context, s)
+func testSchemaExtensionsClient_Update(t *testing.T, c *test.Test, s msgraph.SchemaExtension) {
+	status, err := c.SchemaExtensionsClient.Update(c.Connection.Context, s)
 	if err != nil {
 		t.Fatalf("SchemaExtensionsClient.Update(): %v", err)
 	}
@@ -318,8 +288,8 @@ func testSchemaExtensionsClient_Update(t *testing.T, c SchemaExtensionsClientTes
 	}
 }
 
-func testSchemaExtensionsClient_Delete(t *testing.T, c SchemaExtensionsClientTest, id string) {
-	status, err := c.client.Delete(c.connection.Context, id)
+func testSchemaExtensionsClient_Delete(t *testing.T, c *test.Test, id string) {
+	status, err := c.SchemaExtensionsClient.Delete(c.Connection.Context, id)
 	if err != nil {
 		t.Fatalf("SchemaExtensionsClient.Delete(): %v", err)
 	}

--- a/msgraph/serviceprincipals_test.go
+++ b/msgraph/serviceprincipals_test.go
@@ -13,7 +13,8 @@ import (
 )
 
 func TestServicePrincipalsClient(t *testing.T) {
-	c := test.NewTest()
+	c := test.NewTest(t)
+	defer c.CancelFunc()
 
 	app := testApplicationsClient_Create(t, c, msgraph.Application{
 		DisplayName: utils.StringPtr(fmt.Sprintf("test-serviceprincipal-%s", c.RandomString)),
@@ -80,7 +81,8 @@ func TestServicePrincipalsClient(t *testing.T) {
 }
 
 func TestServicePrincipalsClient_AppRoleAssignments(t *testing.T) {
-	c := test.NewTest()
+	c := test.NewTest(t)
+	defer c.CancelFunc()
 
 	// pre-generate uuid for a test app role
 	testResourceAppRoleId, _ := uuid.GenerateUUID()
@@ -153,7 +155,7 @@ func TestServicePrincipalsClient_AppRoleAssignments(t *testing.T) {
 }
 
 func testServicePrincipalsClient_Create(t *testing.T, c *test.Test, sp msgraph.ServicePrincipal) (servicePrincipal *msgraph.ServicePrincipal) {
-	servicePrincipal, status, err := c.ServicePrincipalsClient.Create(c.Connection.Context, sp)
+	servicePrincipal, status, err := c.ServicePrincipalsClient.Create(c.Context, sp)
 	if err != nil {
 		t.Fatalf("ServicePrincipalsClient.Create(): %v", err)
 	}
@@ -170,7 +172,7 @@ func testServicePrincipalsClient_Create(t *testing.T, c *test.Test, sp msgraph.S
 }
 
 func testServicePrincipalsClient_Update(t *testing.T, c *test.Test, sp msgraph.ServicePrincipal) (servicePrincipal *msgraph.ServicePrincipal) {
-	status, err := c.ServicePrincipalsClient.Update(c.Connection.Context, sp)
+	status, err := c.ServicePrincipalsClient.Update(c.Context, sp)
 	if err != nil {
 		t.Fatalf("ServicePrincipalsClient.Update(): %v", err)
 	}
@@ -181,7 +183,7 @@ func testServicePrincipalsClient_Update(t *testing.T, c *test.Test, sp msgraph.S
 }
 
 func testServicePrincipalsClient_List(t *testing.T, c *test.Test) (servicePrincipals *[]msgraph.ServicePrincipal) {
-	servicePrincipals, _, err := c.ServicePrincipalsClient.List(c.Connection.Context, odata.Query{Top: 10})
+	servicePrincipals, _, err := c.ServicePrincipalsClient.List(c.Context, odata.Query{Top: 10})
 	if err != nil {
 		t.Fatalf("ServicePrincipalsClient.List(): %v", err)
 	}
@@ -192,7 +194,7 @@ func testServicePrincipalsClient_List(t *testing.T, c *test.Test) (servicePrinci
 }
 
 func testServicePrincipalsClient_Get(t *testing.T, c *test.Test, id string) (servicePrincipal *msgraph.ServicePrincipal) {
-	servicePrincipal, status, err := c.ServicePrincipalsClient.Get(c.Connection.Context, id, odata.Query{})
+	servicePrincipal, status, err := c.ServicePrincipalsClient.Get(c.Context, id, odata.Query{})
 	if err != nil {
 		t.Fatalf("ServicePrincipalsClient.Get(): %v", err)
 	}
@@ -206,7 +208,7 @@ func testServicePrincipalsClient_Get(t *testing.T, c *test.Test, id string) (ser
 }
 
 func testServicePrincipalsClient_Delete(t *testing.T, c *test.Test, id string) {
-	status, err := c.ServicePrincipalsClient.Delete(c.Connection.Context, id)
+	status, err := c.ServicePrincipalsClient.Delete(c.Context, id)
 	if err != nil {
 		t.Fatalf("ServicePrincipalsClient.Delete(): %v", err)
 	}
@@ -216,7 +218,7 @@ func testServicePrincipalsClient_Delete(t *testing.T, c *test.Test, id string) {
 }
 
 func testServicePrincipalsClient_ListGroupMemberships(t *testing.T, c *test.Test, id string) (groups *[]msgraph.Group) {
-	groups, _, err := c.ServicePrincipalsClient.ListGroupMemberships(c.Connection.Context, id, odata.Query{})
+	groups, _, err := c.ServicePrincipalsClient.ListGroupMemberships(c.Context, id, odata.Query{})
 	if err != nil {
 		t.Fatalf("ServicePrincipalsClient.ListGroupMemberships(): %v", err)
 	}
@@ -234,7 +236,7 @@ func testServicePrincipalsClient_ListGroupMemberships(t *testing.T, c *test.Test
 
 func testServicePrincipalsClient_AddPassword(t *testing.T, c *test.Test, a *msgraph.ServicePrincipal) *msgraph.PasswordCredential {
 	pwd := msgraph.PasswordCredential{}
-	newPwd, status, err := c.ServicePrincipalsClient.AddPassword(c.Connection.Context, *a.ID, pwd)
+	newPwd, status, err := c.ServicePrincipalsClient.AddPassword(c.Context, *a.ID, pwd)
 	if err != nil {
 		t.Fatalf("ServicePrincipalsClient.AddPassword(): %v", err)
 	}
@@ -248,7 +250,7 @@ func testServicePrincipalsClient_AddPassword(t *testing.T, c *test.Test, a *msgr
 }
 
 func testServicePrincipalsClient_RemovePassword(t *testing.T, c *test.Test, a *msgraph.ServicePrincipal, p *msgraph.PasswordCredential) {
-	status, err := c.ServicePrincipalsClient.RemovePassword(c.Connection.Context, *a.ID, *p.KeyId)
+	status, err := c.ServicePrincipalsClient.RemovePassword(c.Context, *a.ID, *p.KeyId)
 	if err != nil {
 		t.Fatalf("ServicePrincipalsClient.RemovePassword(): %v", err)
 	}
@@ -258,7 +260,7 @@ func testServicePrincipalsClient_RemovePassword(t *testing.T, c *test.Test, a *m
 }
 
 func testServicePrincipalsClient_AddOwners(t *testing.T, c *test.Test, sp *msgraph.ServicePrincipal) {
-	status, err := c.ServicePrincipalsClient.AddOwners(c.Connection.Context, sp)
+	status, err := c.ServicePrincipalsClient.AddOwners(c.Context, sp)
 	if err != nil {
 		t.Fatalf("ServicePrincipalsClient.AddOwners(): %v", err)
 	}
@@ -268,7 +270,7 @@ func testServicePrincipalsClient_AddOwners(t *testing.T, c *test.Test, sp *msgra
 }
 
 func testServicePrincipalsClient_ListOwnedObjects(t *testing.T, c *test.Test, id string) (ownedObjects *[]string) {
-	ownedObjects, _, err := c.ServicePrincipalsClient.ListOwnedObjects(c.Connection.Context, id)
+	ownedObjects, _, err := c.ServicePrincipalsClient.ListOwnedObjects(c.Context, id)
 	if err != nil {
 		t.Fatalf("ServicePrincipalsClient.ListOwnedObjects(): %v", err)
 	}
@@ -284,7 +286,7 @@ func testServicePrincipalsClient_ListOwnedObjects(t *testing.T, c *test.Test, id
 }
 
 func testServicePrincipalsClient_ListOwners(t *testing.T, c *test.Test, id string, expected []string) (owners *[]string) {
-	owners, status, err := c.ServicePrincipalsClient.ListOwners(c.Connection.Context, id)
+	owners, status, err := c.ServicePrincipalsClient.ListOwners(c.Context, id)
 	if err != nil {
 		t.Fatalf("ServicePrincipalsClient.ListOwners(): %v", err)
 	}
@@ -317,7 +319,7 @@ func testServicePrincipalsClient_ListOwners(t *testing.T, c *test.Test, id strin
 }
 
 func testServicePrincipalsClient_GetOwner(t *testing.T, c *test.Test, spId, ownerId string) (owner *string) {
-	owner, status, err := c.ServicePrincipalsClient.GetOwner(c.Connection.Context, spId, ownerId)
+	owner, status, err := c.ServicePrincipalsClient.GetOwner(c.Context, spId, ownerId)
 	if err != nil {
 		t.Fatalf("ServicePrincipalsClient.GetOwner(): %v", err)
 	}
@@ -333,14 +335,14 @@ func testServicePrincipalsClient_GetOwner(t *testing.T, c *test.Test, spId, owne
 }
 
 func testServicePrincipalsClient_RemoveOwners(t *testing.T, c *test.Test, spId string, ownerIds []string) {
-	_, err := c.ServicePrincipalsClient.RemoveOwners(c.Connection.Context, spId, &ownerIds)
+	_, err := c.ServicePrincipalsClient.RemoveOwners(c.Context, spId, &ownerIds)
 	if err != nil {
 		t.Fatalf("ServicePrincipalsClient.RemoveOwners(): %v", err)
 	}
 }
 
 func testServicePrincipalsClient_AssignAppRole(t *testing.T, c *test.Test, principalId, resourceId, appRoleId string) (appRoleAssignment *msgraph.AppRoleAssignment) {
-	appRoleAssignment, status, err := c.ServicePrincipalsClient.AssignAppRoleForResource(c.Connection.Context, principalId, resourceId, appRoleId)
+	appRoleAssignment, status, err := c.ServicePrincipalsClient.AssignAppRoleForResource(c.Context, principalId, resourceId, appRoleId)
 	if err != nil {
 		t.Fatalf("ServicePrincipalsClient.AssignAppRoleForResource(): %v", err)
 	}
@@ -357,7 +359,7 @@ func testServicePrincipalsClient_AssignAppRole(t *testing.T, c *test.Test, princ
 }
 
 func testServicePrincipalsClient_ListAppRoleAssignments(t *testing.T, c *test.Test, resourceId string) (appRoleAssignments *[]msgraph.AppRoleAssignment) {
-	appRoleAssignments, _, err := c.ServicePrincipalsClient.ListAppRoleAssignments(c.Connection.Context, resourceId, odata.Query{})
+	appRoleAssignments, _, err := c.ServicePrincipalsClient.ListAppRoleAssignments(c.Context, resourceId, odata.Query{})
 	if err != nil {
 		t.Fatalf("ServicePrincipalsClient.ListAppRoleAssignments(): %v", err)
 	}
@@ -368,7 +370,7 @@ func testServicePrincipalsClient_ListAppRoleAssignments(t *testing.T, c *test.Te
 }
 
 func testServicePrincipalsClient_RemoveAppRoleAssignment(t *testing.T, c *test.Test, resourceId, appRoleAssignmentId string) {
-	status, err := c.ServicePrincipalsClient.RemoveAppRoleAssignment(c.Connection.Context, resourceId, appRoleAssignmentId)
+	status, err := c.ServicePrincipalsClient.RemoveAppRoleAssignment(c.Context, resourceId, appRoleAssignmentId)
 	if err != nil {
 		t.Fatalf("ServicePrincipalsClient.RemoveAppRoleAssignment(): %v", err)
 	}

--- a/msgraph/serviceprincipals_test.go
+++ b/msgraph/serviceprincipals_test.go
@@ -6,38 +6,17 @@ import (
 
 	"github.com/hashicorp/go-uuid"
 
-	"github.com/manicminer/hamilton/auth"
 	"github.com/manicminer/hamilton/internal/test"
 	"github.com/manicminer/hamilton/internal/utils"
 	"github.com/manicminer/hamilton/msgraph"
 	"github.com/manicminer/hamilton/odata"
 )
 
-type ServicePrincipalsClientTest struct {
-	connection   *test.Connection
-	client       *msgraph.ServicePrincipalsClient
-	randomString string
-}
-
 func TestServicePrincipalsClient(t *testing.T) {
-	rs := test.RandomString()
-	c := ServicePrincipalsClientTest{
-		connection:   test.NewConnection(auth.MsGraph, auth.TokenVersion2),
-		randomString: rs,
-	}
-	c.client = msgraph.NewServicePrincipalsClient(c.connection.AuthConfig.TenantID)
-	c.client.BaseClient.Authorizer = c.connection.Authorizer
-	c.client.BaseClient.Endpoint = c.connection.AuthConfig.Environment.MsGraph.Endpoint
+	c := test.NewTest()
 
-	a := ApplicationsClientTest{
-		connection:   test.NewConnection(auth.MsGraph, auth.TokenVersion2),
-		randomString: rs,
-	}
-	a.client = msgraph.NewApplicationsClient(a.connection.AuthConfig.TenantID)
-	a.client.BaseClient.Authorizer = a.connection.Authorizer
-	a.client.BaseClient.Endpoint = a.connection.AuthConfig.Environment.MsGraph.Endpoint
-	app := testApplicationsClient_Create(t, a, msgraph.Application{
-		DisplayName: utils.StringPtr(fmt.Sprintf("test-serviceprincipal-%s", a.randomString)),
+	app := testApplicationsClient_Create(t, c, msgraph.Application{
+		DisplayName: utils.StringPtr(fmt.Sprintf("test-serviceprincipal-%s", c.RandomString)),
 	})
 
 	sp := testServicePrincipalsClient_Create(t, c, msgraph.ServicePrincipal{
@@ -46,8 +25,8 @@ func TestServicePrincipalsClient(t *testing.T) {
 		DisplayName:    app.DisplayName,
 	})
 
-	appChild := testApplicationsClient_Create(t, a, msgraph.Application{
-		DisplayName: utils.StringPtr(fmt.Sprintf("test-serviceprincipal-child%s", a.randomString)),
+	appChild := testApplicationsClient_Create(t, c, msgraph.Application{
+		DisplayName: utils.StringPtr(fmt.Sprintf("test-serviceprincipal-child%s", c.RandomString)),
 	})
 	spChild := testServicePrincipalsClient_Create(t, c, msgraph.ServicePrincipal{
 		AccountEnabled: utils.BoolPtr(true),
@@ -66,78 +45,55 @@ func TestServicePrincipalsClient(t *testing.T) {
 	testServicePrincipalsClient_RemovePassword(t, c, sp, pwd)
 	testServicePrincipalsClient_List(t, c)
 
-	g := GroupsClientTest{
-		connection:   test.NewConnection(auth.MsGraph, auth.TokenVersion2),
-		randomString: rs,
-	}
-	g.client = msgraph.NewGroupsClient(g.connection.AuthConfig.TenantID)
-	g.client.BaseClient.Authorizer = g.connection.Authorizer
-	g.client.BaseClient.Endpoint = g.connection.AuthConfig.Environment.MsGraph.Endpoint
-
 	newGroupParent := msgraph.Group{
 		DisplayName:     utils.StringPtr("test-group-servicePrincipal-parent"),
 		MailEnabled:     utils.BoolPtr(false),
-		MailNickname:    utils.StringPtr(fmt.Sprintf("test-group-parent-%s", c.randomString)),
+		MailNickname:    utils.StringPtr(fmt.Sprintf("test-group-parent-%s", c.RandomString)),
 		SecurityEnabled: utils.BoolPtr(true),
 	}
 	newGroupChild := msgraph.Group{
 		DisplayName:     utils.StringPtr("test-group-servicePrincipal-child"),
 		MailEnabled:     utils.BoolPtr(false),
-		MailNickname:    utils.StringPtr(fmt.Sprintf("test-group-child-%s", c.randomString)),
+		MailNickname:    utils.StringPtr(fmt.Sprintf("test-group-child-%s", c.RandomString)),
 		SecurityEnabled: utils.BoolPtr(true),
 	}
 
-	groupParent := testGroupsClient_Create(t, g, newGroupParent)
-	groupChild := testGroupsClient_Create(t, g, newGroupChild)
+	groupParent := testGroupsClient_Create(t, c, newGroupParent)
+	groupChild := testGroupsClient_Create(t, c, newGroupChild)
 	groupParent.Members = &msgraph.Members{groupChild.DirectoryObject}
-	testGroupsClient_AddMembers(t, g, groupParent)
+	testGroupsClient_AddMembers(t, c, groupParent)
 	groupChild.Members = &msgraph.Members{sp.DirectoryObject}
-	testGroupsClient_AddMembers(t, g, groupChild)
+	testGroupsClient_AddMembers(t, c, groupChild)
 
 	testServicePrincipalsClient_ListGroupMemberships(t, c, *sp.ID)
 	testServicePrincipalsClient_ListOwnedObjects(t, c, *sp.ID)
 
 	testServicePrincipalsClient_RemoveOwners(t, c, *spChild.ID, []string{*sp.ID})
-	testGroupsClient_Delete(t, g, *groupParent.ID)
-	testGroupsClient_Delete(t, g, *groupChild.ID)
+	testGroupsClient_Delete(t, c, *groupParent.ID)
+	testGroupsClient_Delete(t, c, *groupChild.ID)
 
 	testServicePrincipalsClient_Delete(t, c, *sp.ID)
 	testServicePrincipalsClient_Delete(t, c, *spChild.ID)
 
-	testApplicationsClient_Delete(t, a, *app.ID)
-	testApplicationsClient_Delete(t, a, *appChild.ID)
+	testApplicationsClient_Delete(t, c, *app.ID)
+	testApplicationsClient_Delete(t, c, *appChild.ID)
 }
 
 func TestServicePrincipalsClient_AppRoleAssignments(t *testing.T) {
-	rs := test.RandomString()
-	c := ServicePrincipalsClientTest{
-		connection:   test.NewConnection(auth.MsGraph, auth.TokenVersion2),
-		randomString: rs,
-	}
-	c.client = msgraph.NewServicePrincipalsClient(c.connection.AuthConfig.TenantID)
-	c.client.BaseClient.Authorizer = c.connection.Authorizer
-	c.client.BaseClient.Endpoint = c.connection.AuthConfig.Environment.MsGraph.Endpoint
-
-	a := ApplicationsClientTest{
-		connection:   test.NewConnection(auth.MsGraph, auth.TokenVersion2),
-		randomString: rs,
-	}
-	a.client = msgraph.NewApplicationsClient(a.connection.AuthConfig.TenantID)
-	a.client.BaseClient.Authorizer = a.connection.Authorizer
-	a.client.BaseClient.Endpoint = a.connection.AuthConfig.Environment.MsGraph.Endpoint
+	c := test.NewTest()
 
 	// pre-generate uuid for a test app role
 	testResourceAppRoleId, _ := uuid.GenerateUUID()
 	// create a new test application with a test app role
-	app := testApplicationsClient_Create(t, a, msgraph.Application{
-		DisplayName: utils.StringPtr(fmt.Sprintf("test-serviceprincipal-appRoleAssignments-%s", a.randomString)),
+	app := testApplicationsClient_Create(t, c, msgraph.Application{
+		DisplayName: utils.StringPtr(fmt.Sprintf("test-serviceprincipal-appRoleAssignments-%s", c.RandomString)),
 		AppRoles: &[]msgraph.AppRole{
 			{
 				ID:          utils.StringPtr(testResourceAppRoleId),
-				DisplayName: utils.StringPtr(fmt.Sprintf("test-resourceApp-role-%s", a.randomString)),
+				DisplayName: utils.StringPtr(fmt.Sprintf("test-resourceApp-role-%s", c.RandomString)),
 				IsEnabled:   utils.BoolPtr(true),
-				Description: utils.StringPtr(fmt.Sprintf("test-resourceApp-role-description-%s", a.randomString)),
-				Value:       utils.StringPtr(fmt.Sprintf("test-resourceApp-role-value-%s", a.randomString)),
+				Description: utils.StringPtr(fmt.Sprintf("test-resourceApp-role-description-%s", c.RandomString)),
+				Value:       utils.StringPtr(fmt.Sprintf("test-resourceApp-role-value-%s", c.RandomString)),
 				AllowedMemberTypes: &[]msgraph.AppRoleAllowedMemberType{
 					msgraph.AppRoleAllowedMemberTypeUser,
 					msgraph.AppRoleAllowedMemberTypeApplication,
@@ -156,33 +112,25 @@ func TestServicePrincipalsClient_AppRoleAssignments(t *testing.T) {
 	testServicePrincipalsClient_Update(t, c, *sp)
 	testServicePrincipalsClient_List(t, c)
 
-	g := GroupsClientTest{
-		connection:   test.NewConnection(auth.MsGraph, auth.TokenVersion2),
-		randomString: rs,
-	}
-	g.client = msgraph.NewGroupsClient(g.connection.AuthConfig.TenantID)
-	g.client.BaseClient.Authorizer = g.connection.Authorizer
-	g.client.BaseClient.Endpoint = g.connection.AuthConfig.Environment.MsGraph.Endpoint
-
 	newGroupParent := msgraph.Group{
 		DisplayName:     utils.StringPtr("test-group-parent-servicePrincipals-appRoleAssignments"),
 		MailEnabled:     utils.BoolPtr(false),
-		MailNickname:    utils.StringPtr(fmt.Sprintf("test-group-parent-%s", c.randomString)),
+		MailNickname:    utils.StringPtr(fmt.Sprintf("test-group-parent-%s", c.RandomString)),
 		SecurityEnabled: utils.BoolPtr(true),
 	}
 	newGroupChild := msgraph.Group{
 		DisplayName:     utils.StringPtr("test-group-child-servicePrincipals-appRoleAssignments"),
 		MailEnabled:     utils.BoolPtr(false),
-		MailNickname:    utils.StringPtr(fmt.Sprintf("test-group-child-%s", c.randomString)),
+		MailNickname:    utils.StringPtr(fmt.Sprintf("test-group-child-%s", c.RandomString)),
 		SecurityEnabled: utils.BoolPtr(true),
 	}
 
-	groupParent := testGroupsClient_Create(t, g, newGroupParent)
-	groupChild := testGroupsClient_Create(t, g, newGroupChild)
+	groupParent := testGroupsClient_Create(t, c, newGroupParent)
+	groupChild := testGroupsClient_Create(t, c, newGroupChild)
 	groupParent.Members = &msgraph.Members{groupChild.DirectoryObject}
-	testGroupsClient_AddMembers(t, g, groupParent)
+	testGroupsClient_AddMembers(t, c, groupParent)
 	groupChild.Members = &msgraph.Members{sp.DirectoryObject}
-	testGroupsClient_AddMembers(t, g, groupChild)
+	testGroupsClient_AddMembers(t, c, groupChild)
 
 	testServicePrincipalsClient_ListGroupMemberships(t, c, *sp.ID)
 
@@ -197,15 +145,15 @@ func TestServicePrincipalsClient_AppRoleAssignments(t *testing.T) {
 	testServicePrincipalsClient_RemoveAppRoleAssignment(t, c, *sp.ID, *appRoleAssignment.Id)
 
 	// remove all test resources
-	testGroupsClient_Delete(t, g, *groupParent.ID)
-	testGroupsClient_Delete(t, g, *groupChild.ID)
+	testGroupsClient_Delete(t, c, *groupParent.ID)
+	testGroupsClient_Delete(t, c, *groupChild.ID)
 	testServicePrincipalsClient_Delete(t, c, *sp.ID)
-	testApplicationsClient_Delete(t, a, *app.ID)
+	testApplicationsClient_Delete(t, c, *app.ID)
 
 }
 
-func testServicePrincipalsClient_Create(t *testing.T, c ServicePrincipalsClientTest, sp msgraph.ServicePrincipal) (servicePrincipal *msgraph.ServicePrincipal) {
-	servicePrincipal, status, err := c.client.Create(c.connection.Context, sp)
+func testServicePrincipalsClient_Create(t *testing.T, c *test.Test, sp msgraph.ServicePrincipal) (servicePrincipal *msgraph.ServicePrincipal) {
+	servicePrincipal, status, err := c.ServicePrincipalsClient.Create(c.Connection.Context, sp)
 	if err != nil {
 		t.Fatalf("ServicePrincipalsClient.Create(): %v", err)
 	}
@@ -221,8 +169,8 @@ func testServicePrincipalsClient_Create(t *testing.T, c ServicePrincipalsClientT
 	return
 }
 
-func testServicePrincipalsClient_Update(t *testing.T, c ServicePrincipalsClientTest, sp msgraph.ServicePrincipal) (servicePrincipal *msgraph.ServicePrincipal) {
-	status, err := c.client.Update(c.connection.Context, sp)
+func testServicePrincipalsClient_Update(t *testing.T, c *test.Test, sp msgraph.ServicePrincipal) (servicePrincipal *msgraph.ServicePrincipal) {
+	status, err := c.ServicePrincipalsClient.Update(c.Connection.Context, sp)
 	if err != nil {
 		t.Fatalf("ServicePrincipalsClient.Update(): %v", err)
 	}
@@ -232,8 +180,8 @@ func testServicePrincipalsClient_Update(t *testing.T, c ServicePrincipalsClientT
 	return
 }
 
-func testServicePrincipalsClient_List(t *testing.T, c ServicePrincipalsClientTest) (servicePrincipals *[]msgraph.ServicePrincipal) {
-	servicePrincipals, _, err := c.client.List(c.connection.Context, odata.Query{Top: 10})
+func testServicePrincipalsClient_List(t *testing.T, c *test.Test) (servicePrincipals *[]msgraph.ServicePrincipal) {
+	servicePrincipals, _, err := c.ServicePrincipalsClient.List(c.Connection.Context, odata.Query{Top: 10})
 	if err != nil {
 		t.Fatalf("ServicePrincipalsClient.List(): %v", err)
 	}
@@ -243,8 +191,8 @@ func testServicePrincipalsClient_List(t *testing.T, c ServicePrincipalsClientTes
 	return
 }
 
-func testServicePrincipalsClient_Get(t *testing.T, c ServicePrincipalsClientTest, id string) (servicePrincipal *msgraph.ServicePrincipal) {
-	servicePrincipal, status, err := c.client.Get(c.connection.Context, id, odata.Query{})
+func testServicePrincipalsClient_Get(t *testing.T, c *test.Test, id string) (servicePrincipal *msgraph.ServicePrincipal) {
+	servicePrincipal, status, err := c.ServicePrincipalsClient.Get(c.Connection.Context, id, odata.Query{})
 	if err != nil {
 		t.Fatalf("ServicePrincipalsClient.Get(): %v", err)
 	}
@@ -257,8 +205,8 @@ func testServicePrincipalsClient_Get(t *testing.T, c ServicePrincipalsClientTest
 	return
 }
 
-func testServicePrincipalsClient_Delete(t *testing.T, c ServicePrincipalsClientTest, id string) {
-	status, err := c.client.Delete(c.connection.Context, id)
+func testServicePrincipalsClient_Delete(t *testing.T, c *test.Test, id string) {
+	status, err := c.ServicePrincipalsClient.Delete(c.Connection.Context, id)
 	if err != nil {
 		t.Fatalf("ServicePrincipalsClient.Delete(): %v", err)
 	}
@@ -267,8 +215,8 @@ func testServicePrincipalsClient_Delete(t *testing.T, c ServicePrincipalsClientT
 	}
 }
 
-func testServicePrincipalsClient_ListGroupMemberships(t *testing.T, c ServicePrincipalsClientTest, id string) (groups *[]msgraph.Group) {
-	groups, _, err := c.client.ListGroupMemberships(c.connection.Context, id, odata.Query{})
+func testServicePrincipalsClient_ListGroupMemberships(t *testing.T, c *test.Test, id string) (groups *[]msgraph.Group) {
+	groups, _, err := c.ServicePrincipalsClient.ListGroupMemberships(c.Connection.Context, id, odata.Query{})
 	if err != nil {
 		t.Fatalf("ServicePrincipalsClient.ListGroupMemberships(): %v", err)
 	}
@@ -284,9 +232,9 @@ func testServicePrincipalsClient_ListGroupMemberships(t *testing.T, c ServicePri
 	return
 }
 
-func testServicePrincipalsClient_AddPassword(t *testing.T, c ServicePrincipalsClientTest, a *msgraph.ServicePrincipal) *msgraph.PasswordCredential {
+func testServicePrincipalsClient_AddPassword(t *testing.T, c *test.Test, a *msgraph.ServicePrincipal) *msgraph.PasswordCredential {
 	pwd := msgraph.PasswordCredential{}
-	newPwd, status, err := c.client.AddPassword(c.connection.Context, *a.ID, pwd)
+	newPwd, status, err := c.ServicePrincipalsClient.AddPassword(c.Connection.Context, *a.ID, pwd)
 	if err != nil {
 		t.Fatalf("ServicePrincipalsClient.AddPassword(): %v", err)
 	}
@@ -299,8 +247,8 @@ func testServicePrincipalsClient_AddPassword(t *testing.T, c ServicePrincipalsCl
 	return newPwd
 }
 
-func testServicePrincipalsClient_RemovePassword(t *testing.T, c ServicePrincipalsClientTest, a *msgraph.ServicePrincipal, p *msgraph.PasswordCredential) {
-	status, err := c.client.RemovePassword(c.connection.Context, *a.ID, *p.KeyId)
+func testServicePrincipalsClient_RemovePassword(t *testing.T, c *test.Test, a *msgraph.ServicePrincipal, p *msgraph.PasswordCredential) {
+	status, err := c.ServicePrincipalsClient.RemovePassword(c.Connection.Context, *a.ID, *p.KeyId)
 	if err != nil {
 		t.Fatalf("ServicePrincipalsClient.RemovePassword(): %v", err)
 	}
@@ -309,8 +257,8 @@ func testServicePrincipalsClient_RemovePassword(t *testing.T, c ServicePrincipal
 	}
 }
 
-func testServicePrincipalsClient_AddOwners(t *testing.T, c ServicePrincipalsClientTest, sp *msgraph.ServicePrincipal) {
-	status, err := c.client.AddOwners(c.connection.Context, sp)
+func testServicePrincipalsClient_AddOwners(t *testing.T, c *test.Test, sp *msgraph.ServicePrincipal) {
+	status, err := c.ServicePrincipalsClient.AddOwners(c.Connection.Context, sp)
 	if err != nil {
 		t.Fatalf("ServicePrincipalsClient.AddOwners(): %v", err)
 	}
@@ -319,8 +267,8 @@ func testServicePrincipalsClient_AddOwners(t *testing.T, c ServicePrincipalsClie
 	}
 }
 
-func testServicePrincipalsClient_ListOwnedObjects(t *testing.T, c ServicePrincipalsClientTest, id string) (ownedObjects *[]string) {
-	ownedObjects, _, err := c.client.ListOwnedObjects(c.connection.Context, id)
+func testServicePrincipalsClient_ListOwnedObjects(t *testing.T, c *test.Test, id string) (ownedObjects *[]string) {
+	ownedObjects, _, err := c.ServicePrincipalsClient.ListOwnedObjects(c.Connection.Context, id)
 	if err != nil {
 		t.Fatalf("ServicePrincipalsClient.ListOwnedObjects(): %v", err)
 	}
@@ -335,8 +283,8 @@ func testServicePrincipalsClient_ListOwnedObjects(t *testing.T, c ServicePrincip
 	return
 }
 
-func testServicePrincipalsClient_ListOwners(t *testing.T, c ServicePrincipalsClientTest, id string, expected []string) (owners *[]string) {
-	owners, status, err := c.client.ListOwners(c.connection.Context, id)
+func testServicePrincipalsClient_ListOwners(t *testing.T, c *test.Test, id string, expected []string) (owners *[]string) {
+	owners, status, err := c.ServicePrincipalsClient.ListOwners(c.Connection.Context, id)
 	if err != nil {
 		t.Fatalf("ServicePrincipalsClient.ListOwners(): %v", err)
 	}
@@ -368,8 +316,8 @@ func testServicePrincipalsClient_ListOwners(t *testing.T, c ServicePrincipalsCli
 	return
 }
 
-func testServicePrincipalsClient_GetOwner(t *testing.T, c ServicePrincipalsClientTest, spId, ownerId string) (owner *string) {
-	owner, status, err := c.client.GetOwner(c.connection.Context, spId, ownerId)
+func testServicePrincipalsClient_GetOwner(t *testing.T, c *test.Test, spId, ownerId string) (owner *string) {
+	owner, status, err := c.ServicePrincipalsClient.GetOwner(c.Connection.Context, spId, ownerId)
 	if err != nil {
 		t.Fatalf("ServicePrincipalsClient.GetOwner(): %v", err)
 	}
@@ -384,15 +332,15 @@ func testServicePrincipalsClient_GetOwner(t *testing.T, c ServicePrincipalsClien
 	return
 }
 
-func testServicePrincipalsClient_RemoveOwners(t *testing.T, c ServicePrincipalsClientTest, spId string, ownerIds []string) {
-	_, err := c.client.RemoveOwners(c.connection.Context, spId, &ownerIds)
+func testServicePrincipalsClient_RemoveOwners(t *testing.T, c *test.Test, spId string, ownerIds []string) {
+	_, err := c.ServicePrincipalsClient.RemoveOwners(c.Connection.Context, spId, &ownerIds)
 	if err != nil {
 		t.Fatalf("ServicePrincipalsClient.RemoveOwners(): %v", err)
 	}
 }
 
-func testServicePrincipalsClient_AssignAppRole(t *testing.T, c ServicePrincipalsClientTest, principalId, resourceId, appRoleId string) (appRoleAssignment *msgraph.AppRoleAssignment) {
-	appRoleAssignment, status, err := c.client.AssignAppRoleForResource(c.connection.Context, principalId, resourceId, appRoleId)
+func testServicePrincipalsClient_AssignAppRole(t *testing.T, c *test.Test, principalId, resourceId, appRoleId string) (appRoleAssignment *msgraph.AppRoleAssignment) {
+	appRoleAssignment, status, err := c.ServicePrincipalsClient.AssignAppRoleForResource(c.Connection.Context, principalId, resourceId, appRoleId)
 	if err != nil {
 		t.Fatalf("ServicePrincipalsClient.AssignAppRoleForResource(): %v", err)
 	}
@@ -408,8 +356,8 @@ func testServicePrincipalsClient_AssignAppRole(t *testing.T, c ServicePrincipals
 	return
 }
 
-func testServicePrincipalsClient_ListAppRoleAssignments(t *testing.T, c ServicePrincipalsClientTest, resourceId string) (appRoleAssignments *[]msgraph.AppRoleAssignment) {
-	appRoleAssignments, _, err := c.client.ListAppRoleAssignments(c.connection.Context, resourceId, odata.Query{})
+func testServicePrincipalsClient_ListAppRoleAssignments(t *testing.T, c *test.Test, resourceId string) (appRoleAssignments *[]msgraph.AppRoleAssignment) {
+	appRoleAssignments, _, err := c.ServicePrincipalsClient.ListAppRoleAssignments(c.Connection.Context, resourceId, odata.Query{})
 	if err != nil {
 		t.Fatalf("ServicePrincipalsClient.ListAppRoleAssignments(): %v", err)
 	}
@@ -419,8 +367,8 @@ func testServicePrincipalsClient_ListAppRoleAssignments(t *testing.T, c ServiceP
 	return
 }
 
-func testServicePrincipalsClient_RemoveAppRoleAssignment(t *testing.T, c ServicePrincipalsClientTest, resourceId, appRoleAssignmentId string) {
-	status, err := c.client.RemoveAppRoleAssignment(c.connection.Context, resourceId, appRoleAssignmentId)
+func testServicePrincipalsClient_RemoveAppRoleAssignment(t *testing.T, c *test.Test, resourceId, appRoleAssignmentId string) {
+	status, err := c.ServicePrincipalsClient.RemoveAppRoleAssignment(c.Connection.Context, resourceId, appRoleAssignmentId)
 	if err != nil {
 		t.Fatalf("ServicePrincipalsClient.RemoveAppRoleAssignment(): %v", err)
 	}

--- a/msgraph/sign_in_reports.go
+++ b/msgraph/sign_in_reports.go
@@ -15,8 +15,8 @@ type SignInReportsClient struct {
 	BaseClient Client
 }
 
-// NewSignInLogsClient returns a new SignInReportsClient.
-func NewSignInLogsClient(tenantId string) *SignInReportsClient {
+// NewSignInReportsClient returns a new SignInReportsClient.
+func NewSignInReportsClient(tenantId string) *SignInReportsClient {
 	return &SignInReportsClient{
 		BaseClient: NewClient(VersionBeta, tenantId),
 	}

--- a/msgraph/sign_in_reports_test.go
+++ b/msgraph/sign_in_reports_test.go
@@ -3,24 +3,13 @@ package msgraph_test
 import (
 	"testing"
 
-	"github.com/manicminer/hamilton/auth"
 	"github.com/manicminer/hamilton/internal/test"
 	"github.com/manicminer/hamilton/msgraph"
 	"github.com/manicminer/hamilton/odata"
 )
 
-type SignInReportsClientTest struct {
-	connection *test.Connection
-	client     *msgraph.SignInReportsClient
-}
-
 func TestSignInReportsTest(t *testing.T) {
-	c := SignInReportsClientTest{
-		connection: test.NewConnection(auth.MsGraph, auth.TokenVersion2),
-	}
-	c.client = msgraph.NewSignInLogsClient(c.connection.AuthConfig.TenantID)
-	c.client.BaseClient.Authorizer = c.connection.Authorizer
-	c.client.BaseClient.Endpoint = c.connection.AuthConfig.Environment.MsGraph.Endpoint
+	c := test.NewTest()
 
 	signInLogs := testSignInReports_List(t, c)
 	if *signInLogs != nil && len(*signInLogs) > 0 {
@@ -28,8 +17,8 @@ func TestSignInReportsTest(t *testing.T) {
 	}
 }
 
-func testSignInReports_List(t *testing.T, c SignInReportsClientTest) (signInLogs *[]msgraph.SignInReport) {
-	signInLogs, status, err := c.client.List(c.connection.Context, odata.Query{Top: 10})
+func testSignInReports_List(t *testing.T, c *test.Test) (signInLogs *[]msgraph.SignInReport) {
+	signInLogs, status, err := c.SignInReportsClient.List(c.Connection.Context, odata.Query{Top: 10})
 
 	if status < 200 || status >= 300 {
 		t.Fatalf("SignInReportsClient.List(): invalid status: %d", status)
@@ -45,8 +34,8 @@ func testSignInReports_List(t *testing.T, c SignInReportsClientTest) (signInLogs
 	return
 }
 
-func testSignInReports_Get(t *testing.T, c SignInReportsClientTest, id string) (signInLog *msgraph.SignInReport) {
-	signInLog, status, err := c.client.Get(c.connection.Context, id, odata.Query{})
+func testSignInReports_Get(t *testing.T, c *test.Test, id string) (signInLog *msgraph.SignInReport) {
+	signInLog, status, err := c.SignInReportsClient.Get(c.Connection.Context, id, odata.Query{})
 	if err != nil {
 		t.Fatalf("SignInReportsClient.Get(): %v", err)
 	}

--- a/msgraph/sign_in_reports_test.go
+++ b/msgraph/sign_in_reports_test.go
@@ -9,7 +9,8 @@ import (
 )
 
 func TestSignInReportsTest(t *testing.T) {
-	c := test.NewTest()
+	c := test.NewTest(t)
+	defer c.CancelFunc()
 
 	signInLogs := testSignInReports_List(t, c)
 	if *signInLogs != nil && len(*signInLogs) > 0 {
@@ -18,7 +19,7 @@ func TestSignInReportsTest(t *testing.T) {
 }
 
 func testSignInReports_List(t *testing.T, c *test.Test) (signInLogs *[]msgraph.SignInReport) {
-	signInLogs, status, err := c.SignInReportsClient.List(c.Connection.Context, odata.Query{Top: 10})
+	signInLogs, status, err := c.SignInReportsClient.List(c.Context, odata.Query{Top: 10})
 
 	if status < 200 || status >= 300 {
 		t.Fatalf("SignInReportsClient.List(): invalid status: %d", status)
@@ -35,7 +36,7 @@ func testSignInReports_List(t *testing.T, c *test.Test) (signInLogs *[]msgraph.S
 }
 
 func testSignInReports_Get(t *testing.T, c *test.Test, id string) (signInLog *msgraph.SignInReport) {
-	signInLog, status, err := c.SignInReportsClient.Get(c.Connection.Context, id, odata.Query{})
+	signInLog, status, err := c.SignInReportsClient.Get(c.Context, id, odata.Query{})
 	if err != nil {
 		t.Fatalf("SignInReportsClient.Get(): %v", err)
 	}

--- a/msgraph/users_test.go
+++ b/msgraph/users_test.go
@@ -11,7 +11,8 @@ import (
 )
 
 func TestUsersClient(t *testing.T) {
-	c := test.NewTest()
+	c := test.NewTest(t)
+	defer c.CancelFunc()
 
 	user := testUsersClient_Create(t, c, msgraph.User{
 		AccountEnabled:    utils.BoolPtr(true),
@@ -74,7 +75,7 @@ func TestUsersClient(t *testing.T) {
 }
 
 func testUsersClient_Create(t *testing.T, c *test.Test, u msgraph.User) (user *msgraph.User) {
-	user, status, err := c.UsersClient.Create(c.Connection.Context, u)
+	user, status, err := c.UsersClient.Create(c.Context, u)
 	if err != nil {
 		t.Fatalf("UsersClient.Create(): %v", err)
 	}
@@ -91,7 +92,7 @@ func testUsersClient_Create(t *testing.T, c *test.Test, u msgraph.User) (user *m
 }
 
 func testUsersClient_Update(t *testing.T, c *test.Test, u msgraph.User) {
-	status, err := c.UsersClient.Update(c.Connection.Context, u)
+	status, err := c.UsersClient.Update(c.Context, u)
 	if err != nil {
 		t.Fatalf("UsersClient.Update(): %v", err)
 	}
@@ -101,7 +102,7 @@ func testUsersClient_Update(t *testing.T, c *test.Test, u msgraph.User) {
 }
 
 func testUsersClient_List(t *testing.T, c *test.Test) (users *[]msgraph.User) {
-	users, _, err := c.UsersClient.List(c.Connection.Context, odata.Query{Top: 10, Expand: odata.Expand{Relationship: "memberOf"}})
+	users, _, err := c.UsersClient.List(c.Context, odata.Query{Top: 10, Expand: odata.Expand{Relationship: "memberOf"}})
 	if err != nil {
 		t.Fatalf("UsersClient.List(): %v", err)
 	}
@@ -112,7 +113,7 @@ func testUsersClient_List(t *testing.T, c *test.Test) (users *[]msgraph.User) {
 }
 
 func testUsersClient_Get(t *testing.T, c *test.Test, id string) (user *msgraph.User) {
-	user, status, err := c.UsersClient.Get(c.Connection.Context, id, odata.Query{})
+	user, status, err := c.UsersClient.Get(c.Context, id, odata.Query{})
 	if err != nil {
 		t.Fatalf("UsersClient.Get(): %v", err)
 	}
@@ -126,7 +127,7 @@ func testUsersClient_Get(t *testing.T, c *test.Test, id string) (user *msgraph.U
 }
 
 func testUsersClient_GetDeleted(t *testing.T, c *test.Test, id string) (user *msgraph.User) {
-	user, status, err := c.UsersClient.GetDeleted(c.Connection.Context, id, odata.Query{})
+	user, status, err := c.UsersClient.GetDeleted(c.Context, id, odata.Query{})
 	if err != nil {
 		t.Fatalf("UsersClient.GetDeleted(): %v", err)
 	}
@@ -140,7 +141,7 @@ func testUsersClient_GetDeleted(t *testing.T, c *test.Test, id string) (user *ms
 }
 
 func testUsersClient_Delete(t *testing.T, c *test.Test, id string) {
-	status, err := c.UsersClient.Delete(c.Connection.Context, id)
+	status, err := c.UsersClient.Delete(c.Context, id)
 	if err != nil {
 		t.Fatalf("UsersClient.Delete(): %v", err)
 	}
@@ -150,7 +151,7 @@ func testUsersClient_Delete(t *testing.T, c *test.Test, id string) {
 }
 
 func testUsersClient_DeletePermanently(t *testing.T, c *test.Test, id string) {
-	status, err := c.UsersClient.DeletePermanently(c.Connection.Context, id)
+	status, err := c.UsersClient.DeletePermanently(c.Context, id)
 	if err != nil {
 		t.Fatalf("UsersClient.DeletePermanently(): %v", err)
 	}
@@ -160,7 +161,7 @@ func testUsersClient_DeletePermanently(t *testing.T, c *test.Test, id string) {
 }
 
 func testUsersClient_ListGroupMemberships(t *testing.T, c *test.Test, id string) (groups *[]msgraph.Group) {
-	groups, _, err := c.UsersClient.ListGroupMemberships(c.Connection.Context, id, odata.Query{})
+	groups, _, err := c.UsersClient.ListGroupMemberships(c.Context, id, odata.Query{})
 	if err != nil {
 		t.Fatalf("UsersClient.ListGroupMemberships(): %v", err)
 	}
@@ -177,7 +178,7 @@ func testUsersClient_ListGroupMemberships(t *testing.T, c *test.Test, id string)
 }
 
 func testUsersClient_ListDeleted(t *testing.T, c *test.Test, expectedId string) (deletedUsers *[]msgraph.User) {
-	deletedUsers, status, err := c.UsersClient.ListDeleted(c.Connection.Context, odata.Query{
+	deletedUsers, status, err := c.UsersClient.ListDeleted(c.Context, odata.Query{
 		Filter: fmt.Sprintf("id eq '%s'", expectedId),
 		Top:    10,
 	})
@@ -207,7 +208,7 @@ func testUsersClient_ListDeleted(t *testing.T, c *test.Test, expectedId string) 
 }
 
 func testUsersClient_RestoreDeleted(t *testing.T, c *test.Test, id string) {
-	user, status, err := c.UsersClient.RestoreDeleted(c.Connection.Context, id)
+	user, status, err := c.UsersClient.RestoreDeleted(c.Context, id)
 	if err != nil {
 		t.Fatalf("UsersClient.RestoreDeleted(): %v", err)
 	}
@@ -226,7 +227,7 @@ func testUsersClient_RestoreDeleted(t *testing.T, c *test.Test, id string) {
 }
 
 func testUsersClient_AssignManager(t *testing.T, c *test.Test, id string, manager msgraph.User) {
-	status, err := c.UsersClient.AssignManager(c.Connection.Context, id, manager)
+	status, err := c.UsersClient.AssignManager(c.Context, id, manager)
 	if err != nil {
 		t.Fatalf("UsersClient.AssignManager(): %v", err)
 	}
@@ -236,7 +237,7 @@ func testUsersClient_AssignManager(t *testing.T, c *test.Test, id string, manage
 }
 
 func testUsersClient_GetManager(t *testing.T, c *test.Test, id string) (user *msgraph.User) {
-	user, status, err := c.UsersClient.GetManager(c.Connection.Context, id)
+	user, status, err := c.UsersClient.GetManager(c.Context, id)
 	if err != nil {
 		t.Fatalf("UsersClient.GetManager(): %v", err)
 	}
@@ -250,7 +251,7 @@ func testUsersClient_GetManager(t *testing.T, c *test.Test, id string) (user *ms
 }
 
 func testUsersClient_DeleteManager(t *testing.T, c *test.Test, id string) (user *msgraph.User) {
-	status, err := c.UsersClient.DeleteManager(c.Connection.Context, id)
+	status, err := c.UsersClient.DeleteManager(c.Context, id)
 	if err != nil {
 		t.Fatalf("UsersClient.DeleteManager(): %v", err)
 	}

--- a/odata/errors.go
+++ b/odata/errors.go
@@ -4,6 +4,7 @@ const (
 	ErrorAddedObjectReferencesAlreadyExist      = "One or more added object references already exist"
 	ErrorCannotDeleteOrUpdateEnabledEntitlement = "Permission (scope or role) cannot be deleted or updated unless disabled first"
 	ErrorConflictingObjectPresentInDirectory    = "A conflicting object with one or more of the specified property values is present in the directory"
+	ErrorNotValidReferenceUpdate                = "Not a valid reference update"
 	ErrorResourceDoesNotExist                   = "Resource '.+' does not exist or one of its queried reference-property objects are not present"
 	ErrorRemovedObjectReferencesDoNotExist      = "One or more removed object references do not exist"
 	ErrorServicePrincipalAppInOtherTenant       = "When using this permission, the backing application of the service principal being created must in the local tenant"


### PR DESCRIPTION
- Auth package refactoring:
  - Remove the `auth.Api` type and instead use `environments.Api` directly
  - Use the resource URI instead of the friendly name for Azure CLI auth tokens

- Add the `AuxiliaryTokens()` method to the `auth.Authorizer` interface to support obtaining tokens for additional tenants
- Expand support in `auth.AutorestAuthorizerWrapper` to support any `autorest.Authorizer`
  - `autorest.BearerAuthorizer` and `autorest.MultiTenantBearerAuthorizer` are fully supported with access tokens, refresh tokens and expiry
  - Other authorizers can supply access tokens only
- Support auxiliary tenants with client secret and client certificate authorizers

- Implement the `autorest.Authorizer` interface with `auth.CachedAuthorizer` (which wraps all supported Authorizers)
  - This allows authorizers to be used with https://github.com/Azure/go-autorest, with multi-tenant support, with the exception of `auth.MsiAuthorizer`

- Export environment configs for more management plane APIs:
  - Resource Manager
  - Batch Management
  - Data Lake
  - Gallery
  - KeyVault
  - Operational Insights
  - OSS RDBMS
  - Service Bus
  - Service Management (Azure Classic)
  - SQL Database
  - Storage
  - Synapse

- Refactor and tidy up tests for the `msgraph` package

- Say goodbye to Azure Germany 🇩🇪 

⚠️ BREAKING CHANGES:

- The signatures for `auth.NewClientCertificateAuthorizer`, `auth.NewClientSecretAuthorizer` and `auth.NewAzureCliAuthorizer` have changed to accommodate passing additional tenant IDs for multi-tenant authorization.