### PR TITLE
Service Principal: Support token signing certificates

### DIFF
--- a/msgraph/models.go
+++ b/msgraph/models.go
@@ -1052,6 +1052,7 @@ type KeyCredential struct {
 	EndDateTime         *time.Time         `json:"endDateTime,omitempty"`
 	KeyId               *string            `json:"keyId,omitempty"`
 	StartDateTime       *time.Time         `json:"startDateTime,omitempty"`
+	Thumbprint          *string            `json:"thumbprint,omitempty"`
 	Type                KeyCredentialType  `json:"type"`
 	Usage               KeyCredentialUsage `json:"usage"`
 	Key                 *string            `json:"key,omitempty"`
@@ -1282,6 +1283,7 @@ type ServicePrincipal struct {
 	PasswordCredentials                 *[]PasswordCredential         `json:"passwordCredentials,omitempty"`
 	PasswordSingleSignOnSettings        *PasswordSingleSignOnSettings `json:"passwordSingleSignOnSettings,omitempty"`
 	PreferredSingleSignOnMode           *PreferredSingleSignOnMode    `json:"preferredSingleSignOnMode,omitempty"`
+	PreferredTokenSigningKeyThumbprint  *string                       `json:"preferredTokenSigningKeyThumbprint,omitempty"`
 	PreferredTokenSigningKeyEndDateTime *time.Time                    `json:"preferredTokenSigningKeyEndDateTime,omitempty"`
 	PublishedPermissionScopes           *[]PermissionScope            `json:"publishedPermissionScopes,omitempty"`
 	ReplyUrls                           *[]string                     `json:"replyUrls,omitempty"`

--- a/msgraph/serviceprincipals_test.go
+++ b/msgraph/serviceprincipals_test.go
@@ -280,7 +280,7 @@ func testServicePrincipalsClient_AddPassword(t *testing.T, c *test.Test, a *msgr
 func testServicePrincipalsClient_AddTokenSigningCertificate(t *testing.T, c *test.Test, a *msgraph.ServicePrincipal) *msgraph.KeyCredential {
 	expiry := time.Now().Add(24 * 90 * time.Hour)
 	tsc := msgraph.KeyCredential{
-		DisplayName: utils.StringPtr("test cert"),
+		DisplayName: utils.StringPtr("cn=test cert"),
 		EndDateTime: &expiry,
 	}
 	newKey, status, err := c.ServicePrincipalsClient.AddTokenSigningCertificate(c.Context, *a.ID, tsc)

--- a/msgraph/serviceprincipals_test.go
+++ b/msgraph/serviceprincipals_test.go
@@ -45,6 +45,10 @@ func TestServicePrincipalsClient(t *testing.T) {
 	testServicePrincipalsClient_Update(t, c, *sp)
 	pwd := testServicePrincipalsClient_AddPassword(t, c, sp)
 	testServicePrincipalsClient_RemovePassword(t, c, sp, pwd)
+
+	tsc := testServicePrincipalsClient_AddTokenSigningCertificate(t, c, sp)
+	testServicePrincipalsClient_SetPreferredTokenSigningKeyThumbprint(t, c, sp, *tsc.Thumbprint)
+
 	testServicePrincipalsClient_List(t, c, odata.Query{})
 
 	claimsMappingPolicy := testClaimsMappingPolicyClient_Create(t, c, msgraph.ClaimsMappingPolicy{
@@ -271,6 +275,38 @@ func testServicePrincipalsClient_AddPassword(t *testing.T, c *test.Test, a *msgr
 		t.Fatalf("ServicePrincipalsClient.AddPassword(): nil or empty secretText returned by API")
 	}
 	return newPwd
+}
+
+func testServicePrincipalsClient_AddTokenSigningCertificate(t *testing.T, c *test.Test, a *msgraph.ServicePrincipal) *msgraph.KeyCredential {
+	expiry := time.Now().Add(24 * 90 * time.Hour)
+	tsc := msgraph.KeyCredential{
+		DisplayName: utils.StringPtr("test cert"),
+		EndDateTime: &expiry,
+	}
+	newKey, status, err := c.ServicePrincipalsClient.AddTokenSigningCertificate(c.Context, *a.ID, tsc)
+	if err != nil {
+		t.Fatalf("ServicePrincipalsClient.AddTokenSigningCertificate(): %v", err)
+	}
+	if status < 200 || status >= 300 {
+		t.Fatalf("ServicePrincipalsClient.AddTokenSigningCertificate(): invalid status: %d", status)
+	}
+
+	if newKey.Thumbprint == nil || len(*newKey.Thumbprint) == 0 {
+		t.Fatalf("ServicePrincipalsClient.AddTokenSigningCertificate(): nil or empty thumbprint returned by API")
+	}
+
+	return newKey
+}
+
+func testServicePrincipalsClient_SetPreferredTokenSigningKeyThumbprint(t *testing.T, c *test.Test, a *msgraph.ServicePrincipal, thumbprint string) {
+
+	status, err := c.ServicePrincipalsClient.SetPreferredTokenSigningKeyThumbprint(c.Context, *a.ID, thumbprint)
+	if err != nil {
+		t.Fatalf("ServicePrincipalsClient.AddTokenSigningCertificate(): %v", err)
+	}
+	if status < 200 || status >= 300 {
+		t.Fatalf("ServicePrincipalsClient.AddTokenSigningCertificate(): invalid status: %d", status)
+	}
 }
 
 func testServicePrincipalsClient_RemovePassword(t *testing.T, c *test.Test, a *msgraph.ServicePrincipal, p *msgraph.PasswordCredential) {


### PR DESCRIPTION
Replaces #151 originally opened by @dhohengassner as I'm unable to push to their fork.

---

✨ add servicePrincipal methods AddTokenSigningCertificate and SetPreferredTokenSigningKeyThumbprint

This commit adds support to create the certificiate for Azure AD signed certs and set
the preferred token thumbprint on the service principal.

This will allow to follow the steps described in
https://docs.microsoft.com/en-us/graph/application-saml-sso-configure-api#create-a-signing-certificate
using hamilton SDK.

Currently Microsoft does not support a method to remove the created certificate key from the service principal.
https://docs.microsoft.com/en-us/graph/api/serviceprincipal-addtokensigningcertificate

Also manual removal via `removePassword` and `removekey` API calls are not supported and fail with an internal server error.

This SDK extension is the base to extend the `terraform-provider-azuread`. 

Issue: https://github.com/hashicorp/terraform-provider-azuread/issues/732