### PR TITLE
Add entitlement management role clients

### DIFF
--- a/internal/test/testing.go
+++ b/internal/test/testing.go
@@ -116,6 +116,8 @@ type Test struct {
 	DirectoryRoleTemplatesClient              *msgraph.DirectoryRoleTemplatesClient
 	DirectoryRolesClient                      *msgraph.DirectoryRolesClient
 	DomainsClient                             *msgraph.DomainsClient
+	EntitlementRoleAssignmentsClient          *msgraph.EntitlementRoleAssignmentsClient
+	EntitlementRoleDefinitionsClient          *msgraph.EntitlementRoleDefinitionsClient
 	GroupsAppRoleAssignmentsClient            *msgraph.AppRoleAssignmentsClient
 	GroupsClient                              *msgraph.GroupsClient
 	IdentityProvidersClient                   *msgraph.IdentityProvidersClient
@@ -283,6 +285,16 @@ func NewTest(t *testing.T) (c *Test) {
 	c.DomainsClient.BaseClient.Authorizer = c.Connections["default"].Authorizer
 	c.DomainsClient.BaseClient.Endpoint = c.Connections["default"].AuthConfig.Environment.MsGraph.Endpoint
 	c.DomainsClient.BaseClient.RetryableClient.RetryMax = retry
+
+	c.EntitlementRoleAssignmentsClient = msgraph.NewEntitlementRoleAssignmentsClient(c.Connections["default"].AuthConfig.TenantID)
+	c.EntitlementRoleAssignmentsClient.BaseClient.Authorizer = c.Connections["default"].Authorizer
+	c.EntitlementRoleAssignmentsClient.BaseClient.Endpoint = c.Connections["default"].AuthConfig.Environment.MsGraph.Endpoint
+	c.EntitlementRoleAssignmentsClient.BaseClient.RetryableClient.RetryMax = retry
+
+	c.EntitlementRoleDefinitionsClient = msgraph.NewEntitlementRoleDefinitionsClient(c.Connections["default"].AuthConfig.TenantID)
+	c.EntitlementRoleDefinitionsClient.BaseClient.Authorizer = c.Connections["default"].Authorizer
+	c.EntitlementRoleDefinitionsClient.BaseClient.Endpoint = c.Connections["default"].AuthConfig.Environment.MsGraph.Endpoint
+	c.EntitlementRoleDefinitionsClient.BaseClient.RetryableClient.RetryMax = retry
 
 	c.GroupsAppRoleAssignmentsClient = msgraph.NewGroupsAppRoleAssignmentsClient(c.Connections["default"].AuthConfig.TenantID)
 	c.GroupsAppRoleAssignmentsClient.BaseClient.Authorizer = c.Connections["default"].Authorizer

--- a/msgraph/entitlement_role_assignments.go
+++ b/msgraph/entitlement_role_assignments.go
@@ -1,0 +1,134 @@
+package msgraph
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/manicminer/hamilton/odata"
+)
+
+// EntitlementRoleAssignmentsClient performs operations on RoleAssignments.
+type EntitlementRoleAssignmentsClient struct {
+	BaseClient Client
+}
+
+// NewEntitlementRoleAssignmentsClient returns a new EntitlementRoleAssignmentsClient
+func NewEntitlementRoleAssignmentsClient(tenantId string) *EntitlementRoleAssignmentsClient {
+	return &EntitlementRoleAssignmentsClient{
+		BaseClient: NewClient(Version10, tenantId),
+	}
+}
+
+// List returns a list of RoleAssignments
+func (c *EntitlementRoleAssignmentsClient) List(ctx context.Context, query odata.Query) (*[]UnifiedRoleAssignment, int, error) {
+	resp, status, _, err := c.BaseClient.Get(ctx, GetHttpRequestInput{
+		OData:            query,
+		ValidStatusCodes: []int{http.StatusOK},
+		Uri: Uri{
+			Entity:      "/roleManagement/entitlementManagement/roleAssignments",
+			HasTenantId: true,
+		},
+	})
+	if err != nil {
+		return nil, status, fmt.Errorf("EntitlementRoleAssignmentsClient.BaseClient.Get(): %v", err)
+	}
+
+	defer resp.Body.Close()
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, status, fmt.Errorf("io.ReadAll(): %v", err)
+	}
+
+	var data struct {
+		RoleAssignments []UnifiedRoleAssignment `json:"value"`
+	}
+	if err := json.Unmarshal(respBody, &data); err != nil {
+		return nil, status, fmt.Errorf("json.Unmarshal(): %v", err)
+	}
+
+	return &data.RoleAssignments, status, nil
+}
+
+// Get retrieves a UnifiedRoleAssignment
+func (c *EntitlementRoleAssignmentsClient) Get(ctx context.Context, id string, query odata.Query) (*UnifiedRoleAssignment, int, error) {
+	resp, status, _, err := c.BaseClient.Get(ctx, GetHttpRequestInput{
+		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
+		OData:                  query,
+		ValidStatusCodes:       []int{http.StatusOK},
+		Uri: Uri{
+			Entity:      fmt.Sprintf("/roleManagement/entitlementManagement/roleAssignments/%s", id),
+			HasTenantId: true,
+		},
+	})
+	if err != nil {
+		return nil, status, fmt.Errorf("EntitlementRoleAssignmentsClient.BaseClient.Get(): %v", err)
+	}
+
+	defer resp.Body.Close()
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, status, fmt.Errorf("io.ReadAll(): %v", err)
+	}
+
+	var dirRole UnifiedRoleAssignment
+	if err := json.Unmarshal(respBody, &dirRole); err != nil {
+		return nil, status, fmt.Errorf("json.Unmarshal(): %v", err)
+	}
+
+	return &dirRole, status, nil
+}
+
+// Create creates a new UnifiedRoleAssignment.
+func (c *EntitlementRoleAssignmentsClient) Create(ctx context.Context, roleAssignment UnifiedRoleAssignment) (*UnifiedRoleAssignment, int, error) {
+	var status int
+
+	body, err := json.Marshal(roleAssignment)
+	if err != nil {
+		return nil, status, fmt.Errorf("json.Marshal(): %v", err)
+	}
+
+	resp, status, _, err := c.BaseClient.Post(ctx, PostHttpRequestInput{
+		Body:             body,
+		ValidStatusCodes: []int{http.StatusOK},
+		Uri: Uri{
+			Entity:      "/roleManagement/entitlementManagement/roleAssignments",
+			HasTenantId: true,
+		},
+	})
+	if err != nil {
+		return nil, status, fmt.Errorf("EntitlementRoleAssignmentsClient.BaseClient.Post(): %v", err)
+	}
+
+	defer resp.Body.Close()
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, status, fmt.Errorf("io.ReadAll(): %v", err)
+	}
+
+	var newRoleAssignment UnifiedRoleAssignment
+	if err := json.Unmarshal(respBody, &newRoleAssignment); err != nil {
+		return nil, status, fmt.Errorf("json.Unmarshal(): %v", err)
+	}
+
+	return &newRoleAssignment, status, nil
+}
+
+// Delete removes a UnifiedRoleAssignment.
+func (c *EntitlementRoleAssignmentsClient) Delete(ctx context.Context, id string) (int, error) {
+	_, status, _, err := c.BaseClient.Delete(ctx, DeleteHttpRequestInput{
+		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
+		ValidStatusCodes:       []int{http.StatusNoContent},
+		Uri: Uri{
+			Entity:      fmt.Sprintf("/roleManagement/entitlementManagement/roleAssignments/%s", id),
+			HasTenantId: true,
+		},
+	})
+	if err != nil {
+		return status, fmt.Errorf("RoleAssignments.BaseClient.Get(): %v", err)
+	}
+
+	return status, nil
+}

--- a/msgraph/entitlement_role_assignments_test.go
+++ b/msgraph/entitlement_role_assignments_test.go
@@ -1,0 +1,104 @@
+package msgraph_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/manicminer/hamilton/internal/test"
+	"github.com/manicminer/hamilton/internal/utils"
+	"github.com/manicminer/hamilton/msgraph"
+	"github.com/manicminer/hamilton/odata"
+)
+
+func TestEntitlementRoleAssignmentsClient(t *testing.T) {
+	c := test.NewTest(t)
+	defer c.CancelFunc()
+
+	roleDefinitions := testEntitlementRoleDefinitionsClient_List(t, c)
+
+	roleDefinition := (*roleDefinitions)[0]
+
+	user := testUsersClient_Create(t, c, msgraph.User{
+		AccountEnabled:    utils.BoolPtr(true),
+		DisplayName:       utils.StringPtr("test-user"),
+		MailNickname:      utils.StringPtr(fmt.Sprintf("test-user-%s", c.RandomString)),
+		UserPrincipalName: utils.StringPtr(fmt.Sprintf("test-user-%s@%s", c.RandomString, c.Connections["default"].DomainName)),
+		PasswordProfile: &msgraph.UserPasswordProfile{
+			Password: utils.StringPtr(fmt.Sprintf("IrPa55w0rd%s", c.RandomString)),
+		},
+	})
+
+	accessPackageCatalog := testAccessPackageCatalogClient_Create(t, c, msgraph.AccessPackageCatalog{
+		DisplayName:         utils.StringPtr(fmt.Sprintf("test-catalog-%s", c.RandomString)),
+		CatalogType:         msgraph.AccessPackageCatalogTypeUserManaged,
+		State:               msgraph.AccessPackageCatalogStatePublished,
+		Description:         utils.StringPtr("Test Access Catalog"),
+		IsExternallyVisible: utils.BoolPtr(false),
+	})
+
+	roleAssignment := testEntitlementRoleAssignmentsClient_Create(t, c, msgraph.UnifiedRoleAssignment{
+		DirectoryScopeId: utils.StringPtr("/"),
+		PrincipalId:      user.ID(),
+		RoleDefinitionId: roleDefinition.ID(),
+		AppScopeId:       utils.StringPtr("/AccessPackageCatalog/" + *accessPackageCatalog.ID),
+	})
+
+	testEntitlementRoleAssignmentsClient_Get(t, c, *roleAssignment.ID())
+	testEntitlementRoleAssignmentsClient_List(t, c, odata.Query{Filter: fmt.Sprintf("roleDefinitionId eq '%s'", *roleDefinition.ID())})
+	testEntitlementRoleAssignmentsClient_Delete(t, c, *roleAssignment.ID())
+	testAccessPackageCatalogClient_Delete(t, c, *accessPackageCatalog.ID)
+	testUsersClient_Delete(t, c, *user.ID())
+	testUsersClient_DeletePermanently(t, c, *user.ID())
+}
+
+func testEntitlementRoleAssignmentsClient_Create(t *testing.T, c *test.Test, r msgraph.UnifiedRoleAssignment) (roleAssignment *msgraph.UnifiedRoleAssignment) {
+	roleAssignment, status, err := c.EntitlementRoleAssignmentsClient.Create(c.Context, r)
+	if err != nil {
+		t.Fatalf("EntitlementRoleAssignmentsClient.Create(): %v", err)
+	}
+	if status < 200 || status >= 300 {
+		t.Fatalf("EntitlementRoleAssignmentsClient.Create(): invalid status: %d", status)
+	}
+	if roleAssignment == nil {
+		t.Fatal("EntitlementRoleAssignmentsClient.Create(): roleAssignment was nil")
+	}
+	if roleAssignment.ID() == nil {
+		t.Fatal("EntitlementRoleAssignmentsClient.Create(): roleAssignment.ID was nil")
+	}
+	return
+}
+
+func testEntitlementRoleAssignmentsClient_List(t *testing.T, c *test.Test, query odata.Query) (roleAssignments *[]msgraph.UnifiedRoleAssignment) {
+	roleAssignments, _, err := c.EntitlementRoleAssignmentsClient.List(c.Context, query)
+	if err != nil {
+		t.Fatalf("EntitlementRoleAssignmentsClient.List(): %v", err)
+	}
+	if roleAssignments == nil {
+		t.Fatal("EntitlementRoleAssignmentsClient.List(): roleAssignments was nil")
+	}
+	return
+}
+
+func testEntitlementRoleAssignmentsClient_Get(t *testing.T, c *test.Test, id string) (roleAssignment *msgraph.UnifiedRoleAssignment) {
+	roleAssignment, status, err := c.EntitlementRoleAssignmentsClient.Get(c.Context, id, odata.Query{})
+	if err != nil {
+		t.Fatalf("EntitlementRoleAssignmentsClient.Get(): %v", err)
+	}
+	if status < 200 || status >= 300 {
+		t.Fatalf("EntitlementRoleAssignmentsClient.Get(): invalid status: %d", status)
+	}
+	if roleAssignment == nil {
+		t.Fatal("EntitlementRoleAssignmentsClient.Get(): roleAssignment was nil")
+	}
+	return
+}
+
+func testEntitlementRoleAssignmentsClient_Delete(t *testing.T, c *test.Test, id string) {
+	status, err := c.EntitlementRoleAssignmentsClient.Delete(c.Context, id)
+	if err != nil {
+		t.Fatalf("EntitlementRoleAssignmentsClient.Delete(): %v", err)
+	}
+	if status < 200 || status >= 300 {
+		t.Fatalf("EntitlementRoleAssignmentsClient.Delete(): invalid status: %d", status)
+	}
+}

--- a/msgraph/entitlement_role_definitions.go
+++ b/msgraph/entitlement_role_definitions.go
@@ -1,0 +1,81 @@
+package msgraph
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/manicminer/hamilton/odata"
+)
+
+// EntitlementRoleDefinitionsClient performs operations on RoleDefinitions.
+type EntitlementRoleDefinitionsClient struct {
+	BaseClient Client
+}
+
+// NewEntitlementRoleDefinitionsClient returns a new EntitlementRoleDefinitionsClient
+func NewEntitlementRoleDefinitionsClient(tenantId string) *EntitlementRoleDefinitionsClient {
+	return &EntitlementRoleDefinitionsClient{
+		BaseClient: NewClient(Version10, tenantId),
+	}
+}
+
+// List returns a list of RoleDefinitions
+func (c *EntitlementRoleDefinitionsClient) List(ctx context.Context, query odata.Query) (*[]UnifiedRoleDefinition, int, error) {
+	resp, status, _, err := c.BaseClient.Get(ctx, GetHttpRequestInput{
+		OData:            query,
+		ValidStatusCodes: []int{http.StatusOK},
+		Uri: Uri{
+			Entity:      "/roleManagement/entitlementManagement/roleDefinitions",
+			HasTenantId: true,
+		},
+	})
+	if err != nil {
+		return nil, status, fmt.Errorf("EntitlementRoleDefinitionsClient.BaseClient.Get(): %v", err)
+	}
+
+	defer resp.Body.Close()
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, status, fmt.Errorf("io.ReadAll(): %v", err)
+	}
+
+	var data struct {
+		RoleDefinitions []UnifiedRoleDefinition `json:"value"`
+	}
+	if err := json.Unmarshal(respBody, &data); err != nil {
+		return nil, status, fmt.Errorf("json.Unmarshal(): %v", err)
+	}
+
+	return &data.RoleDefinitions, status, nil
+}
+
+// Get retrieves a UnifiedRoleDefinition
+func (c *EntitlementRoleDefinitionsClient) Get(ctx context.Context, id string, query odata.Query) (*UnifiedRoleDefinition, int, error) {
+	resp, status, _, err := c.BaseClient.Get(ctx, GetHttpRequestInput{
+		OData:            query,
+		ValidStatusCodes: []int{http.StatusOK},
+		Uri: Uri{
+			Entity:      fmt.Sprintf("/roleManagement/entitlementManagement/roleDefinitions/%s", id),
+			HasTenantId: true,
+		},
+	})
+	if err != nil {
+		return nil, status, fmt.Errorf("EntitlementRoleDefinitionsClient.BaseClient.Get(): %v", err)
+	}
+
+	defer resp.Body.Close()
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, status, fmt.Errorf("io.ReadAll(): %v", err)
+	}
+
+	var dirRole UnifiedRoleDefinition
+	if err := json.Unmarshal(respBody, &dirRole); err != nil {
+		return nil, status, fmt.Errorf("json.Unmarshal(): %v", err)
+	}
+
+	return &dirRole, status, nil
+}

--- a/msgraph/entitlement_role_definitions_test.go
+++ b/msgraph/entitlement_role_definitions_test.go
@@ -1,0 +1,44 @@
+package msgraph_test
+
+import (
+	"testing"
+
+	"github.com/manicminer/hamilton/internal/test"
+	"github.com/manicminer/hamilton/msgraph"
+	"github.com/manicminer/hamilton/odata"
+)
+
+func TestEntitlementRoleDefinitionsClient(t *testing.T) {
+	c := test.NewTest(t)
+	defer c.CancelFunc()
+
+	roleDefinitions := testEntitlementRoleDefinitionsClient_List(t, c)
+
+	role := (*roleDefinitions)[0]
+	testEntitlementRoleDefinitionsClient_Get(t, c, *role.ID())
+}
+
+func testEntitlementRoleDefinitionsClient_List(t *testing.T, c *test.Test) (roleDefinitions *[]msgraph.UnifiedRoleDefinition) {
+	roleDefinitions, _, err := c.EntitlementRoleDefinitionsClient.List(c.Context, odata.Query{})
+	if err != nil {
+		t.Fatalf("EntitlementRoleDefinitionsClient.List(): %v", err)
+	}
+	if roleDefinitions == nil {
+		t.Fatal("EntitlementRoleDefinitionsClient.List(): roleDefinitions was nil")
+	}
+	return
+}
+
+func testEntitlementRoleDefinitionsClient_Get(t *testing.T, c *test.Test, id string) (roleDefinition *msgraph.UnifiedRoleDefinition) {
+	roleDefinition, status, err := c.EntitlementRoleDefinitionsClient.Get(c.Context, id, odata.Query{})
+	if err != nil {
+		t.Fatalf("EntitlementRoleDefinitionsClient.Get(): %v", err)
+	}
+	if status < 200 || status >= 300 {
+		t.Fatalf("EntitlementRoleDefinitionsClient.Get(): invalid status: %d", status)
+	}
+	if roleDefinition == nil {
+		t.Fatal("EntitlementRoleDefinitionsClient.Get(): roleDefinition was nil")
+	}
+	return
+}


### PR DESCRIPTION
Hi

This PR adds two new clients `EntitlementRoleAssignmentsClient` and `EntitlementRoleDefinitionsClient` based off of `RoleAssignmentsClient` and `RoleDefinitionsClient`
The only notable difference is that custom roles are not supported so the `EntitlementRoleDefinitionsClient` does not have any create/update/delete functions


https://learn.microsoft.com/en-us/graph/api/rbacapplication-post-roleassignments