### PR TITLE
use eq rather than startswith which returns a list of resources

### DIFF
--- a/msgraph/accesspackageresource.go
+++ b/msgraph/accesspackageresource.go
@@ -57,7 +57,7 @@ func (c *AccessPackageResourceClient) Get(ctx context.Context, catalogId string,
 	resp, status, _, err := c.BaseClient.Get(ctx, GetHttpRequestInput{
 		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
 		OData: odata.Query{
-			Filter: fmt.Sprintf("startswith(originId,'%s')", originId),
+			Filter: fmt.Sprintf("originId eq '%s'", originId),
 		},
 		ValidStatusCodes: []int{http.StatusOK},
 		Uri: Uri{


### PR DESCRIPTION
The startswith function returns a list of resources, should use eq instead, see below screenshot.

Will add test for accesspackageresource later on quite possibly in a separate PR.

<img width="2056" alt="accesspackageresource" src="https://user-images.githubusercontent.com/1937584/200093734-3fd68a9f-2978-46ac-83f2-fc4cefa771c4.png">
