### PR TITLE
Groups fixes

### DIFF
--- a/msgraph/groups.go
+++ b/msgraph/groups.go
@@ -206,6 +206,13 @@ func (c *GroupsClient) GetDeleted(ctx context.Context, id string, query odata.Qu
 func (c *GroupsClient) Update(ctx context.Context, group Group) (int, error) {
 	var status int
 
+	if group.ID == nil {
+		return status, fmt.Errorf("cannot update group with nil ID")
+	}
+
+	groupId := *group.ID
+	group.ID = nil
+
 	body, err := json.Marshal(group)
 	if err != nil {
 		return status, fmt.Errorf("json.Marshal(): %v", err)
@@ -214,9 +221,12 @@ func (c *GroupsClient) Update(ctx context.Context, group Group) (int, error) {
 	_, status, _, err = c.BaseClient.Patch(ctx, PatchHttpRequestInput{
 		Body:                   body,
 		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
-		ValidStatusCodes:       []int{http.StatusNoContent},
+		ValidStatusCodes: []int{
+			http.StatusOK,
+			http.StatusNoContent,
+		},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/groups/%s", *group.ID),
+			Entity:      fmt.Sprintf("/groups/%s", groupId),
 			HasTenantId: true,
 		},
 	})

--- a/msgraph/models.go
+++ b/msgraph/models.go
@@ -847,7 +847,7 @@ type Group struct {
 	Owners           *Owners                `json:"owners@odata.bind,omitempty"`
 	SchemaExtensions *[]SchemaExtensionData `json:"-"`
 
-	AllowExternalSenders          *string                             `json:"allowExternalSenders,omitempty"`
+	AllowExternalSenders          *bool                               `json:"allowExternalSenders,omitempty"`
 	AssignedLabels                *[]GroupAssignedLabel               `json:"assignedLabels,omitempty"`
 	AssignedLicenses              *[]GroupAssignedLicense             `json:"assignLicenses,omitempty"`
 	AutoSubscribeNewMembers       *bool                               `json:"autoSubscribeNewMembers,omitempty"`


### PR DESCRIPTION
- Group model: fix type for `AllowExternalSenders` field
- Don't include the ID in the body when updating a group, as this prevents some Unified group fields from being updated

Test results (note: test runner is currently offline)

![Screenshot 2022-01-28 at 00 51 34](https://user-images.githubusercontent.com/251987/151467942-d74ecd84-5416-4545-a8df-fdaad810fb65.png)
