### PR TITLE
Add RoleEligibilityScheduleRequestClient

### DIFF
--- a/internal/test/testing.go
+++ b/internal/test/testing.go
@@ -123,6 +123,7 @@ type Test struct {
 	ReportsClient                             *msgraph.ReportsClient
 	RoleAssignmentsClient                     *msgraph.RoleAssignmentsClient
 	RoleDefinitionsClient                     *msgraph.RoleDefinitionsClient
+	RoleEligibilityScheduleRequestClient      *msgraph.RoleEligibilityScheduleRequestClient
 	SchemaExtensionsClient                    *msgraph.SchemaExtensionsClient
 	ServicePrincipalsAppRoleAssignmentsClient *msgraph.AppRoleAssignmentsClient
 	ServicePrincipalsClient                   *msgraph.ServicePrincipalsClient
@@ -349,6 +350,11 @@ func NewTest(t *testing.T) (c *Test) {
 	c.RoleDefinitionsClient.BaseClient.Authorizer = c.Connections["default"].Authorizer
 	c.RoleDefinitionsClient.BaseClient.Endpoint = *endpoint
 	c.RoleDefinitionsClient.BaseClient.RetryableClient.RetryMax = retry
+
+	c.RoleEligibilityScheduleRequestClient = msgraph.NewRoleEligibilityScheduleRequestClient()
+	c.RoleEligibilityScheduleRequestClient.BaseClient.Authorizer = c.Connections["default"].Authorizer
+	c.RoleEligibilityScheduleRequestClient.BaseClient.Endpoint = *endpoint
+	c.RoleEligibilityScheduleRequestClient.BaseClient.RetryableClient.RetryMax = retry
 
 	c.SchemaExtensionsClient = msgraph.NewSchemaExtensionsClient()
 	c.SchemaExtensionsClient.BaseClient.Authorizer = c.Connections["default"].Authorizer

--- a/msgraph/models.go
+++ b/msgraph/models.go
@@ -1383,9 +1383,9 @@ type SamlSingleSignOnSettings struct {
 	RelayState *string `json:"relayState,omitempty"`
 }
 
-type ScheduleInfo struct {
-	StartDateTime time.Time         `json:"startDateTime"`
-	Expiration    ExpirationPattern `json:"expiration"`
+type RequestSchedule struct {
+	StartDateTime *time.Time         `json:"startDateTime,omitempty"`
+	Expiration    *ExpirationPattern `json:"expiration,omitempty"`
 }
 
 type SchemaExtension struct {
@@ -1664,8 +1664,8 @@ type TemporaryAccessPassAuthenticationMethod struct {
 }
 
 type TicketInfo struct {
-	TicketNumber string `json:"ticketNumber"`
-	TicketSystem string `json:"ticketSystem"`
+	TicketNumber *string `json:"ticketNumber,omitempty"`
+	TicketSystem *string `json:"ticketSystem,omitempty"`
 }
 
 type TokenIssuancePolicy struct {
@@ -1704,13 +1704,13 @@ type UnifiedRoleEligibilityScheduleRequest struct {
 	AppScopeID        *string                           `json:"appScopeId,omitempty"`
 	ApprovalID        *string                           `json:"approvalId,omitempty"`
 	CompletedDateTime *time.Time                        `json:"completedDateTime,omitempty"`
-	CreatedDateTime   *time.Time                        `json:"completedDateTime,omitempty"`
+	CreatedDateTime   *time.Time                        `json:"createdDateTime,omitempty"`
 	DirectoryScopeId  *string                           `json:"directoryScopeId,omitempty"`
 	IsValidationOnly  *bool                             `json:"isValidationOnly,omitempty"`
 	Justification     *string                           `json:"justification,omitempty"`
 	PrincipalId       *string                           `json:"principalId,omitempty"`
 	RoleDefinitionId  *string                           `json:"roleDefinitionId,omitempty"`
-	ScheduleInfo      *ScheduleInfo                     `json:"scheduleInfo,omitempty"`
+	ScheduleInfo      *RequestSchedule                  `json:"scheduleInfo,omitempty"`
 	Status            *string                           `json:"status,omitempty"`
 	TargetScheduleID  *string                           `json:"targetScheduleId,omitempty"`
 	TicketInfo        *TicketInfo                       `json:"ticketInfo,omitempty"`

--- a/msgraph/models.go
+++ b/msgraph/models.go
@@ -1383,6 +1383,11 @@ type SamlSingleSignOnSettings struct {
 	RelayState *string `json:"relayState,omitempty"`
 }
 
+type ScheduleInfo struct {
+	StartDateTime time.Time         `json:"startDateTime"`
+	Expiration    ExpirationPattern `json:"expiration"`
+}
+
 type SchemaExtension struct {
 	ID          *string                      `json:"id,omitempty"`
 	Description *string                      `json:"description,omitempty"`
@@ -1658,6 +1663,11 @@ type TemporaryAccessPassAuthenticationMethod struct {
 	MethodUsabilityReason *MethodUsabilityReason `json:"methodUsabilityReason,omitempty"`
 }
 
+type TicketInfo struct {
+	TicketNumber string `json:"ticketNumber"`
+	TicketSystem string `json:"ticketSystem"`
+}
+
 type TokenIssuancePolicy struct {
 	DirectoryObject
 	Definition            *[]string `json:"definition,omitempty"`
@@ -1686,6 +1696,24 @@ type UnifiedRoleDefinition struct {
 	RolePermissions *[]UnifiedRolePermission `json:"rolePermissions,omitempty"`
 	TemplateId      *string                  `json:"templateId,omitempty"`
 	Version         *string                  `json:"version,omitempty"`
+}
+
+type UnifiedRoleEligibilityScheduleRequest struct {
+	ID                *string                           `json:"id,omitempty"`
+	Action            *UnifiedRoleScheduleRequestAction `json:"action,omitempty"`
+	AppScopeID        *string                           `json:"appScopeId,omitempty"`
+	ApprovalID        *string                           `json:"approvalId,omitempty"`
+	CompletedDateTime *time.Time                        `json:"completedDateTime,omitempty"`
+	CreatedDateTime   *time.Time                        `json:"completedDateTime,omitempty"`
+	DirectoryScopeId  *string                           `json:"directoryScopeId,omitempty"`
+	IsValidationOnly  *bool                             `json:"isValidationOnly,omitempty"`
+	Justification     *string                           `json:"justification,omitempty"`
+	PrincipalId       *string                           `json:"principalId,omitempty"`
+	RoleDefinitionId  *string                           `json:"roleDefinitionId,omitempty"`
+	ScheduleInfo      *ScheduleInfo                     `json:"scheduleInfo,omitempty"`
+	Status            *string                           `json:"status,omitempty"`
+	TargetScheduleID  *string                           `json:"targetScheduleId,omitempty"`
+	TicketInfo        *TicketInfo                       `json:"ticketInfo,omitempty"`
 }
 
 type UnifiedRolePermission struct {
@@ -1965,15 +1993,4 @@ type UserFlowAttribute struct {
 	DisplayName           *string                    `json:"displayName,omitempty"`
 	UserFlowAttributeType *string                    `json:"userFlowAttributeType,omitempty"`
 	DataType              *UserflowAttributeDataType `json:"dataType,omitempty"`
-}
-
-type UnifiedRoleEligibilityScheduleRequest struct {
-	DirectoryObject
-
-	Action           *string      `json:"action,omitempty"`
-	DirectoryScopeId *string      `json:"directoryScopeId,omitempty"`
-	Justification    *string      `json:"justification,omitempty"`
-	PrincipalId      *string      `json:"principalId,omitempty"`
-	RoleDefinitionId *string      `json:"roleDefinitionId,omitempty"`
-	ScheduleInfo     *interface{} `json:"scheduleInfo,omitempty"`
 }

--- a/msgraph/models.go
+++ b/msgraph/models.go
@@ -1966,3 +1966,14 @@ type UserFlowAttribute struct {
 	UserFlowAttributeType *string                    `json:"userFlowAttributeType,omitempty"`
 	DataType              *UserflowAttributeDataType `json:"dataType,omitempty"`
 }
+
+type UnifiedRoleEligibilityScheduleRequest struct {
+	DirectoryObject
+
+	Action           *string      `json:"action,omitempty"`
+	DirectoryScopeId *string      `json:"directoryScopeId,omitempty"`
+	Justification    *string      `json:"justification,omitempty"`
+	PrincipalId      *string      `json:"principalId,omitempty"`
+	RoleDefinitionId *string      `json:"roleDefinitionId,omitempty"`
+	ScheduleInfo     *interface{} `json:"scheduleInfo,omitempty"`
+}

--- a/msgraph/role_eligibility_schedule_request.go
+++ b/msgraph/role_eligibility_schedule_request.go
@@ -1,0 +1,120 @@
+package msgraph
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+var actionAdminAssign string = "adminAssign"
+var actionAdminRemove string = "adminRemove"
+
+// RoleEligibilityScheduleRequestClient performs operations on RoleEligibilityScheduleRequests.
+type RoleEligibilityScheduleRequestClient struct {
+	BaseClient Client
+}
+
+// NewRoleEligibilityScheduleRequest returns a new RoleEligibilityScheduleRequestClient
+func NewRoleEligibilityScheduleRequestClient() *RoleEligibilityScheduleRequestClient {
+	return &RoleEligibilityScheduleRequestClient{
+		BaseClient: NewClient(Version10),
+	}
+}
+
+// Get retrieves a UnifiedRoleEligibilityScheduleRequest
+func (c *RoleEligibilityScheduleRequestClient) Get(ctx context.Context, id string, query odata.Query) (*UnifiedRoleEligibilityScheduleRequest, int, error) {
+	resp, status, _, err := c.BaseClient.Get(ctx, GetHttpRequestInput{
+		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
+		OData:                  query,
+		ValidStatusCodes:       []int{http.StatusOK},
+		Uri: Uri{
+			Entity: fmt.Sprintf("/roleManagement/directory/roleEligibilityScheduleRequests/%s", id),
+		},
+	})
+	if err != nil {
+		return nil, status, fmt.Errorf("RoleEligibilityScheduleRequestClient.BaseClient.Get(): %v", err)
+	}
+
+	defer resp.Body.Close()
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, status, fmt.Errorf("io.ReadAll(): %v", err)
+	}
+
+	var dirRole UnifiedRoleEligibilityScheduleRequest
+	if err := json.Unmarshal(respBody, &dirRole); err != nil {
+		return nil, status, fmt.Errorf("json.Unmarshal(): %v", err)
+	}
+
+	return &dirRole, status, nil
+}
+
+// Create creates a new UnifiedRoleEligibilityScheduleRequest.
+func (c *RoleEligibilityScheduleRequestClient) Create(ctx context.Context, resr UnifiedRoleEligibilityScheduleRequest) (*UnifiedRoleEligibilityScheduleRequest, int, error) {
+	var status int
+
+	resr.Action = &actionAdminAssign
+	body, err := json.Marshal(resr)
+	if err != nil {
+		return nil, status, fmt.Errorf("json.Marshal(): %v", err)
+	}
+
+	resp, status, _, err := c.BaseClient.Post(ctx, PostHttpRequestInput{
+		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
+		Body:                   body,
+		ValidStatusCodes:       []int{http.StatusCreated},
+		Uri: Uri{
+			Entity: "/roleManagement/directory/roleEligibilityScheduleRequests",
+		},
+	})
+	if err != nil {
+		return nil, status, fmt.Errorf("RoleEligibilityScheduleRequestClient.BaseClient.Post(): %v", err)
+	}
+
+	defer resp.Body.Close()
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, status, fmt.Errorf("io.ReadAll(): %v", err)
+	}
+
+	var newRoleAssignment UnifiedRoleEligibilityScheduleRequest
+	if err := json.Unmarshal(respBody, &newRoleAssignment); err != nil {
+		return nil, status, fmt.Errorf("json.Unmarshal(): %v", err)
+	}
+
+	return &newRoleAssignment, status, nil
+}
+
+// Delete removes a UnifiedRoleEligibilityScheduleRequest.
+func (c *RoleEligibilityScheduleRequestClient) Delete(ctx context.Context, id string) (int, error) {
+	resr, status, err := c.Get(ctx, id, odata.Query{})
+	if err != nil {
+		return status, fmt.Errorf("RoleEligibilityScheduleRequestClient.Get(): %v", err)
+	}
+	resrBody := UnifiedRoleEligibilityScheduleRequest{
+		Action:           &actionAdminRemove,
+		RoleDefinitionId: resr.RoleDefinitionId,
+		DirectoryScopeId: resr.DirectoryScopeId,
+		PrincipalId:      resr.PrincipalId,
+	}
+	body, err := json.Marshal(resrBody)
+	if err != nil {
+		return status, fmt.Errorf("json.Marshal(): %v", err)
+	}
+	_, status, _, err = c.BaseClient.Post(ctx, PostHttpRequestInput{
+		Body:             body,
+		ValidStatusCodes: []int{http.StatusCreated},
+		Uri: Uri{
+			Entity: "/roleManagement/directory/roleEligibilityScheduleRequests",
+		},
+	})
+	if err != nil {
+		return status, fmt.Errorf("RoleAssignments.BaseClient.Get(): %v", err)
+	}
+
+	return status, nil
+}

--- a/msgraph/role_eligibility_schedule_request.go
+++ b/msgraph/role_eligibility_schedule_request.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 
 	"github.com/hashicorp/go-azure-sdk/sdk/odata"
-	"github.com/manicminer/hamilton/internal/utils"
 )
 
 // RoleEligibilityScheduleRequestClient performs operations on RoleEligibilityScheduleRequests.
@@ -83,7 +82,6 @@ func (c *RoleEligibilityScheduleRequestClient) List(ctx context.Context) (*[]Uni
 func (c *RoleEligibilityScheduleRequestClient) Create(ctx context.Context, resr UnifiedRoleEligibilityScheduleRequest) (*UnifiedRoleEligibilityScheduleRequest, int, error) {
 	var status int
 
-	resr.Action = utils.StringPtr(UnifiedRoleScheduleRequestActionAdminAssign)
 	body, err := json.Marshal(resr)
 	if err != nil {
 		return nil, status, fmt.Errorf("json.Marshal(): %v", err)
@@ -113,36 +111,6 @@ func (c *RoleEligibilityScheduleRequestClient) Create(ctx context.Context, resr 
 	}
 
 	return &newEligibilityScheduleRequest, status, nil
-}
-
-// Delete removes a UnifiedRoleEligibilityScheduleRequest.
-func (c *RoleEligibilityScheduleRequestClient) Delete(ctx context.Context, id string) (int, error) {
-	resr, status, err := c.Get(ctx, id, odata.Query{})
-	if err != nil {
-		return status, fmt.Errorf("RoleEligibilityScheduleRequestClient.Get(): %v", err)
-	}
-	resrBody := UnifiedRoleEligibilityScheduleRequest{
-		Action:           utils.StringPtr(UnifiedRoleScheduleRequestActionAdminRemove),
-		RoleDefinitionId: resr.RoleDefinitionId,
-		DirectoryScopeId: resr.DirectoryScopeId,
-		PrincipalId:      resr.PrincipalId,
-	}
-	body, err := json.Marshal(resrBody)
-	if err != nil {
-		return status, fmt.Errorf("json.Marshal(): %v", err)
-	}
-	_, status, _, err = c.BaseClient.Post(ctx, PostHttpRequestInput{
-		Body:             body,
-		ValidStatusCodes: []int{http.StatusCreated},
-		Uri: Uri{
-			Entity: "/roleManagement/directory/roleEligibilityScheduleRequests",
-		},
-	})
-	if err != nil {
-		return status, fmt.Errorf("RoleEligibilityScheduleRequestClient.BaseClient.Post(): %v", err)
-	}
-
-	return status, nil
 }
 
 // Cancel revokes a granted UnifiedRoleEligibilityScheduleRequest

--- a/msgraph/role_eligibility_schedule_request.go
+++ b/msgraph/role_eligibility_schedule_request.go
@@ -43,12 +43,40 @@ func (c *RoleEligibilityScheduleRequestClient) Get(ctx context.Context, id strin
 		return nil, status, fmt.Errorf("io.ReadAll(): %v", err)
 	}
 
-	var dirRole UnifiedRoleEligibilityScheduleRequest
-	if err := json.Unmarshal(respBody, &dirRole); err != nil {
+	var roleEligibilityScheduleRequest UnifiedRoleEligibilityScheduleRequest
+	if err := json.Unmarshal(respBody, &roleEligibilityScheduleRequest); err != nil {
 		return nil, status, fmt.Errorf("json.Unmarshal(): %v", err)
 	}
 
-	return &dirRole, status, nil
+	return &roleEligibilityScheduleRequest, status, nil
+}
+
+// List retrieves all UnifiedRoleEligibilityScheduleRequests.
+func (c *RoleEligibilityScheduleRequestClient) List(ctx context.Context) (*[]UnifiedRoleEligibilityScheduleRequest, int, error) {
+	var status int
+
+	resp, status, _, err := c.BaseClient.Get(ctx, GetHttpRequestInput{
+		ValidStatusCodes: []int{http.StatusOK},
+		Uri: Uri{
+			Entity: "/roleManagement/directory/roleEligibilityScheduleRequests",
+		},
+	})
+	if err != nil {
+		return nil, status, fmt.Errorf("RoleEligibilityScheduleRequestClient.BaseClient.Get(): %v", err)
+	}
+
+	defer resp.Body.Close()
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, status, fmt.Errorf("io.ReadAll(): %v", err)
+	}
+
+	var roleEligibilityScheduleRequests []UnifiedRoleEligibilityScheduleRequest
+	if err := json.Unmarshal(respBody, &roleEligibilityScheduleRequests); err != nil {
+		return nil, status, fmt.Errorf("json.Unmarshal(): %v", err)
+	}
+
+	return &roleEligibilityScheduleRequests, status, nil
 }
 
 // Create creates a new UnifiedRoleEligibilityScheduleRequest.
@@ -79,12 +107,12 @@ func (c *RoleEligibilityScheduleRequestClient) Create(ctx context.Context, resr 
 		return nil, status, fmt.Errorf("io.ReadAll(): %v", err)
 	}
 
-	var newRoleAssignment UnifiedRoleEligibilityScheduleRequest
-	if err := json.Unmarshal(respBody, &newRoleAssignment); err != nil {
+	var newEligibilityScheduleRequest UnifiedRoleEligibilityScheduleRequest
+	if err := json.Unmarshal(respBody, &newEligibilityScheduleRequest); err != nil {
 		return nil, status, fmt.Errorf("json.Unmarshal(): %v", err)
 	}
 
-	return &newRoleAssignment, status, nil
+	return &newEligibilityScheduleRequest, status, nil
 }
 
 // Delete removes a UnifiedRoleEligibilityScheduleRequest.
@@ -108,6 +136,22 @@ func (c *RoleEligibilityScheduleRequestClient) Delete(ctx context.Context, id st
 		ValidStatusCodes: []int{http.StatusCreated},
 		Uri: Uri{
 			Entity: "/roleManagement/directory/roleEligibilityScheduleRequests",
+		},
+	})
+	if err != nil {
+		return status, fmt.Errorf("RoleEligibilityScheduleRequestClient.BaseClient.Post(): %v", err)
+	}
+
+	return status, nil
+}
+
+// Cancel revokes a granted UnifiedRoleEligibilityScheduleRequest
+func (c *RoleEligibilityScheduleRequestClient) Cancel(ctx context.Context, id string, query odata.Query) (int, error) {
+	_, status, _, err := c.BaseClient.Post(ctx, PostHttpRequestInput{
+		OData:            query,
+		ValidStatusCodes: []int{http.StatusNoContent},
+		Uri: Uri{
+			Entity: fmt.Sprintf("/roleManagement/directory/roleEligibilityScheduleRequests/%s/cancel", id),
 		},
 	})
 	if err != nil {

--- a/msgraph/role_eligibility_schedule_request.go
+++ b/msgraph/role_eligibility_schedule_request.go
@@ -8,10 +8,8 @@ import (
 	"net/http"
 
 	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+	"github.com/manicminer/hamilton/internal/utils"
 )
-
-var actionAdminAssign string = "adminAssign"
-var actionAdminRemove string = "adminRemove"
 
 // RoleEligibilityScheduleRequestClient performs operations on RoleEligibilityScheduleRequests.
 type RoleEligibilityScheduleRequestClient struct {
@@ -57,7 +55,7 @@ func (c *RoleEligibilityScheduleRequestClient) Get(ctx context.Context, id strin
 func (c *RoleEligibilityScheduleRequestClient) Create(ctx context.Context, resr UnifiedRoleEligibilityScheduleRequest) (*UnifiedRoleEligibilityScheduleRequest, int, error) {
 	var status int
 
-	resr.Action = &actionAdminAssign
+	resr.Action = utils.StringPtr(UnifiedRoleScheduleRequestActionAdminAssign)
 	body, err := json.Marshal(resr)
 	if err != nil {
 		return nil, status, fmt.Errorf("json.Marshal(): %v", err)
@@ -96,7 +94,7 @@ func (c *RoleEligibilityScheduleRequestClient) Delete(ctx context.Context, id st
 		return status, fmt.Errorf("RoleEligibilityScheduleRequestClient.Get(): %v", err)
 	}
 	resrBody := UnifiedRoleEligibilityScheduleRequest{
-		Action:           &actionAdminRemove,
+		Action:           utils.StringPtr(UnifiedRoleScheduleRequestActionAdminRemove),
 		RoleDefinitionId: resr.RoleDefinitionId,
 		DirectoryScopeId: resr.DirectoryScopeId,
 		PrincipalId:      resr.PrincipalId,
@@ -113,7 +111,7 @@ func (c *RoleEligibilityScheduleRequestClient) Delete(ctx context.Context, id st
 		},
 	})
 	if err != nil {
-		return status, fmt.Errorf("RoleAssignments.BaseClient.Get(): %v", err)
+		return status, fmt.Errorf("RoleEligibilityScheduleRequestClient.BaseClient.Post(): %v", err)
 	}
 
 	return status, nil

--- a/msgraph/role_eligibility_schedule_request.go
+++ b/msgraph/role_eligibility_schedule_request.go
@@ -70,12 +70,15 @@ func (c *RoleEligibilityScheduleRequestClient) List(ctx context.Context) (*[]Uni
 		return nil, status, fmt.Errorf("io.ReadAll(): %v", err)
 	}
 
-	var roleEligibilityScheduleRequests []UnifiedRoleEligibilityScheduleRequest
-	if err := json.Unmarshal(respBody, &roleEligibilityScheduleRequests); err != nil {
+	var data struct {
+		Value []UnifiedRoleEligibilityScheduleRequest `json:"value"`
+	}
+
+	if err := json.Unmarshal(respBody, &data); err != nil {
 		return nil, status, fmt.Errorf("json.Unmarshal(): %v", err)
 	}
 
-	return &roleEligibilityScheduleRequests, status, nil
+	return &data.Value, status, nil
 }
 
 // Create creates a new UnifiedRoleEligibilityScheduleRequest.

--- a/msgraph/role_eligibility_schedule_request_test.go
+++ b/msgraph/role_eligibility_schedule_request_test.go
@@ -25,25 +25,14 @@ func TestRoleEligibilityScheduleRequestClient(t *testing.T) {
 		},
 	})
 
-	roleDefinition := testRoleDefinitionsClient_Create(t, c, msgraph.UnifiedRoleDefinition{
-		Description: msgraph.NullableString("testing role eligibility schedule request"),
-		DisplayName: utils.StringPtr("test-eligible"),
-		IsEnabled:   utils.BoolPtr(true),
-		RolePermissions: &[]msgraph.UnifiedRolePermission{
-			{
-				AllowedResourceActions: &[]string{
-					"microsoft.directory/groups/allProperties/read",
-				},
-			},
-		},
-		Version: utils.StringPtr("1.5"),
-	})
+	directoryRoles := testDirectoryRolesClient_List(t, c)
+	directoryRole := (*directoryRoles)[0]
 
 	now := time.Now()
 
 	roleEligibilityScheduleRequest := testRoleEligibilityScheduleRequestClient_Create(t, c, msgraph.UnifiedRoleEligibilityScheduleRequest{
 		Action:           utils.StringPtr(msgraph.UnifiedRoleScheduleRequestActionAdminAssign),
-		RoleDefinitionId: roleDefinition.ID(),
+		RoleDefinitionId: directoryRole.RoleTemplateId,
 		PrincipalId:      user.ID(),
 		DirectoryScopeId: utils.StringPtr("/"),
 		Justification:    utils.StringPtr("Test eligible"),
@@ -61,7 +50,6 @@ func TestRoleEligibilityScheduleRequestClient(t *testing.T) {
 	testRoleEligibilityScheduleRequestClient_Create(t, c, *roleEligibilityScheduleRequest)
 	testUsersClient_Delete(t, c, *user.ID())
 	testUsersClient_DeletePermanently(t, c, *user.ID())
-	testRoleDefinitionsClient_Delete(t, c, *roleDefinition.ID())
 }
 
 func testRoleEligibilityScheduleRequestClient_Create(t *testing.T, c *test.Test, r msgraph.UnifiedRoleEligibilityScheduleRequest) (roleEligibilityScheduleRequest *msgraph.UnifiedRoleEligibilityScheduleRequest) {

--- a/msgraph/role_eligibility_schedule_request_test.go
+++ b/msgraph/role_eligibility_schedule_request_test.go
@@ -39,14 +39,16 @@ func TestRoleEligibilityScheduleRequestClient(t *testing.T) {
 		Version: utils.StringPtr("1.5"),
 	})
 
+	now := time.Now()
+
 	roleEligibilityScheduleRequest := testRoleEligibilityScheduleRequestClient_Create(t, c, msgraph.UnifiedRoleEligibilityScheduleRequest{
 		RoleDefinitionId: roleDefinition.ID(),
 		PrincipalId:      user.ID(),
 		DirectoryScopeId: utils.StringPtr("/"),
 		Justification:    utils.StringPtr("abc"),
-		ScheduleInfo: &msgraph.ScheduleInfo{
-			StartDateTime: time.Now(),
-			Expiration: msgraph.ExpirationPattern{
+		ScheduleInfo: &msgraph.RequestSchedule{
+			StartDateTime: &now,
+			Expiration: &msgraph.ExpirationPattern{
 				Type: utils.StringPtr(msgraph.ExpirationPatternTypeNoExpiration),
 			},
 		},

--- a/msgraph/role_eligibility_schedule_request_test.go
+++ b/msgraph/role_eligibility_schedule_request_test.go
@@ -1,0 +1,110 @@
+package msgraph_test
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+	"github.com/manicminer/hamilton/internal/test"
+	"github.com/manicminer/hamilton/internal/utils"
+	"github.com/manicminer/hamilton/msgraph"
+)
+
+func TestRoleEligibilityScheduleRequestClient(t *testing.T) {
+	c := test.NewTest(t)
+	defer c.CancelFunc()
+
+	user := testUsersClient_Create(t, c, msgraph.User{
+		AccountEnabled:    utils.BoolPtr(true),
+		DisplayName:       utils.StringPtr("test-user"),
+		MailNickname:      utils.StringPtr(fmt.Sprintf("test-user-%s", c.RandomString)),
+		UserPrincipalName: utils.StringPtr(fmt.Sprintf("test-user-%s@%s", c.RandomString, c.Connections["default"].DomainName)),
+		PasswordProfile: &msgraph.UserPasswordProfile{
+			Password: utils.StringPtr(fmt.Sprintf("IrPa55w0rd%s", c.RandomString)),
+		},
+	})
+
+	roleDefinition := testRoleDefinitionsClient_Create(t, c, msgraph.UnifiedRoleDefinition{
+		Description: msgraph.NullableString("testing role eligibility schedule request"),
+		DisplayName: utils.StringPtr("test-assignor"),
+		IsEnabled:   utils.BoolPtr(true),
+		RolePermissions: &[]msgraph.UnifiedRolePermission{
+			{
+				AllowedResourceActions: &[]string{
+					"microsoft.directory/groups/allProperties/read",
+				},
+			},
+		},
+		Version: utils.StringPtr("1.5"),
+	})
+
+	var expiration interface{} = struct {
+		Type string `json:"type"`
+	}{
+		Type: "NoExpiration",
+	}
+
+	var scheduleInfo interface{} = struct {
+		StartDateTime string      `json:"startDateTime"`
+		Expiration    interface{} `json:"expiration"`
+	}{
+		StartDateTime: time.Now().UTC().Format(time.RFC3339),
+		Expiration:    expiration,
+	}
+
+	roleEligibilityScheduleRequest := testRoleEligibilityScheduleRequestClient_Create(t, c, msgraph.UnifiedRoleEligibilityScheduleRequest{
+		RoleDefinitionId: roleDefinition.ID(),
+		PrincipalId:      user.ID(),
+		DirectoryScopeId: utils.StringPtr("/"),
+		Justification:    utils.StringPtr("abc"),
+		ScheduleInfo:     &scheduleInfo,
+	})
+
+	testRoleEligibilityScheduleRequestClient_Get(t, c, *roleEligibilityScheduleRequest.ID())
+	testRoleEligibilityScheduleRequestClient_Delete(t, c, *roleEligibilityScheduleRequest.ID())
+	testUsersClient_Delete(t, c, *user.ID())
+	testUsersClient_DeletePermanently(t, c, *user.ID())
+	testRoleDefinitionsClient_Delete(t, c, *roleDefinition.ID())
+}
+
+func testRoleEligibilityScheduleRequestClient_Create(t *testing.T, c *test.Test, r msgraph.UnifiedRoleEligibilityScheduleRequest) (roleEligibilityScheduleRequest *msgraph.UnifiedRoleEligibilityScheduleRequest) {
+	roleEligibilityScheduleRequest, status, err := c.RoleEligibilityScheduleRequestClient.Create(c.Context, r)
+	if err != nil {
+		t.Fatalf("RoleEligibilityScheduleRequestClient.Create(): %v", err)
+	}
+	if status < 200 || status >= 300 {
+		t.Fatalf("RoleEligibilityScheduleRequestClient.Create(): invalid status: %d", status)
+	}
+	if roleEligibilityScheduleRequest == nil {
+		t.Fatal("RoleEligibilityScheduleRequestClient.Create(): roleEligibilityScheduleRequest was nil")
+	}
+	if roleEligibilityScheduleRequest.ID() == nil {
+		t.Fatal("RoleEligibilityScheduleRequestClient.Create(): roleEligibilityScheduleRequest.ID was nil")
+	}
+	return
+}
+
+func testRoleEligibilityScheduleRequestClient_Get(t *testing.T, c *test.Test, id string) (roleEligibilityScheduleRequest *msgraph.UnifiedRoleEligibilityScheduleRequest) {
+	roleEligibilityScheduleRequest, status, err := c.RoleEligibilityScheduleRequestClient.Get(c.Context, id, odata.Query{})
+	if err != nil {
+		t.Fatalf("RoleEligibilityScheduleRequestClient.Get(): %v", err)
+	}
+	if status < 200 || status >= 300 {
+		t.Fatalf("RoleEligibilityScheduleRequestClient.Get(): invalid status: %d", status)
+	}
+	if roleEligibilityScheduleRequest == nil {
+		t.Fatal("RoleEligibilityScheduleRequestClient.Get(): roleEligibilityScheduleRequest was nil")
+	}
+	return
+}
+
+func testRoleEligibilityScheduleRequestClient_Delete(t *testing.T, c *test.Test, id string) {
+	status, err := c.RoleEligibilityScheduleRequestClient.Delete(c.Context, id)
+	if err != nil {
+		t.Fatalf("RoleEligibilityScheduleRequestClient.Delete(): %v", err)
+	}
+	if status < 200 || status >= 300 {
+		t.Fatalf("RoleEligibilityScheduleRequestClient.Delete(): invalid status: %d", status)
+	}
+}

--- a/msgraph/role_eligibility_schedule_request_test.go
+++ b/msgraph/role_eligibility_schedule_request_test.go
@@ -39,30 +39,21 @@ func TestRoleEligibilityScheduleRequestClient(t *testing.T) {
 		Version: utils.StringPtr("1.5"),
 	})
 
-	var expiration interface{} = struct {
-		Type string `json:"type"`
-	}{
-		Type: "NoExpiration",
-	}
-
-	var scheduleInfo interface{} = struct {
-		StartDateTime string      `json:"startDateTime"`
-		Expiration    interface{} `json:"expiration"`
-	}{
-		StartDateTime: time.Now().UTC().Format(time.RFC3339),
-		Expiration:    expiration,
-	}
-
 	roleEligibilityScheduleRequest := testRoleEligibilityScheduleRequestClient_Create(t, c, msgraph.UnifiedRoleEligibilityScheduleRequest{
 		RoleDefinitionId: roleDefinition.ID(),
 		PrincipalId:      user.ID(),
 		DirectoryScopeId: utils.StringPtr("/"),
 		Justification:    utils.StringPtr("abc"),
-		ScheduleInfo:     &scheduleInfo,
+		ScheduleInfo: &msgraph.ScheduleInfo{
+			StartDateTime: time.Now(),
+			Expiration: msgraph.ExpirationPattern{
+				Type: utils.StringPtr(msgraph.ExpirationPatternTypeNoExpiration),
+			},
+		},
 	})
 
-	testRoleEligibilityScheduleRequestClient_Get(t, c, *roleEligibilityScheduleRequest.ID())
-	testRoleEligibilityScheduleRequestClient_Delete(t, c, *roleEligibilityScheduleRequest.ID())
+	testRoleEligibilityScheduleRequestClient_Get(t, c, *roleEligibilityScheduleRequest.ID)
+	testRoleEligibilityScheduleRequestClient_Delete(t, c, *roleEligibilityScheduleRequest.ID)
 	testUsersClient_Delete(t, c, *user.ID())
 	testUsersClient_DeletePermanently(t, c, *user.ID())
 	testRoleDefinitionsClient_Delete(t, c, *roleDefinition.ID())
@@ -79,7 +70,7 @@ func testRoleEligibilityScheduleRequestClient_Create(t *testing.T, c *test.Test,
 	if roleEligibilityScheduleRequest == nil {
 		t.Fatal("RoleEligibilityScheduleRequestClient.Create(): roleEligibilityScheduleRequest was nil")
 	}
-	if roleEligibilityScheduleRequest.ID() == nil {
+	if roleEligibilityScheduleRequest.ID == nil {
 		t.Fatal("RoleEligibilityScheduleRequestClient.Create(): roleEligibilityScheduleRequest.ID was nil")
 	}
 	return

--- a/msgraph/valuetypes.go
+++ b/msgraph/valuetypes.go
@@ -749,6 +749,21 @@ const (
 	SignInAudiencePersonalMicrosoftAccount           SignInAudience = "PersonalMicrosoftAccount"
 )
 
+type UnifiedRoleScheduleRequestAction = string
+
+const (
+	UnifiedRoleScheduleRequestActionAdminAssign        UnifiedRoleScheduleRequestAction = "adminAssign"
+	UnifiedRoleScheduleRequestActionAdminExtend        UnifiedRoleScheduleRequestAction = "adminExtend"
+	UnifiedRoleScheduleRequestActionAdminRemove        UnifiedRoleScheduleRequestAction = "adminRemove"
+	UnifiedRoleScheduleRequestActionAdminRenew         UnifiedRoleScheduleRequestAction = "adminRenew"
+	UnifiedRoleScheduleRequestActionAdminUpdate        UnifiedRoleScheduleRequestAction = "adminUpdate"
+	UnifiedRoleScheduleRequestActionSelfActivate       UnifiedRoleScheduleRequestAction = "selfActivate"
+	UnifiedRoleScheduleRequestActionSelfDeactivate     UnifiedRoleScheduleRequestAction = "selfDeactivate"
+	UnifiedRoleScheduleRequestActionSelfExtend         UnifiedRoleScheduleRequestAction = "selfExtend"
+	UnifiedRoleScheduleRequestActionSelfRenew          UnifiedRoleScheduleRequestAction = "selfRenew"
+	UnifiedRoleScheduleRequestActionUnknownFutureValue UnifiedRoleScheduleRequestAction = "unknownFutureValue"
+)
+
 type UsageAuthMethod = string
 
 const (


### PR DESCRIPTION
This PR adds a `RoleEligibilityScheduleRequestClient`, which lets us use the [PIM API for managing role eligibilities](https://learn.microsoft.com/en-us/graph/api/resources/privilegedidentitymanagementv3-overview?view=graph-rest-1.0#pim-api-for-managing-role-eligibilities). This is part of a PR to the https://github.com/hashicorp/terraform-provider-azuread repo, where we would like to be able to manage role eligibilities through terraform.

I havn't written any tests, as I wanted to get some input on how this should be done. The user/service principal requires [a role and a permission](https://learn.microsoft.com/en-us/graph/api/resources/privilegedidentitymanagementv3-overview?view=graph-rest-1.0#permissions-and-privileges) to be able to use the API. Should I set up the permissions as part of the test (and remove them after)? Should I assume the calling service principal has the correct roles and permissions?