### PR TITLE
Provide a function to create a group directly into an administrative unit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 0.53.0 (Unreleased)
 
+- Add the App ID for `Microsoft.StorageSync` to `PublishedApis` ([#200](https://github.com/manicminer/hamilton/pull/200))
 - Bugfix: Fix casing of values for `OnPremisesGroupType` type ([#199](https://github.com/manicminer/hamilton/pull/199))
 
 ## 0.52.0 (November 30, 2022)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.53.0 (Unreleased)
+## 0.53.0 (January 11, 2023)
 
 - Add the App ID for `Microsoft.StorageSync` to `PublishedApis` ([#200](https://github.com/manicminer/hamilton/pull/200))
 - Bugfix: Fix casing of values for `OnPremisesGroupType` type ([#199](https://github.com/manicminer/hamilton/pull/199))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.53.0 (Unreleased)
+
+- Bugfix: Fix casing of values for `OnPremisesGroupType` type ([#199](https://github.com/manicminer/hamilton/pull/199))
+
 ## 0.52.0 (November 30, 2022)
 
 - Bugfix: Use `eq` over `startsWith` in `msgraph.AccessPackageResourceClient{}.Get()` to improve accuracy ([#194](https://github.com/manicminer/hamilton/pull/194))

--- a/msgraph/administrative_units_test.go
+++ b/msgraph/administrative_units_test.go
@@ -53,6 +53,7 @@ func TestAdministrativeUnitsClient(t *testing.T) {
 	}
 	createdGroup := testAdministrativeUnitsClient_CreateGroup(t, c, *administrativeUnit.ID, &group)
 	testAdministrativeUnitsClient_RemoveMembers(t, c, *administrativeUnit.ID, &([]string{*createdGroup.ID()}))
+	testGroup_Delete(t, c, createdGroup)
 
 	directoryRoleTemplates := testDirectoryRoleTemplatesClient_List(t, c)
 	var helpdeskAdministratorRoleId string


### PR DESCRIPTION
We'd like to provide an additional function on the AdministrativeUnitsClient which allows us to create group objects directly into an administrative unit, as documented on [MS Docs](https://learn.microsoft.com/en-us/azure/active-directory/roles/admin-units-members-add#create-a-new-group-in-an-administrative-unit-2).

This would enable managing group in an administrative unit without write permission on a whole tenant. As it states [here](https://learn.microsoft.com/en-us/azure/active-directory/roles/admin-units-members-add#prerequisites), the permissions could be scoped only to the respective AU.
It would also enable to solve [this issue](https://github.com/hashicorp/terraform-provider-azuread/issues/906) on the terraform provider for azuread, as the provider uses this package as dependency.