### PR TITLE
Run tests on cloud runners

### DIFF
--- a/.github/workflows/auth-tests.yml
+++ b/.github/workflows/auth-tests.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.16.4
+          go-version: 1.17.6
 
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/auth-tests.yml
+++ b/.github/workflows/auth-tests.yml
@@ -7,9 +7,18 @@ on:
       - "auth/**.go"
       - ".github/workflows/auth-tests.yml"
 
+env:
+  AZURE_ENVIRONMENT: ${{ secrets.AZURE_ENVIRONMENT }}
+  CLIENT_ID: ${{ secrets.AUTH_CLIENT_ID }}
+  CLIENT_CERTIFICATE: ${{ secrets.AUTH_CLIENT_CERTIFICATE }}
+  CLIENT_CERTIFICATE_PASSWORD: ${{ secrets.AUTH_CLIENT_CERTIFICATE_PASSWORD }}
+  CLIENT_SECRET: ${{ secrets.AUTH_CLIENT_SECRET }}
+  MSI_TOKEN: ${{ secrets.AUTH_MSI_TOKEN }}
+  TENANT_ID: ${{ secrets.TENANT_ID }}
+
 jobs:
   test-auth:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: true
     steps:

--- a/.github/workflows/environments-tests.yml
+++ b/.github/workflows/environments-tests.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.16.4
+          go-version: 1.17.6
 
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/github-auth-tests.yml
+++ b/.github/workflows/github-auth-tests.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.16.4
+          go-version: 1.17.6
 
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/golint.yml
+++ b/.github/workflows/golint.yml
@@ -16,9 +16,9 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: "1.16.4"
+          go-version: "1.17.6"
       - uses: golangci/golangci-lint-action@v2
         with:
-          version: "v1.41"
+          version: "v1.44"
 
 # vim: set ts=2 sts=2 sw=2 et:

--- a/.github/workflows/msgraph-tests.yml
+++ b/.github/workflows/msgraph-tests.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.16.4
+          go-version: 1.17.6
 
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/msgraph-tests.yml
+++ b/.github/workflows/msgraph-tests.yml
@@ -7,9 +7,13 @@ on:
       - "msgraph/**.go"
       - ".github/workflows/msgraph-tests.yml"
 
+permissions:
+  contents: 'read'
+  id-token: 'write'
+
 jobs:
   test-msgraph:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: true
     steps:
@@ -23,5 +27,10 @@ jobs:
 
       - name: Test
         run: go test -count=1 -race -v ./msgraph
+        env:
+          AZURE_ENVIRONMENT: ${{ secrets.AZURE_ENVIRONMENT }}
+          CLIENT_ID: ${{ secrets.CLIENT_ID }}
+          TENANT_ID: ${{ secrets.TENANT_ID }}
+          TENANT_DOMAIN: ${{ secrets.TENANT_DOMAIN }}
 
 # vim: set ts=2 sts=2 sw=2 et:

--- a/.github/workflows/odata-tests.yml
+++ b/.github/workflows/odata-tests.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.16.4
+          go-version: 1.17.6
 
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/scheduled-cleanup.yml
+++ b/.github/workflows/scheduled-cleanup.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.16.4
+          go-version: 1.17.6
 
       - name: Checkout
         uses: actions/checkout@v2

--- a/auth/config.go
+++ b/auth/config.go
@@ -53,4 +53,13 @@ type Config struct {
 
 	// Specifies the password to authenticate with using client secret authentication
 	ClientSecret string
+
+	// Enables GitHub OIDC authentication
+	EnableGitHubOIDCAuth bool
+
+	// The URL for GitHub's OIDC provider
+	IDTokenRequestURL string
+
+	// The bearer token for the request to GitHub's OIDC provider
+	IDTokenRequestToken string
 }

--- a/auth/github.go
+++ b/auth/github.go
@@ -27,7 +27,7 @@ type GitHubOIDCConfig struct {
 	// ClientID is the application's ID.
 	ClientID string
 
-	// IDTokenRequestURL is URL for GitHub's OIDC provider.
+	// IDTokenRequestURL is the URL for GitHub's OIDC provider.
 	IDTokenRequestURL string
 
 	// IDTokenRequestToken is the bearer token for the request to the OIDC provider.

--- a/auth/msi.go
+++ b/auth/msi.go
@@ -146,7 +146,7 @@ func azureMetadata(ctx context.Context, url string) (body []byte, err error) {
 	}
 	defer resp.Body.Close()
 	if c := resp.StatusCode; c < 200 || c > 299 {
-		err = fmt.Errorf("received HTTP status %d", resp.StatusCode)
+		err = fmt.Errorf("received HTTP status %d with body: %s", resp.StatusCode, body)
 		return
 	}
 	return

--- a/internal/test/testing.go
+++ b/internal/test/testing.go
@@ -31,6 +31,8 @@ var (
 	clientCertPassword    = os.Getenv("CLIENT_CERTIFICATE_PASSWORD")
 	clientSecret          = os.Getenv("CLIENT_SECRET")
 	environment           = os.Getenv("AZURE_ENVIRONMENT")
+	idTokenRequestUrl     = os.Getenv("ACTIONS_ID_TOKEN_REQUEST_URL")
+	idTokenRequestToken   = os.Getenv("ACTIONS_ID_TOKEN_REQUEST_TOKEN")
 	retryMax              = envDefault("RETRY_MAX", "14")
 )
 
@@ -57,9 +59,12 @@ func NewConnection(tokenVersion auth.TokenVersion) *Connection {
 			ClientCertPath:         clientCertificatePath,
 			ClientCertPassword:     clientCertPassword,
 			ClientSecret:           clientSecret,
+			IDTokenRequestURL:      idTokenRequestUrl,
+			IDTokenRequestToken:    idTokenRequestToken,
 			EnableClientCertAuth:   true,
 			EnableClientSecretAuth: true,
 			EnableAzureCliToken:    true,
+			EnableGitHubOIDCAuth:   true,
 		},
 		DomainName: tenantDomain,
 	}


### PR DESCRIPTION
- Support for selecting GitHub OIDC authentication when using the `auth.NewAuthorizer()` helper function
- Bump supported Go version to 1.17.6

---

Run all tests on cloud hosted GHA runners.

msgraph tests now use GitHub OIDC authentication to acquire a token for creating/deleting test resources.

Uses different credentials for testing client credentials auth flow and Azure CLI auth - as these are now stored in GH secrets they can potentially be leaked but they have no meaningful roles or scopes assigned so are powerless to do anything.