### PR TITLE
:sparkles: Add ClaimsMappingPolicy

### DIFF
--- a/internal/test/testing.go
+++ b/internal/test/testing.go
@@ -214,6 +214,11 @@ func NewTest(t *testing.T) (c *Test) {
 	c.AuthenticationMethodsClient.BaseClient.Endpoint = c.Connection.AuthConfig.Environment.MsGraph.Endpoint
 	c.AuthenticationMethodsClient.BaseClient.RetryableClient.RetryMax = retry
 
+	c.ClaimsMappingPolicyClient = msgraph.NewClaimsMappingPolicyClient(c.Connection.AuthConfig.TenantID)
+	c.ClaimsMappingPolicyClient.BaseClient.Authorizer = c.Connection.Authorizer
+	c.ClaimsMappingPolicyClient.BaseClient.Endpoint = c.Connection.AuthConfig.Environment.MsGraph.Endpoint
+	c.ClaimsMappingPolicyClient.BaseClient.RetryableClient.RetryMax = retry
+
 	c.ConditionalAccessPoliciesClient = msgraph.NewConditionalAccessPoliciesClient(c.Connection.AuthConfig.TenantID)
 	c.ConditionalAccessPoliciesClient.BaseClient.Authorizer = c.Connection.Authorizer
 	c.ConditionalAccessPoliciesClient.BaseClient.Endpoint = c.Connection.AuthConfig.Environment.MsGraph.Endpoint
@@ -323,10 +328,6 @@ func NewTest(t *testing.T) (c *Test) {
 	c.UsersClient.BaseClient.Authorizer = c.Connection.Authorizer
 	c.UsersClient.BaseClient.Endpoint = c.Connection.AuthConfig.Environment.MsGraph.Endpoint
 	c.UsersClient.BaseClient.RetryableClient.RetryMax = retry
-	c.ClaimsMappingPolicyClient = msgraph.NewClaimsMappingPolicyClient(c.Connection.AuthConfig.TenantID)
-	c.ClaimsMappingPolicyClient.BaseClient.Authorizer = c.Connection.Authorizer
-	c.ClaimsMappingPolicyClient.BaseClient.Endpoint = c.Connection.AuthConfig.Environment.MsGraph.Endpoint
-	c.ClaimsMappingPolicyClient.BaseClient.RetryableClient.RetryMax = retry
 
 	return
 }

--- a/internal/test/testing.go
+++ b/internal/test/testing.go
@@ -101,6 +101,7 @@ type Test struct {
 	ApplicationsClient                        *msgraph.ApplicationsClient
 	AppRoleAssignedToClient                   *msgraph.AppRoleAssignedToClient
 	AuthenticationMethodsClient               *msgraph.AuthenticationMethodsClient
+	ClaimsMappingPolicyClient                 *msgraph.ClaimsMappingPolicyClient
 	ConditionalAccessPoliciesClient           *msgraph.ConditionalAccessPoliciesClient
 	DelegatedPermissionGrantsClient           *msgraph.DelegatedPermissionGrantsClient
 	DirectoryAuditReportsClient               *msgraph.DirectoryAuditReportsClient
@@ -322,6 +323,10 @@ func NewTest(t *testing.T) (c *Test) {
 	c.UsersClient.BaseClient.Authorizer = c.Connection.Authorizer
 	c.UsersClient.BaseClient.Endpoint = c.Connection.AuthConfig.Environment.MsGraph.Endpoint
 	c.UsersClient.BaseClient.RetryableClient.RetryMax = retry
+	c.ClaimsMappingPolicyClient = msgraph.NewClaimsMappingPolicyClient(c.Connection.AuthConfig.TenantID)
+	c.ClaimsMappingPolicyClient.BaseClient.Authorizer = c.Connection.Authorizer
+	c.ClaimsMappingPolicyClient.BaseClient.Endpoint = c.Connection.AuthConfig.Environment.MsGraph.Endpoint
+	c.ClaimsMappingPolicyClient.BaseClient.RetryableClient.RetryMax = retry
 
 	return
 }

--- a/internal/utils/pointers.go
+++ b/internal/utils/pointers.go
@@ -19,3 +19,8 @@ func Int32Ptr(i int32) *int32 {
 func StringPtr(s string) *string {
 	return &s
 }
+
+// ArrayStringPtr returns a pointer to the provided array of strings.
+func ArrayStringPtr(s []string) *[]string {
+	return &s
+}

--- a/msgraph/claims_mapping_policy.go
+++ b/msgraph/claims_mapping_policy.go
@@ -1,0 +1,169 @@
+package msgraph
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/manicminer/hamilton/odata"
+)
+
+type ClaimsMappingPolicyClient struct {
+	BaseClient Client
+}
+
+// NewClaimsMappingPolicyClient returns a new ClaimsMappingPolicyClient
+func NewClaimsMappingPolicyClient(tenantId string) *ClaimsMappingPolicyClient {
+	return &ClaimsMappingPolicyClient{
+		BaseClient: NewClient(VersionBeta, tenantId),
+	}
+}
+
+// Create creates a new ClaimsMappingPolicy.
+func (c *ClaimsMappingPolicyClient) Create(ctx context.Context, policy ClaimsMappingPolicy) (*ClaimsMappingPolicy, int, error) {
+	var status int
+
+	body, err := json.Marshal(policy)
+	if err != nil {
+		return nil, status, fmt.Errorf("json.Marshal(): %v", err)
+	}
+
+	resp, status, _, err := c.BaseClient.Post(ctx, PostHttpRequestInput{
+		Body:             body,
+		ValidStatusCodes: []int{http.StatusCreated},
+		Uri: Uri{
+			Entity:      "/policies/claimsMappingPolicies",
+			HasTenantId: false,
+		},
+	})
+	if err != nil {
+		return nil, status, fmt.Errorf("ClaimsMappingPolicyClient.BaseClient.Post(): %v", err)
+	}
+
+	defer resp.Body.Close()
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, status, fmt.Errorf("io.ReadAll(): %v", err)
+	}
+
+	var newPolicy ClaimsMappingPolicy
+	if err := json.Unmarshal(respBody, &newPolicy); err != nil {
+		return nil, status, fmt.Errorf("json.Unmarshal(): %v", err)
+	}
+
+	return &newPolicy, status, nil
+}
+
+// List returns a list of ClaimsMappingPolicy, optionally queried using OData.
+func (c *ClaimsMappingPolicyClient) List(ctx context.Context, query odata.Query) (*[]ClaimsMappingPolicy, int, error) {
+	resp, status, _, err := c.BaseClient.Get(ctx, GetHttpRequestInput{
+		DisablePaging:    query.Top > 0,
+		OData:            query,
+		ValidStatusCodes: []int{http.StatusOK},
+		Uri: Uri{
+			Entity:      "/policies/claimsMappingPolicies",
+			HasTenantId: false,
+		},
+	})
+	if err != nil {
+		return nil, status, fmt.Errorf("ClaimsMappingPolicyClient.BaseClient.Get(): %v", err)
+	}
+
+	defer resp.Body.Close()
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, status, fmt.Errorf("io.ReadAll(): %v", err)
+	}
+
+	var data struct {
+		ClaimsMappingPolicies []ClaimsMappingPolicy `json:"value"`
+	}
+	if err := json.Unmarshal(respBody, &data); err != nil {
+		return nil, status, fmt.Errorf("json.Unmarshal(): %v", err)
+	}
+
+	return &data.ClaimsMappingPolicies, status, nil
+}
+
+// Get retrieves a ClaimsMappingPolicy.
+func (c *ClaimsMappingPolicyClient) Get(ctx context.Context, id string, query odata.Query) (*ClaimsMappingPolicy, int, error) {
+	resp, status, _, err := c.BaseClient.Get(ctx, GetHttpRequestInput{
+		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
+		OData:                  query,
+		ValidStatusCodes:       []int{http.StatusOK},
+		Uri: Uri{
+			Entity:      fmt.Sprintf("/policies/claimsMappingPolicies/%s", id),
+			HasTenantId: false,
+		},
+	})
+	if err != nil {
+		return nil, status, fmt.Errorf("ClaimsMappingPolicyClient.BaseClient.Get(): %v", err)
+	}
+
+	defer resp.Body.Close()
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, status, fmt.Errorf("io.ReadAll(): %v", err)
+	}
+
+	var claimsMappingPolicies ClaimsMappingPolicy
+	if err := json.Unmarshal(respBody, &claimsMappingPolicies); err != nil {
+		return nil, status, fmt.Errorf("json.Unmarshal(): %v", err)
+	}
+
+	return &claimsMappingPolicies, status, nil
+}
+
+// Update amends an existing ClaimsMappingPolicy.
+func (c *ClaimsMappingPolicyClient) Update(ctx context.Context, claimsMappingPolicy ClaimsMappingPolicy) (int, error) {
+	var status int
+
+	if claimsMappingPolicy.ID == nil {
+		return status, fmt.Errorf("cannot update ClaimsMappingPolicy with nil ID")
+	}
+
+	claimsMappingPolicyId := *claimsMappingPolicy.ID
+	claimsMappingPolicy.ID = nil
+
+	body, err := json.Marshal(claimsMappingPolicy)
+	if err != nil {
+		return status, fmt.Errorf("json.Marshal(): %v", err)
+	}
+
+	_, status, _, err = c.BaseClient.Patch(ctx, PatchHttpRequestInput{
+		Body:                   body,
+		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
+		ValidStatusCodes: []int{
+			http.StatusOK,
+			http.StatusNoContent,
+		},
+		Uri: Uri{
+			Entity:      fmt.Sprintf("/policies/claimsMappingPolicies/%s", claimsMappingPolicyId),
+			HasTenantId: true,
+		},
+	})
+	if err != nil {
+		return status, fmt.Errorf("ClaimsMappingPolicy.BaseClient.Patch(): %v", err)
+	}
+
+	return status, nil
+}
+
+// Delete removes a ClaimsMappingPolicy.
+func (c *ClaimsMappingPolicyClient) Delete(ctx context.Context, id string) (int, error) {
+	_, status, _, err := c.BaseClient.Delete(ctx, DeleteHttpRequestInput{
+		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
+		ValidStatusCodes:       []int{http.StatusNoContent},
+		Uri: Uri{
+			Entity:      fmt.Sprintf("/policies/claimsMappingPolicies/%s", id),
+			HasTenantId: false,
+		},
+	})
+	if err != nil {
+		return status, fmt.Errorf("ClaimsMappingPolicyClient.BaseClient.Delete(): %v", err)
+	}
+
+	return status, nil
+}

--- a/msgraph/claims_mapping_policy.go
+++ b/msgraph/claims_mapping_policy.go
@@ -17,7 +17,7 @@ type ClaimsMappingPolicyClient struct {
 // NewClaimsMappingPolicyClient returns a new ClaimsMappingPolicyClient
 func NewClaimsMappingPolicyClient(tenantId string) *ClaimsMappingPolicyClient {
 	return &ClaimsMappingPolicyClient{
-		BaseClient: NewClient(VersionBeta, tenantId),
+		BaseClient: NewClient(Version10, tenantId),
 	}
 }
 
@@ -32,6 +32,7 @@ func (c *ClaimsMappingPolicyClient) Create(ctx context.Context, policy ClaimsMap
 
 	resp, status, _, err := c.BaseClient.Post(ctx, PostHttpRequestInput{
 		Body:             body,
+		OData:            odata.Query{Metadata: odata.MetadataFull},
 		ValidStatusCodes: []int{http.StatusCreated},
 		Uri: Uri{
 			Entity:      "/policies/claimsMappingPolicies",
@@ -58,6 +59,8 @@ func (c *ClaimsMappingPolicyClient) Create(ctx context.Context, policy ClaimsMap
 
 // List returns a list of ClaimsMappingPolicy, optionally queried using OData.
 func (c *ClaimsMappingPolicyClient) List(ctx context.Context, query odata.Query) (*[]ClaimsMappingPolicy, int, error) {
+	query.Metadata = odata.MetadataFull
+
 	resp, status, _, err := c.BaseClient.Get(ctx, GetHttpRequestInput{
 		DisablePaging:    query.Top > 0,
 		OData:            query,
@@ -89,6 +92,8 @@ func (c *ClaimsMappingPolicyClient) List(ctx context.Context, query odata.Query)
 
 // Get retrieves a ClaimsMappingPolicy.
 func (c *ClaimsMappingPolicyClient) Get(ctx context.Context, id string, query odata.Query) (*ClaimsMappingPolicy, int, error) {
+	query.Metadata = odata.MetadataFull
+
 	resp, status, _, err := c.BaseClient.Get(ctx, GetHttpRequestInput{
 		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
 		OData:                  query,

--- a/msgraph/claims_mapping_policy_test.go
+++ b/msgraph/claims_mapping_policy_test.go
@@ -1,0 +1,91 @@
+package msgraph_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/manicminer/hamilton/internal/test"
+	"github.com/manicminer/hamilton/internal/utils"
+	"github.com/manicminer/hamilton/msgraph"
+	"github.com/manicminer/hamilton/odata"
+)
+
+func TestClaimsMappingPolicyClient(t *testing.T) {
+	c := test.NewTest(t)
+	defer c.CancelFunc()
+	policy := testClaimsMappingPolicyClient_Create(t, c, msgraph.ClaimsMappingPolicy{
+		DisplayName: utils.StringPtr(fmt.Sprintf("test-claims-mapping-policy-%s", c.RandomString)),
+		Definition: utils.ArrayStringPtr(
+			[]string{
+				"{\"ClaimsMappingPolicy\":{\"Version\":1,\"IncludeBasicClaimSet\":\"true\",\"ClaimsSchema\": [{\"Source\":\"user\",\"ID\":\"employeeid\",\"SamlClaimType\":\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\",\"JwtClaimType\":\"name\"},{\"Source\":\"company\",\"ID\":\"tenantcountry\",\"SamlClaimType\":\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/country\",\"JwtClaimType\":\"country\"}]}}",
+			},
+		),
+	})
+	testClaimsMappingPolicyClient_List(t, c)
+	testClaimsMappingPolicyClient_Get(t, c, *policy.ID)
+	policy.DisplayName = utils.StringPtr(fmt.Sprintf("test-claims-mapping-policy-%s", c.RandomString))
+	testClaimsMappingPolicyClient_Update(t, c, *policy)
+	testClaimsMappingPolicyClient_Delete(t, c, *policy.ID)
+}
+
+func testClaimsMappingPolicyClient_Create(t *testing.T, c *test.Test, p msgraph.ClaimsMappingPolicy) (policy *msgraph.ClaimsMappingPolicy) {
+	policy, status, err := c.ClaimsMappingPolicyClient.Create(c.Context, p)
+	if err != nil {
+		t.Fatalf("ClaimsMappingPolicyClient.Create(): %v", err)
+	}
+	if status < 200 || status >= 300 {
+		t.Fatalf("ClaimsMappingPolicyClient.Create(): invalid status: %d", status)
+	}
+	if policy == nil {
+		t.Fatal("ClaimsMappingPolicyClient.Create(): policy was nil")
+	}
+	if policy.ID == nil {
+		t.Fatal("ClaimsMappingPolicyClient.Create(): policy.ID was nil")
+	}
+	return
+}
+
+func testClaimsMappingPolicyClient_List(t *testing.T, c *test.Test) (policy *[]msgraph.ClaimsMappingPolicy) {
+	policies, _, err := c.ClaimsMappingPolicyClient.List(c.Context, odata.Query{Top: 10})
+	if err != nil {
+		t.Fatalf("ClaimsMappingPolicy.List(): %v", err)
+	}
+	if policies == nil {
+		t.Fatal("ClaimsMappingPolicy.List(): ClaimsMappingPolicies was nil")
+	}
+	return
+}
+
+func testClaimsMappingPolicyClient_Get(t *testing.T, c *test.Test, id string) (ClaimsMappingPolicy *msgraph.ClaimsMappingPolicy) {
+	policies, status, err := c.ClaimsMappingPolicyClient.Get(c.Context, id, odata.Query{})
+	if err != nil {
+		t.Fatalf("ClaimsMappingPolicyClient.Get(): %v", err)
+	}
+	if status < 200 || status >= 300 {
+		t.Fatalf("ClaimsMappingPolicyClient.Get(): invalid status: %d", status)
+	}
+	if policies == nil {
+		t.Fatal("ClaimsMappingPolicyClient.Get(): policies was nil")
+	}
+	return
+}
+
+func testClaimsMappingPolicyClient_Update(t *testing.T, c *test.Test, g msgraph.ClaimsMappingPolicy) {
+	status, err := c.ClaimsMappingPolicyClient.Update(c.Context, g)
+	if err != nil {
+		t.Fatalf("ClaimsMappingPolicyClient.Update(): %v", err)
+	}
+	if status < 200 || status >= 300 {
+		t.Fatalf("ClaimsMappingPolicyClient.Update(): invalid status: %d", status)
+	}
+}
+
+func testClaimsMappingPolicyClient_Delete(t *testing.T, c *test.Test, id string) {
+	status, err := c.ClaimsMappingPolicyClient.Delete(c.Context, id)
+	if err != nil {
+		t.Fatalf("ClaimsMappingPolicyClient.Delete(): %v", err)
+	}
+	if status < 200 || status >= 300 {
+		t.Fatalf("ClaimsMappingPolicyClient.Delete(): invalid status: %d", status)
+	}
+}

--- a/msgraph/models.go
+++ b/msgraph/models.go
@@ -541,18 +541,11 @@ type BaseNamedLocation struct {
 }
 
 type ClaimsMappingPolicy struct {
-	ODataId               *odata.Id `json:"@odata.id,omitempty"`
+	DirectoryObject
 	Definition            *[]string `json:"definition,omitempty"`
 	Description           *string   `json:"description,omitempty"`
 	DisplayName           *string   `json:"displayName,omitempty"`
 	IsOrganizationDefault *bool     `json:"isOrganizationDefault,omitempty"`
-}
-
-func (o *ClaimsMappingPolicy) Uri(endpoint environments.ApiEndpoint, apiversion ApiVersion) string {
-	if o.ID == nil {
-		return ""
-	}
-	return fmt.Sprintf("%s/%s/policies/claimsMappingPolicies/%s", endpoint, apiversion, *o.ID)
 }
 
 type CloudAppSecurityControl struct {
@@ -1265,9 +1258,8 @@ type ScopedRoleMembership struct {
 // ServicePrincipal describes a Service Principal object.
 type ServicePrincipal struct {
 	DirectoryObject
-	Owners                *Owners `json:"owners@odata.bind,omitempty"`
-	ClaimsMappingPolicies *[]ClaimsMappingPolicy `json:"claimsmappingpolicies@odata.bind,omitempty"`
-
+	Owners                              *Owners                       `json:"owners@odata.bind,omitempty"`
+	ClaimsMappingPolicies               *[]ClaimsMappingPolicy        `json:"claimsmappingpolicies@odata.bind,omitempty"`
 	AccountEnabled                      *bool                         `json:"accountEnabled,omitempty"`
 	AddIns                              *[]AddIn                      `json:"addIns,omitempty"`
 	AlternativeNames                    *[]string                     `json:"alternativeNames,omitempty"`

--- a/msgraph/models.go
+++ b/msgraph/models.go
@@ -540,6 +540,13 @@ type BaseNamedLocation struct {
 	ModifiedDateTime *time.Time  `json:"modifiedDateTime,omitempty"`
 }
 
+type ClaimsMappingPolicy struct {
+	Definition            *[]string `json:"definition,omitempty"`
+	Description           *string   `json:"description,omitempty"`
+	DisplayName           *string   `json:"displayName,omitempty"`
+	IsOrganizationDefault *bool     `json:"isOrganizationDefault,omitempty"`
+}
+
 type CloudAppSecurityControl struct {
 	IsEnabled            *bool                                                `json:"isEnabled,omitempty"`
 	CloudAppSecurityType *ConditionalAccessCloudAppSecuritySessionControlType `json:"cloudAppSecurityType,omitempty"`

--- a/msgraph/models.go
+++ b/msgraph/models.go
@@ -541,10 +541,18 @@ type BaseNamedLocation struct {
 }
 
 type ClaimsMappingPolicy struct {
+	ODataId               *odata.Id `json:"@odata.id,omitempty"`
 	Definition            *[]string `json:"definition,omitempty"`
 	Description           *string   `json:"description,omitempty"`
 	DisplayName           *string   `json:"displayName,omitempty"`
 	IsOrganizationDefault *bool     `json:"isOrganizationDefault,omitempty"`
+}
+
+func (o *ClaimsMappingPolicy) Uri(endpoint environments.ApiEndpoint, apiversion ApiVersion) string {
+	if o.ID == nil {
+		return ""
+	}
+	return fmt.Sprintf("%s/%s/policies/claimsMappingPolicies/%s", endpoint, apiversion, *o.ID)
 }
 
 type CloudAppSecurityControl struct {
@@ -1257,7 +1265,8 @@ type ScopedRoleMembership struct {
 // ServicePrincipal describes a Service Principal object.
 type ServicePrincipal struct {
 	DirectoryObject
-	Owners *Owners `json:"owners@odata.bind,omitempty"`
+	Owners                *Owners `json:"owners@odata.bind,omitempty"`
+	ClaimsMappingPolicies *[]ClaimsMappingPolicy `json:"claimsmappingpolicies@odata.bind,omitempty"`
 
 	AccountEnabled                      *bool                         `json:"accountEnabled,omitempty"`
 	AddIns                              *[]AddIn                      `json:"addIns,omitempty"`

--- a/msgraph/serviceprincipals.go
+++ b/msgraph/serviceprincipals.go
@@ -368,8 +368,7 @@ func (c *ServicePrincipalsClient) AssignClaimsMappingPolicy(ctx context.Context,
 			return false
 		}
 
-		path := odata.Id(fmt.Sprintf("https://graph.microsoft.com/v1.0/policies/claimsMappingPolicies/%s", *policy.ID))
-		body, err := json.Marshal(ClaimsMappingPolicy{ODataId: &path})
+		body, err := json.Marshal(DirectoryObject{ODataId: policy.ODataId})
 		if err != nil {
 			return status, fmt.Errorf("json.Marshal(): %v", err)
 		}

--- a/msgraph/serviceprincipals.go
+++ b/msgraph/serviceprincipals.go
@@ -348,6 +348,136 @@ func (c *ServicePrincipalsClient) RemoveOwners(ctx context.Context, servicePrinc
 	return status, nil
 }
 
+// AssignClaimsMappingPolicy assigns a claimsMappingPolicy to a servicePrincipal
+func (c *ServicePrincipalsClient) AssignClaimsMappingPolicy(ctx context.Context, servicePrincipal *ServicePrincipal) (int, error) {
+	var status int
+
+	if servicePrincipal.ID == nil {
+		return status, errors.New("cannot update service principal with nil ID")
+	}
+	if servicePrincipal.ClaimsMappingPolicies == nil {
+		return status, errors.New("cannot update service principal with nil ClaimsMappingPolicies")
+	}
+
+	for _, policy := range *servicePrincipal.ClaimsMappingPolicies {
+		// don't fail if an owner already exists
+		checkPolicyAlreadyExists := func(resp *http.Response, o *odata.OData) bool {
+			if resp != nil && resp.StatusCode == http.StatusBadRequest && o != nil && o.Error != nil {
+				return o.Error.Match(odata.ErrorAddedObjectReferencesAlreadyExist)
+			}
+			return false
+		}
+
+		path := odata.Id(fmt.Sprintf("https://graph.microsoft.com/v1.0/policies/claimsMappingPolicies/%s", *policy.ID))
+		body, err := json.Marshal(ClaimsMappingPolicy{ODataId: &path})
+		if err != nil {
+			return status, fmt.Errorf("json.Marshal(): %v", err)
+		}
+
+		_, status, _, err = c.BaseClient.Post(ctx, PostHttpRequestInput{
+			Body:                   body,
+			ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
+			ValidStatusCodes:       []int{http.StatusNoContent},
+			ValidStatusFunc:        checkPolicyAlreadyExists,
+			Uri: Uri{
+				Entity:      fmt.Sprintf("/servicePrincipals/%s/claimsMappingPolicies/$ref", *servicePrincipal.ID),
+				HasTenantId: false,
+			},
+		})
+		if err != nil {
+			return status, fmt.Errorf("ServicePrincipalsClient.BaseClient.Post(): %v", err)
+		}
+	}
+
+	return status, nil
+}
+
+// ListClaimsMappingPolicy retrieves the claimsMappingPolicies assigned to the specified Service Principal.
+// id is the object ID of the service principal.
+func (c *ServicePrincipalsClient) ListClaimsMappingPolicy(ctx context.Context, id string) (*[]ClaimsMappingPolicy, int, error) {
+	resp, status, _, err := c.BaseClient.Get(ctx, GetHttpRequestInput{
+		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
+		ValidStatusCodes:       []int{http.StatusOK},
+		Uri: Uri{
+			Entity:      fmt.Sprintf("/servicePrincipals/%s/claimsMappingPolicies", id),
+			HasTenantId: true,
+		},
+	})
+	if err != nil {
+		return nil, status, fmt.Errorf("ServicePrincipalsClient.BaseClient.Get(): %v", err)
+	}
+
+	defer resp.Body.Close()
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, status, fmt.Errorf("io.ReadAll(): %v", err)
+	}
+
+	var data struct {
+		Policies []ClaimsMappingPolicy `json:"value"`
+	}
+
+	if err := json.Unmarshal(respBody, &data); err != nil {
+		return nil, status, fmt.Errorf("json.Unmarshal(): %v", err)
+	}
+
+	return &data.Policies, status, nil
+}
+
+// RemoveClaimsMappingPolicy removes a claimsMappingPolicy from a servicePrincipal
+func (c *ServicePrincipalsClient) RemoveClaimsMappingPolicy(ctx context.Context, servicePrincipal *ServicePrincipal, policyIds *[]string) (int, error) {
+	var status int
+
+	if policyIds == nil {
+		return status, errors.New("cannot remove, nil policyIds")
+	}
+
+	assignedPolicies, _, err := c.ListClaimsMappingPolicy(ctx, *servicePrincipal.ID)
+	if err != nil {
+		return status, fmt.Errorf("ServicePrincipalsClient.BaseClient.ListClaimsMappingPolicy(): %v", err)
+	}
+
+	if len(*assignedPolicies) == 0 {
+		return http.StatusNoContent, nil
+	}
+
+	mapClaimsMappingPolicy := map[string]ClaimsMappingPolicy{}
+	for _, v := range *assignedPolicies {
+		mapClaimsMappingPolicy[*v.ID] = v
+	}
+
+	for _, policyId := range *policyIds {
+
+		// Check if policy is currently assigned
+		_, ok := mapClaimsMappingPolicy[policyId]
+		if !ok {
+			continue
+		}
+
+		checkPolicyStatus := func(resp *http.Response, o *odata.OData) bool {
+			if resp != nil && resp.StatusCode == http.StatusNotFound && o != nil && o.Error != nil {
+				return o.Error.Match(odata.ErrorResourceDoesNotExist)
+			}
+			return false
+		}
+
+		_, status, _, err = c.BaseClient.Delete(ctx, DeleteHttpRequestInput{
+			ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
+			ValidStatusCodes:       []int{http.StatusNoContent},
+			ValidStatusFunc:        checkPolicyStatus,
+			Uri: Uri{
+				Entity:      fmt.Sprintf("/servicePrincipals/%s/claimsMappingPolicies/%s/$ref", *servicePrincipal.ID, policyId),
+				HasTenantId: false,
+			},
+		})
+		if err != nil {
+			return status, fmt.Errorf("ServicePrincipalsClient.BaseClient.Delete(): %v", err)
+		}
+	}
+
+	return status, nil
+}
+
 // ListGroupMemberships returns a list of Groups the Service Principal is member of, optionally queried using OData.
 func (c *ServicePrincipalsClient) ListGroupMemberships(ctx context.Context, id string, query odata.Query) (*[]Group, int, error) {
 	resp, status, _, err := c.BaseClient.Get(ctx, GetHttpRequestInput{


### PR DESCRIPTION
This adds initial support for the ClaimsMappingPolicy resource.
Support for this resource type is prerequisite for adding support
to the azure ad terraform provider so it can support Azure AD
Claims Mapping polices.

Fixes: manicminer/hamilton#118

Graph API Reference:
https://docs.microsoft.com/en-us/graph/api/resources/claimsmappingpolicy?view=graph-rest-1.0