### PR TITLE
Change PreferredTokenSigningKeyThumbprint to nullable

### DIFF
--- a/msgraph/models.go
+++ b/msgraph/models.go
@@ -1340,7 +1340,7 @@ type ServicePrincipal struct {
 	PasswordCredentials                 *[]PasswordCredential         `json:"passwordCredentials,omitempty"`
 	PasswordSingleSignOnSettings        *PasswordSingleSignOnSettings `json:"passwordSingleSignOnSettings,omitempty"`
 	PreferredSingleSignOnMode           *PreferredSingleSignOnMode    `json:"preferredSingleSignOnMode,omitempty"`
-	PreferredTokenSigningKeyThumbprint  *string                       `json:"preferredTokenSigningKeyThumbprint,omitempty"`
+	PreferredTokenSigningKeyThumbprint  *StringNullWhenEmpty          `json:"preferredTokenSigningKeyThumbprint,omitempty"`
 	PreferredTokenSigningKeyEndDateTime *time.Time                    `json:"preferredTokenSigningKeyEndDateTime,omitempty"`
 	PublishedPermissionScopes           *[]PermissionScope            `json:"publishedPermissionScopes,omitempty"`
 	ReplyUrls                           *[]string                     `json:"replyUrls,omitempty"`


### PR DESCRIPTION
When working on implementing a resource to set the PreferredTokenSigningKeyThumbprint, it was found that this field needs to be able to be set to null if the field is empty.

This is required to remove a preferred token if desired.