### PR TITLE
feat: support oidc federated authentication

### DIFF
--- a/auth/config.go
+++ b/auth/config.go
@@ -54,6 +54,7 @@ type Config struct {
 	// Specifies the password to authenticate with using client secret authentication
 	ClientSecret string
 
+	// Enables OIDC Federated authentication
 	EnableClientFederatedAuth bool
 
 	// Specifies the federated assertion to authenticate using client credentials

--- a/auth/config.go
+++ b/auth/config.go
@@ -54,6 +54,11 @@ type Config struct {
 	// Specifies the password to authenticate with using client secret authentication
 	ClientSecret string
 
+	EnableClientFederatedAuth bool
+
+	// Specifies the federated assertion to authenticate using client credentials
+	FederatedAssertion string
+
 	// Enables GitHub OIDC authentication
 	EnableGitHubOIDCAuth bool
 


### PR DESCRIPTION
## Overview

This implements federated authentication via OIDC. This works for Kubernetes Federation along with Generic OIDC issuer.

The client credentials as pointed out by another individual who's name I cannot find (sorry!) 

This basically allows for any OIDC issuer that is configured with a service principal to work. Simple pass the JWT token from the OIDC issuer to the auth config instead and enable client federated auth. 

## Testing

I did not provide tests as I have no way of setting up federated authentication for those test to pass properly for you but I can walk you through the process if interested, there are a couple ways to do this.

## Example Code

```golang
package main

import (
	"context"
	"fmt"
	"log"
	"os"

	"github.com/manicminer/hamilton/auth"
	"github.com/manicminer/hamilton/environments"
	"github.com/manicminer/hamilton/msgraph"
	"github.com/manicminer/hamilton/odata"
)

var (
	tenantId = os.Getenv("AZURE_TENANT_ID")
	clientId = os.Getenv("AZURE_CLIENT_ID")
	jwtToken = os.Getenv("AZURE_FEDERATED_TOKEN")
)

func main() {
	ctx := context.Background()

	environment := environments.Global

	authConfig := &auth.Config{
		Environment:               environment,
		TenantID:                  tenantId,
		ClientID:                  clientId,
		FederatedAssertion:        jwtToken,
		EnableClientFederatedAuth: true,
	}

	authorizer, err := authConfig.NewAuthorizer(ctx, environment.MsGraph)
	if err != nil {
		log.Fatal(err)
	}

	client := msgraph.NewUsersClient(tenantId)
	client.BaseClient.Authorizer = authorizer

	users, _, err := client.List(ctx, odata.Query{})
	if err != nil {
		log.Println(err)
		return
	}
	if users == nil {
		log.Println("bad API response, nil result received")
		return
	}
	for _, user := range *users {
		fmt.Printf("%s: %s <%s>\n", *user.ID, *user.DisplayName, *user.UserPrincipalName)
	}
}
```

