### PR TITLE
Helper func to load environment from metadata endpoint

### DIFF
--- a/.github/workflows/environments-tests.yml
+++ b/.github/workflows/environments-tests.yml
@@ -1,0 +1,27 @@
+---
+name: Tests - environments
+on:
+  pull_request:
+    types: ["opened", "synchronize"]
+    paths:
+      - "environments/**.go"
+      - ".github/workflows/environments-tests.yml"
+
+jobs:
+  test-environments:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+    steps:
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.16.4
+
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Test
+        run: go test -count=1 -race -v ./environments
+
+# vim: set ts=2 sts=2 sw=2 et:

--- a/environments/apis.go
+++ b/environments/apis.go
@@ -104,17 +104,17 @@ var (
 	}
 
 	KeyVaultPublic = Api{
-		AppId:    PublishedApis["AzureBatch"],
+		AppId:    PublishedApis["AzureKeyVault"],
 		Endpoint: KeyVaultPublicEndpoint,
 	}
 
 	KeyVaultChina = Api{
-		AppId:    PublishedApis["AzureBatch"],
+		AppId:    PublishedApis["AzureKeyVault"],
 		Endpoint: KeyVaultChinaEndpoint,
 	}
 
 	KeyVaultUSGov = Api{
-		AppId:    PublishedApis["AzureBatch"],
+		AppId:    PublishedApis["AzureKeyVault"],
 		Endpoint: KeyVaultUSGovEndpoint,
 	}
 

--- a/environments/metadata.go
+++ b/environments/metadata.go
@@ -1,0 +1,70 @@
+package environments
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strings"
+)
+
+type metadataEndpoints struct {
+	GalleryEndpoint  string `json:"galleryEndpoint"`
+	AadGraphEndpoint string `json:"graphEndpoint"`
+	AadGraphAudience string `json:"graphAudience"`
+	PortalEndpoint   string `json:"portalEndpoint"`
+	Authentication   struct {
+		LoginEndpoint       string   `json:"loginEndpoint"`
+		ManagementAudiences []string `json:"audiences"`
+		Tenant              string   `json:"tenant"`
+	} `json:"authentication"`
+}
+
+func EnvironmentFromMetadata(endpoint string) (*Environment, error) {
+	uri := fmt.Sprintf("%s/%s", strings.TrimSuffix(endpoint, "/"), "/metadata/endpoints?api-version=1.0")
+	resp, err := http.Get(uri)
+	if err != nil {
+		return nil, fmt.Errorf("unable to load metadata from %q: %v", uri, err)
+	}
+
+	defer resp.Body.Close()
+	jsonResponse, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("reading response from %q: %v", uri, err)
+	}
+
+	var endpoints metadataEndpoints
+	err = json.Unmarshal(jsonResponse, &endpoints)
+	if err != nil {
+		return nil, fmt.Errorf("unmarshaling response from %q: %v", uri, err)
+	}
+
+	resourceManagerEndpoint := strings.TrimSuffix(endpoint, "/")
+
+	env := Environment{
+		AzureADEndpoint: AzureADEndpoint(strings.TrimSuffix(endpoints.Authentication.LoginEndpoint, "/")),
+		AadGraph: Api{
+			AppId:    PublishedApis["AzureActiveDirectoryGraph"],
+			Endpoint: ApiEndpoint(strings.TrimSuffix(endpoints.AadGraphEndpoint, "/")),
+		},
+		ResourceManager: Api{
+			AppId:    PublishedApis["AzureServiceManagement"],
+			Endpoint: ApiEndpoint(resourceManagerEndpoint),
+		},
+	}
+
+	// The following logic borrowed from go-autorest in order to meet user expectations
+	if parts := strings.Split(resourceManagerEndpoint, "."); len(parts) > 2 {
+		dnsSuffix := fmt.Sprintf("%s.%s", parts[len(parts)-2], parts[len(parts)-1])
+		env.KeyVault = Api{
+			AppId:    PublishedApis["AzureKeyVault"],
+			Endpoint: ApiEndpoint(fmt.Sprintf("https://%s.%s", "vault", dnsSuffix)),
+		}
+		env.Storage = Api{
+			AppId:    PublishedApis["AzureStorage"],
+			Endpoint: ApiEndpoint(fmt.Sprintf("https://%s.%s", "storage", dnsSuffix)),
+		}
+	}
+
+	return &env, nil
+}

--- a/environments/metadata_test.go
+++ b/environments/metadata_test.go
@@ -1,0 +1,40 @@
+package environments
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestEnvironmentFromMetadata(t *testing.T) {
+	env, err := EnvironmentFromMetadata("https://management.azure.com/")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if env == nil {
+		t.Fatal("env was nil")
+	}
+
+	expected := Environment{
+		AzureADEndpoint: AzureADEndpoint("https://login.microsoftonline.com"),
+		AadGraph: Api{
+			AppId:    PublishedApis["AzureActiveDirectoryGraph"],
+			Endpoint: ApiEndpoint("https://graph.windows.net"),
+		},
+		KeyVault: Api{
+			AppId:    PublishedApis["AzureKeyVault"],
+			Endpoint: ApiEndpoint("https://vault.azure.com"),
+		},
+		ResourceManager: Api{
+			AppId:    PublishedApis["AzureServiceManagement"],
+			Endpoint: "https://management.azure.com",
+		},
+		Storage: Api{
+			AppId:    PublishedApis["AzureStorage"],
+			Endpoint: ApiEndpoint("https://storage.azure.com"),
+		},
+	}
+
+	if !reflect.DeepEqual(*env, expected) {
+		t.Fatalf("expected: %#v, got: %#v", expected, *env)
+	}
+}


### PR DESCRIPTION
Helper func to generate environment configuration from metadata endpoint

- Intended as an equivalent to https://github.com/Azure/go-autorest/blob/master/autorest/azure/metadata_environment.go#L96-L141
- Not entirely useful as you need to supply the Resource Manager endpoint which is then re-used in the output struct, and the metadata endpoint does not currently provide an MS Graph endpoint
- But it should work as a drop in replacement for the above linked helper function in go-autorest


- Also fix an incorrect API ID for Key Vault