### PR TITLE
Make msgraph.Group a hashable type - change types of unhashable fields

### DIFF
--- a/msgraph/groups_test.go
+++ b/msgraph/groups_test.go
@@ -60,7 +60,7 @@ func TestGroupsClient(t *testing.T) {
 
 	newGroup365 := msgraph.Group{
 		DisplayName:     utils.StringPtr("test-group-365"),
-		GroupTypes:      []msgraph.GroupType{msgraph.GroupTypeUnified},
+		GroupTypes:      &[]msgraph.GroupType{msgraph.GroupTypeUnified},
 		MailEnabled:     utils.BoolPtr(true),
 		MailNickname:    utils.StringPtr(fmt.Sprintf("test-365-group-%s", c.RandomString)),
 		SecurityEnabled: utils.BoolPtr(true),

--- a/msgraph/models.go
+++ b/msgraph/models.go
@@ -865,7 +865,7 @@ type Group struct {
 	Description                   *StringNullWhenEmpty                `json:"description,omitempty"`
 	DisplayName                   *string                             `json:"displayName,omitempty"`
 	ExpirationDateTime            *time.Time                          `json:"expirationDateTime,omitempty"`
-	GroupTypes                    []GroupType                         `json:"groupTypes,omitempty"`
+	GroupTypes                    *[]GroupType                        `json:"groupTypes,omitempty"`
 	HasMembersWithLicenseErrors   *bool                               `json:"hasMembersWithLicenseErrors,omitempty"`
 	HideFromAddressLists          *bool                               `json:"hideFromAddressLists,omitempty"`
 	HideFromOutlookClients        *bool                               `json:"hideFromOutlookClients,omitempty"`
@@ -887,8 +887,8 @@ type Group struct {
 	PreferredLanguage             *string                             `json:"preferredLanguage,omitempty"`
 	ProxyAddresses                *[]string                           `json:"proxyAddresses,omitempty"`
 	RenewedDateTime               *time.Time                          `json:"renewedDateTime,omitempty"`
-	ResourceBehaviorOptions       []GroupResourceBehaviorOption       `json:"resourceBehaviorOptions,omitempty"`
-	ResourceProvisioningOptions   []GroupResourceProvisioningOption   `json:"resourceProvisioningOptions,omitempty"`
+	ResourceBehaviorOptions       *[]GroupResourceBehaviorOption      `json:"resourceBehaviorOptions,omitempty"`
+	ResourceProvisioningOptions   *[]GroupResourceProvisioningOption  `json:"resourceProvisioningOptions,omitempty"`
 	SecurityEnabled               *bool                               `json:"securityEnabled,omitempty"`
 	SecurityIdentifier            *string                             `json:"securityIdentifier,omitempty"`
 	Theme                         *GroupTheme                         `json:"theme,omitempty"`
@@ -945,7 +945,7 @@ func (g *Group) UnmarshalJSON(data []byte) error {
 func (g *Group) HasTypes(types []GroupType) bool {
 	for _, t := range types {
 		found := false
-		for _, gt := range g.GroupTypes {
+		for _, gt := range *g.GroupTypes {
 			if t == gt {
 				found = true
 				break

--- a/msgraph/schema_extensions_test.go
+++ b/msgraph/schema_extensions_test.go
@@ -72,7 +72,7 @@ func testSchemaExtensionsGroup(t *testing.T, c *test.Test, schema *msgraph.Schem
 	// First create a group having schema extension data expressed using msgraph.SchemaExtensionMap
 	group := testGroupsClient_Create(t, c, msgraph.Group{
 		DisplayName:     utils.StringPtr("test-group"),
-		GroupTypes:      []msgraph.GroupType{msgraph.GroupTypeUnified},
+		GroupTypes:      &[]msgraph.GroupType{msgraph.GroupTypeUnified},
 		MailEnabled:     utils.BoolPtr(true),
 		MailNickname:    utils.StringPtr(fmt.Sprintf("test-365-group-%s", c.RandomString)),
 		SecurityEnabled: utils.BoolPtr(true),


### PR DESCRIPTION
This will allow values of type `msgraph.Group` to be hashable and thus usable as keys in Go maps. For example, this is useful in making Groups cached objects in caches whose implementation relies on maps internally.

Addresses https://github.com/manicminer/hamilton/issues/159. 