### PR TITLE
quick fixes for two issues: nil pointer and type mismatch

### DIFF
--- a/msgraph/accesspackageresource.go
+++ b/msgraph/accesspackageresource.go
@@ -84,7 +84,7 @@ func (c *AccessPackageResourceClient) Get(ctx context.Context, catalogId string,
 
 	accessPackageResources := data.AccessPackageResources
 
-	if accessPackageResources == nil || len(accessPackageResources) == 0 {
+	if len(accessPackageResources) == 0 {
 		return nil, status, fmt.Errorf("No accessPackageResource found with catalogId %v and originId %v", catalogId, originId)
 	}
 

--- a/msgraph/accesspackageresource.go
+++ b/msgraph/accesspackageresource.go
@@ -82,7 +82,11 @@ func (c *AccessPackageResourceClient) Get(ctx context.Context, catalogId string,
 		return nil, status, fmt.Errorf("json.Unmarshal(): %v", err)
 	}
 
-	accessPackageResource := data.AccessPackageResources[0]
+	accessPackageResources := data.AccessPackageResources
 
-	return &accessPackageResource, status, nil
+	if accessPackageResources == nil || len(accessPackageResources) == 0 {
+		return nil, status, fmt.Errorf("No accessPackageResource found with catalogId %v and originId %v", catalogId, originId)
+	}
+
+	return &accessPackageResources[0], status, nil
 }

--- a/msgraph/models.go
+++ b/msgraph/models.go
@@ -90,7 +90,7 @@ type AccessPackageResource struct {
 	AccessPackageResourceEnvironment *AccessPackageResourceEnvironment `json:"accessPackageResourceEnvironment,omitempty"`
 	AddedBy                          *string                           `json:"addedBy,omitempty"`
 	AddedOn                          *time.Time                        `json:"addedOn,omitempty"`
-	Description                      *bool                             `json:"description,omitempty"`
+	Description                      *string                           `json:"description,omitempty"`
 	DisplayName                      *string                           `json:"displayName,omitempty"`
 	ID                               *string                           `json:"id,omitempty"`
 	IsPendingOnboarding              *bool                             `json:"isPendingOnboarding,omitempty"`


### PR DESCRIPTION
This PR fixes two issues:

1. type mis-match for "Description" field of "AccessPackageResource", reference: https://learn.microsoft.com/en-us/graph/api/resources/accesspackageresource?view=graph-rest-beta
This is introduced recently.
3. For AccessPackageResource, when there is no match on Azure, AccessPackageResources will be an empty array, hence the fix
