### PR TITLE
✨ add servicePrincipal methods AddTokenSigningCertificate and SetPref…

### DIFF
--- a/msgraph/models.go
+++ b/msgraph/models.go
@@ -1044,6 +1044,7 @@ type KeyCredential struct {
 	EndDateTime         *time.Time         `json:"endDateTime,omitempty"`
 	KeyId               *string            `json:"keyId,omitempty"`
 	StartDateTime       *time.Time         `json:"startDateTime,omitempty"`
+	Thumbprint          *string            `json:"thumbprint,omitempty"`
 	Type                KeyCredentialType  `json:"type"`
 	Usage               KeyCredentialUsage `json:"usage"`
 	Key                 *string            `json:"key,omitempty"`
@@ -1274,6 +1275,7 @@ type ServicePrincipal struct {
 	PasswordCredentials                 *[]PasswordCredential         `json:"passwordCredentials,omitempty"`
 	PasswordSingleSignOnSettings        *PasswordSingleSignOnSettings `json:"passwordSingleSignOnSettings,omitempty"`
 	PreferredSingleSignOnMode           *PreferredSingleSignOnMode    `json:"preferredSingleSignOnMode,omitempty"`
+	PreferredTokenSigningKeyThumbprint  *string                       `json:"preferredTokenSigningKeyThumbprint,omitempty"`
 	PreferredTokenSigningKeyEndDateTime *time.Time                    `json:"preferredTokenSigningKeyEndDateTime,omitempty"`
 	PublishedPermissionScopes           *[]PermissionScope            `json:"publishedPermissionScopes,omitempty"`
 	ReplyUrls                           *[]string                     `json:"replyUrls,omitempty"`

--- a/msgraph/serviceprincipals.go
+++ b/msgraph/serviceprincipals.go
@@ -449,6 +449,71 @@ func (c *ServicePrincipalsClient) RemovePassword(ctx context.Context, servicePri
 	return status, nil
 }
 
+// AddTokenSigningCertificate appends a new self signed certificate (keys and password) to a Service Principal.
+func (c *ServicePrincipalsClient) AddTokenSigningCertificate(ctx context.Context, servicePrincipalId string, keyCredential KeyCredential) (*KeyCredential, int, error) {
+	var status int
+
+	body, err := json.Marshal(keyCredential)
+	if err != nil {
+		return nil, status, fmt.Errorf("json.Marshal(): %v", err)
+	}
+
+	resp, status, _, err := c.BaseClient.Post(ctx, PostHttpRequestInput{
+		Body:                   body,
+		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
+		ValidStatusCodes:       []int{http.StatusOK, http.StatusCreated},
+		Uri: Uri{
+			Entity:      fmt.Sprintf("/servicePrincipals/%s/addTokenSigningCertificate", servicePrincipalId),
+			HasTenantId: true,
+		},
+	})
+	if err != nil {
+		return nil, status, fmt.Errorf("ServicePrincipalsClient.BaseClient.Post(): %v", err)
+	}
+
+	defer resp.Body.Close()
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, status, fmt.Errorf("io.ReadAll(): %v", err)
+	}
+
+	var newKeyCredential KeyCredential
+	if err := json.Unmarshal(respBody, &newKeyCredential); err != nil {
+		return nil, status, fmt.Errorf("json.Unmarshal(): %v", err)
+	}
+
+	return &newKeyCredential, status, nil
+}
+
+// SetPreferredTokenSigningKeyThumbprint sets the field preferredTokenSigningKeyThumbprint for a Service Principal.
+func (c *ServicePrincipalsClient) SetPreferredTokenSigningKeyThumbprint(ctx context.Context, servicePrincipalId string, thumbprint string) (int, error) {
+	var status int
+
+	body, err := json.Marshal(struct {
+		Thumbprint string `json:"preferredTokenSigningKeyThumbprint"`
+	}{
+		Thumbprint: thumbprint,
+	})
+	if err != nil {
+		return status, fmt.Errorf("json.Marshal(): %v", err)
+	}
+
+	_, status, _, err = c.BaseClient.Patch(ctx, PatchHttpRequestInput{
+		Body:                   body,
+		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
+		ValidStatusCodes:       []int{http.StatusNoContent},
+		Uri: Uri{
+			Entity:      fmt.Sprintf("/servicePrincipals/%s", servicePrincipalId),
+			HasTenantId: true,
+		},
+	})
+	if err != nil {
+		return status, fmt.Errorf("ServicePrincipalsClient.BaseClient.Patch(): %v", err)
+	}
+
+	return status, nil
+}
+
 // ListOwnedObjects retrieves the owned objects of the specified Service Principal.
 // id is the object ID of the service principal.
 func (c *ServicePrincipalsClient) ListOwnedObjects(ctx context.Context, id string) (*[]string, int, error) {


### PR DESCRIPTION
✨ add servicePrincipal methods AddTokenSigningCertificate and SetPreferredTokenSigningKeyThumbprint

This commit adds support to create the certificiate for Azure AD signed certs and set
the preferred token thumbprint on the service principal.

This will allow to follow the steps described in
https://docs.microsoft.com/en-us/graph/application-saml-sso-configure-api#create-a-signing-certificate
using hamilton SDK.

Currently Microsoft does not support a method to remove the created certificate key from the service principal.
https://docs.microsoft.com/en-us/graph/api/serviceprincipal-addtokensigningcertificate

Also manual removal via `removePassword` and `removekey` API calls are not supported and fail with an internal server error.

This SDK extension is the base to extend the `terraform-provider-azuread`. 

Issue: https://github.com/hashicorp/terraform-provider-azuread/issues/732