### PR TITLE
fix on prem group type casing

### DIFF
--- a/msgraph/valuetypes.go
+++ b/msgraph/valuetypes.go
@@ -451,9 +451,9 @@ const (
 type OnPremisesGroupType = string
 
 const (
-	UniversalDistributionGroup        OnPremisesGroupType = "universalDistributionGroup"
-	UniversalMailEnabledSecurityGroup OnPremisesGroupType = "universalMailEnabledSecurityGroup"
-	UniversalSecurityGroup            OnPremisesGroupType = "universalSecurityGroup"
+	UniversalDistributionGroup        OnPremisesGroupType = "UniversalDistributionGroup"
+	UniversalMailEnabledSecurityGroup OnPremisesGroupType = "UniversalMailEnabledSecurityGroup"
+	UniversalSecurityGroup            OnPremisesGroupType = "UniversalSecurityGroup"
 )
 
 type Members []DirectoryObject


### PR DESCRIPTION
Msgraph stores this as Pascal and sends it back in that way so we should have the same naming.