### PR TITLE
service/containerregistry: Add ACRHelper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 ## 0.40.0 (Unreleased)
 
+- Support v1.0 API for [Entitlement Management](https://docs.microsoft.com/en-us/graph/api/resources/entitlementmanagement-overview?view=graph-rest-1.0) ([#133](https://github.com/manicminer/hamilton/pull/133))
+  - `AccessPackageQuestion` model - add the `Choices` and `IsSingleLineQuestion` fields
+  - `AccessPackageCatalog` model - add the `State` field
+  - `AssignmentReviewSettings` model - add the `IsAccessRecommendationEnabled`, `IsApprovalJustificationRequired` and `AccessReviewTimeoutBehavior` fields
+  - `UserSet` model - add the `ManagerLevel` field
+  - New model: `AccessPackageMultipleChoiceQuestions`
+
+⚠️ BREAKING CHANGES:
+
+- `AccessPackage` model - the `CatalogId` field is replaced by the `Catalog` field
+- `AssignmentReviewSettings` model - the `RecurrenceType` field now has a custom type
+- `AssignmentReviewSettings` model - the `ReviewerType` field now has a custom type
+
 ## 0.39.0 (January 7, 2022)
 
 - Support for [Federated Identity Credentials](https://docs.microsoft.com/en-us/graph/api/resources/federatedidentitycredential?view=graph-rest-beta) (beta-only) ([#134](https://github.com/manicminer/hamilton/pull/134))

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.16
 require (
 	github.com/Azure/go-autorest/autorest v0.11.21
 	github.com/Azure/go-autorest/autorest/adal v0.9.14
+	github.com/docker/docker-credential-helpers v0.6.4
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/hashicorp/go-retryablehttp v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -53,8 +53,11 @@ github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5P
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
+github.com/danieljoos/wincred v1.1.0/go.mod h1:XYlo+eRTsVA9aHGp7NGjFkPla4m+DCL7hqDjlFjiygg=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/docker/docker-credential-helpers v0.6.4 h1:axCks+yV+2MR3/kZhAmy07yC56WZ2Pwu/fKWtKuZB0o=
+github.com/docker/docker-credential-helpers v0.6.4/go.mod h1:ofX3UI0Gz1TteYBjtgs07O36Pyasyp66D2uKT7H8W1c=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
@@ -140,6 +143,7 @@ github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFR
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
@@ -256,6 +260,7 @@ golang.org/x/sys v0.0.0-20200515095857-1151b9dac4a9/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200523222454-059865788121/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200803210538-64077c9b5642/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/services/containerregistry/acrhelper.go
+++ b/services/containerregistry/acrhelper.go
@@ -1,0 +1,164 @@
+package containerregistry
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/docker/docker-credential-helpers/credentials"
+	"github.com/manicminer/hamilton/auth"
+	"github.com/manicminer/hamilton/environments"
+)
+
+type ACRHelper struct{}
+
+var _ credentials.Helper = (*ACRHelper)(nil)
+
+func NewACRHelper() credentials.Helper {
+	return &ACRHelper{}
+}
+
+func (ACRHelper) Add(_ *credentials.Credentials) error {
+	return fmt.Errorf("method Add() is not implemented")
+}
+
+func (ACRHelper) Delete(_ string) error {
+	return fmt.Errorf("method Delete() not implemented")
+}
+
+func (self ACRHelper) Get(serverURL string) (string, string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	authConfig := self.newConfig()
+	authorizer, err := self.newAuthorizer(ctx, authConfig)
+	if err != nil {
+		return "", "", err
+	}
+
+	token, err := authorizer.Token()
+	if err != nil {
+		return "", "", err
+	}
+
+	acrToken, err := self.getACRToken(ctx, token.AccessToken, serverURL, authConfig.TenantID)
+	if err != nil {
+		return "", "", err
+	}
+
+	return "<token>", acrToken, nil
+}
+
+func (self ACRHelper) List() (map[string]string, error) {
+	return nil, fmt.Errorf("method List() is not implemented")
+}
+
+func (self ACRHelper) newConfig() *auth.Config {
+	auxTenants := strings.Split(os.Getenv("AZURE_AUXILIARY_TENANT_IDS"), ";")
+	for i := range auxTenants {
+		auxTenants[i] = strings.TrimSpace(auxTenants[i])
+	}
+
+	return &auth.Config{
+		Environment:        environments.Global,
+		TenantID:           strings.TrimSpace(os.Getenv("AZURE_TENANT_ID")),
+		ClientID:           strings.TrimSpace(os.Getenv("AZURE_CLIENT_ID")),
+		ClientSecret:       strings.TrimSpace(os.Getenv("AZURE_CLIENT_SECRET")),
+		ClientCertPath:     os.Getenv("AZURE_CERTIFICATE_PATH"),
+		ClientCertPassword: os.Getenv("AZURE_CERTIFICATE_PASSWORD"),
+		AuxiliaryTenantIDs: auxTenants,
+		Version:            auth.TokenVersion2,
+	}
+}
+
+func (self ACRHelper) newAuthorizer(ctx context.Context, authCfg *auth.Config) (auth.Authorizer, error) {
+	a, err := auth.NewClientCertificateAuthorizer(ctx, authCfg.Environment, authCfg.Environment.ResourceManager, authCfg.Version, authCfg.TenantID, authCfg.AuxiliaryTenantIDs, authCfg.ClientID, authCfg.ClientCertData, authCfg.ClientCertPath, authCfg.ClientCertPassword)
+	if err == nil {
+		return a, nil
+	}
+
+	if authCfg.TenantID != "" && authCfg.ClientID != "" && authCfg.ClientSecret != "" {
+		a, err = auth.NewClientSecretAuthorizer(ctx, authCfg.Environment, authCfg.Environment.ResourceManager, authCfg.Version, authCfg.TenantID, authCfg.AuxiliaryTenantIDs, authCfg.ClientID, authCfg.ClientSecret)
+		if err == nil {
+			return a, nil
+		}
+	}
+
+	a, err = auth.NewMsiAuthorizer(ctx, authCfg.Environment.ResourceManager, authCfg.MsiEndpoint, authCfg.ClientID)
+	if err == nil {
+		return a, nil
+	}
+
+	a, err = auth.NewAzureCliAuthorizer(ctx, authCfg.Environment.ResourceManager, authCfg.TenantID)
+	if err == nil {
+		return a, nil
+	}
+
+	return nil, fmt.Errorf("no valid authorizer could be found")
+}
+
+func (self ACRHelper) getACRToken(ctx context.Context, accessToken string, serverURL string, tenantID string) (string, error) {
+	service, err := self.getService(serverURL)
+	if err != nil {
+		return "", err
+	}
+
+	data := url.Values{}
+	data.Set("grant_type", "access_token")
+	data.Set("service", service)
+	data.Set("access_token", accessToken)
+	if len(tenantID) > 0 {
+		data.Set("tenant", tenantID)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, fmt.Sprintf("https://%s/oauth2/exchange", service), strings.NewReader(data.Encode()))
+	if err != nil {
+		return "", err
+	}
+
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+
+	resBytes, err := io.ReadAll(res.Body)
+	if err != nil {
+		return "", err
+	}
+
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("received non-200 status code: %d", res.StatusCode)
+	}
+
+	var resData struct {
+		RefreshToken string `json:"refresh_token"`
+	}
+
+	err = json.Unmarshal(resBytes, &resData)
+
+	return resData.RefreshToken, nil
+}
+
+func (self ACRHelper) getService(serverURL string) (string, error) {
+	scheme := "https://"
+	if strings.HasPrefix(serverURL, "https://") {
+		scheme = ""
+	}
+
+	serviceURL, err := url.Parse(fmt.Sprintf("%s%s", scheme, serverURL))
+	if err != nil {
+		return "", fmt.Errorf("failed to parse server URL - %w", err)
+	}
+
+	return serviceURL.Hostname(), nil
+}


### PR DESCRIPTION
ACRHelper is a credentials.Helper from docker-credential-helpers project
that makes it possible to use it with go-containerregistry.

Fixes #140 