### PR TITLE
Add OData query parameters to appRoleAssignments fixes #180

### DIFF
--- a/msgraph/app_role_assignments.go
+++ b/msgraph/app_role_assignments.go
@@ -50,9 +50,10 @@ func NewServicePrincipalsAppRoleAssignmentsClient(tenantId string) *AppRoleAssig
 }
 
 // List returns a list of app role assignments.
-func (c *AppRoleAssignmentsClient) List(ctx context.Context, id string) (*[]AppRoleAssignment, int, error) {
+func (c *AppRoleAssignmentsClient) List(ctx context.Context, id string, query odata.Query) (*[]AppRoleAssignment, int, error) {
 	resp, status, _, err := c.BaseClient.Get(ctx, GetHttpRequestInput{
 		ValidStatusCodes: []int{http.StatusOK},
+		OData:            query,
 		Uri: Uri{
 			Entity:      fmt.Sprintf("/%s/%s/appRoleAssignments", c.resourceType, id),
 			HasTenantId: true,

--- a/msgraph/app_role_assignments_test.go
+++ b/msgraph/app_role_assignments_test.go
@@ -311,7 +311,7 @@ func TestServicePrincipalsAppRoleAssignmentsClient(t *testing.T) {
 }
 
 func testGroupsAppRoleAssignmentsClient_List(t *testing.T, c *test.Test, id string) (appRoleAssignments *[]msgraph.AppRoleAssignment) {
-	appRoleAssignments, _, err := c.GroupsAppRoleAssignmentsClient.List(c.Context, id)
+	appRoleAssignments, _, err := c.GroupsAppRoleAssignmentsClient.List(c.Context, id, odata.Query{})
 	if err != nil {
 		t.Fatalf("AppRoleAssignmentsClient.List(): %v", err)
 	}
@@ -322,7 +322,7 @@ func testGroupsAppRoleAssignmentsClient_List(t *testing.T, c *test.Test, id stri
 }
 
 func testServicePrincipalsAppRoleAssignmentsClient_List(t *testing.T, c *test.Test, id string) (appRoleAssignments *[]msgraph.AppRoleAssignment) {
-	appRoleAssignments, _, err := c.ServicePrincipalsAppRoleAssignmentsClient.List(c.Context, id)
+	appRoleAssignments, _, err := c.ServicePrincipalsAppRoleAssignmentsClient.List(c.Context, id, odata.Query{})
 	if err != nil {
 		t.Fatalf("AppRoleAssignmentsClient.List(): %v", err)
 	}
@@ -333,7 +333,7 @@ func testServicePrincipalsAppRoleAssignmentsClient_List(t *testing.T, c *test.Te
 }
 
 func testUsersAppRoleAssignmentsClient_List(t *testing.T, c *test.Test, id string) (appRoleAssignments *[]msgraph.AppRoleAssignment) {
-	appRoleAssignments, _, err := c.UsersAppRoleAssignmentsClient.List(c.Context, id)
+	appRoleAssignments, _, err := c.UsersAppRoleAssignmentsClient.List(c.Context, id, odata.Query{})
 	if err != nil {
 		t.Fatalf("AppRoleAssignmentsClient.List(): %v", err)
 	}


### PR DESCRIPTION
Adds the OData query option to appRoleAssignments list method. Fixes #180 