### PR TITLE
Drop tenant ID from path in Microsoft Graph requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ func main() {
 		log.Fatal(err)
 	}
 
-	client := msgraph.NewUsersClient(tenantId)
+	client := msgraph.NewUsersClient()
 	client.BaseClient.Authorizer = authorizer
 
 	users, _, err := client.List(ctx, odata.Query{})

--- a/example/example.go
+++ b/example/example.go
@@ -36,7 +36,7 @@ func main() {
 		log.Fatal(err)
 	}
 
-	client := msgraph.NewUsersClient(tenantId)
+	client := msgraph.NewUsersClient()
 	client.BaseClient.Authorizer = authorizer
 
 	users, _, err := client.List(ctx, odata.Query{})

--- a/internal/cmd/test-cleanup/accesspackageassignmentpolicies.go
+++ b/internal/cmd/test-cleanup/accesspackageassignmentpolicies.go
@@ -9,7 +9,7 @@ import (
 )
 
 func cleanupAccessPackageAssignmentPolicies() {
-	client := msgraph.NewAccessPackageAssignmentPolicyClient(tenantId)
+	client := msgraph.NewAccessPackageAssignmentPolicyClient()
 	client.BaseClient.Authorizer = authorizer
 
 	result, _, err := client.List(ctx, odata.Query{Filter: fmt.Sprintf("startsWith(displayName, '%s')", displayNamePrefix)})

--- a/internal/cmd/test-cleanup/accesspackageassignmentrequests.go
+++ b/internal/cmd/test-cleanup/accesspackageassignmentrequests.go
@@ -8,7 +8,7 @@ import (
 )
 
 func cleanupAccessPackageAssignmentRequests() {
-	client := msgraph.NewAccessPackageAssignmentRequestClient(tenantId)
+	client := msgraph.NewAccessPackageAssignmentRequestClient()
 	client.BaseClient.Authorizer = authorizer
 
 	result, _, err := client.List(ctx, odata.Query{})

--- a/internal/cmd/test-cleanup/accesspackagecatalogs.go
+++ b/internal/cmd/test-cleanup/accesspackagecatalogs.go
@@ -10,7 +10,7 @@ import (
 )
 
 func cleanupAccessPackageCatalogs() {
-	client := msgraph.NewAccessPackageCatalogClient(tenantId)
+	client := msgraph.NewAccessPackageCatalogClient()
 	client.BaseClient.Authorizer = authorizer
 
 	result, _, err := client.List(ctx, odata.Query{Filter: fmt.Sprintf("startsWith(displayName, '%s')", displayNamePrefix)})

--- a/internal/cmd/test-cleanup/accesspackages.go
+++ b/internal/cmd/test-cleanup/accesspackages.go
@@ -9,7 +9,7 @@ import (
 )
 
 func cleanupAccessPackages() {
-	client := msgraph.NewAccessPackageClient(tenantId)
+	client := msgraph.NewAccessPackageClient()
 	client.BaseClient.Authorizer = authorizer
 
 	result, _, err := client.List(ctx, odata.Query{Filter: fmt.Sprintf("startsWith(displayName, '%s')", displayNamePrefix)})

--- a/internal/cmd/test-cleanup/administrativeunits.go
+++ b/internal/cmd/test-cleanup/administrativeunits.go
@@ -9,7 +9,7 @@ import (
 )
 
 func cleanupAdministrativeUnits() {
-	administrativeUnitsClient := msgraph.NewAdministrativeUnitsClient(tenantId)
+	administrativeUnitsClient := msgraph.NewAdministrativeUnitsClient()
 	administrativeUnitsClient.BaseClient.Authorizer = authorizer
 
 	administrativeUnits, _, err := administrativeUnitsClient.List(ctx, odata.Query{Filter: fmt.Sprintf("startsWith(displayName, '%s')", displayNamePrefix)})

--- a/internal/cmd/test-cleanup/applications.go
+++ b/internal/cmd/test-cleanup/applications.go
@@ -9,7 +9,7 @@ import (
 )
 
 func cleanupApplications() {
-	appsClient := msgraph.NewApplicationsClient(tenantId)
+	appsClient := msgraph.NewApplicationsClient()
 	appsClient.BaseClient.Authorizer = authorizer
 
 	apps, _, err := appsClient.List(ctx, odata.Query{Filter: fmt.Sprintf("startsWith(displayName, '%s')", displayNamePrefix)})

--- a/internal/cmd/test-cleanup/b2c_userflows.go
+++ b/internal/cmd/test-cleanup/b2c_userflows.go
@@ -9,7 +9,7 @@ import (
 )
 
 func cleanupB2CUserFlows() {
-	client := msgraph.NewB2CUserFlowClient(b2cTenantId)
+	client := msgraph.NewB2CUserFlowClient()
 	client.BaseClient.Authorizer = b2cAuthorizer
 
 	result, _, err := client.List(ctx, odata.Query{Filter: fmt.Sprintf("startsWith(id, 'B2C_1_%s')", displayNamePrefix)})

--- a/internal/cmd/test-cleanup/claimsmappingpolicies.go
+++ b/internal/cmd/test-cleanup/claimsmappingpolicies.go
@@ -9,7 +9,7 @@ import (
 )
 
 func cleanupClaimsMappingPolicies() {
-	client := msgraph.NewClaimsMappingPolicyClient(tenantId)
+	client := msgraph.NewClaimsMappingPolicyClient()
 	client.BaseClient.Authorizer = authorizer
 
 	result, _, err := client.List(ctx, odata.Query{Filter: fmt.Sprintf("startsWith(displayName, '%s')", displayNamePrefix)})

--- a/internal/cmd/test-cleanup/conditionalaccesspolicies.go
+++ b/internal/cmd/test-cleanup/conditionalaccesspolicies.go
@@ -9,7 +9,7 @@ import (
 )
 
 func cleanupConditionalAccessPolicies() {
-	conditionalAccessPoliciesClient := msgraph.NewConditionalAccessPoliciesClient(tenantId)
+	conditionalAccessPoliciesClient := msgraph.NewConditionalAccessPoliciesClient()
 	conditionalAccessPoliciesClient.BaseClient.Authorizer = authorizer
 
 	conditionalAccessPolicies, _, err := conditionalAccessPoliciesClient.List(ctx, odata.Query{Filter: fmt.Sprintf("startsWith(displayName, '%s')", displayNamePrefix)})

--- a/internal/cmd/test-cleanup/connectedorganizations.go
+++ b/internal/cmd/test-cleanup/connectedorganizations.go
@@ -9,7 +9,7 @@ import (
 )
 
 func cleanupConnectedOrganizations() {
-	client := msgraph.NewConnectedOrganizationClient(tenantId)
+	client := msgraph.NewConnectedOrganizationClient()
 	client.BaseClient.Authorizer = authorizer
 
 	result, _, err := client.List(ctx, odata.Query{Filter: fmt.Sprintf("startsWith(displayName, '%s')", displayNamePrefix)})

--- a/internal/cmd/test-cleanup/groups.go
+++ b/internal/cmd/test-cleanup/groups.go
@@ -9,7 +9,7 @@ import (
 )
 
 func cleanupGroups() {
-	groupsClient := msgraph.NewGroupsClient(tenantId)
+	groupsClient := msgraph.NewGroupsClient()
 	groupsClient.BaseClient.Authorizer = authorizer
 
 	groups, _, err := groupsClient.List(ctx, odata.Query{Filter: fmt.Sprintf("startsWith(displayName, '%s')", displayNamePrefix)})

--- a/internal/cmd/test-cleanup/namedlocations.go
+++ b/internal/cmd/test-cleanup/namedlocations.go
@@ -9,7 +9,7 @@ import (
 )
 
 func cleanupNamedLocations() {
-	namedLocationsClient := msgraph.NewNamedLocationsClient(tenantId)
+	namedLocationsClient := msgraph.NewNamedLocationsClient()
 	namedLocationsClient.BaseClient.Authorizer = authorizer
 
 	namedLocations, _, err := namedLocationsClient.List(ctx, odata.Query{Filter: fmt.Sprintf("startsWith(displayName, '%s')", displayNamePrefix)})

--- a/internal/cmd/test-cleanup/roledefinitions.go
+++ b/internal/cmd/test-cleanup/roledefinitions.go
@@ -9,7 +9,7 @@ import (
 )
 
 func cleanupRoleDefinitions() {
-	client := msgraph.NewRoleDefinitionsClient(tenantId)
+	client := msgraph.NewRoleDefinitionsClient()
 	client.BaseClient.Authorizer = authorizer
 
 	result, _, err := client.List(ctx, odata.Query{Filter: fmt.Sprintf("startsWith(displayName, '%s')", displayNamePrefix)})

--- a/internal/cmd/test-cleanup/schemaextensions.go
+++ b/internal/cmd/test-cleanup/schemaextensions.go
@@ -9,7 +9,7 @@ import (
 )
 
 func cleanupSchemaExtensions() {
-	schemaExtensionsClient := msgraph.NewSchemaExtensionsClient(tenantId)
+	schemaExtensionsClient := msgraph.NewSchemaExtensionsClient()
 	schemaExtensionsClient.BaseClient.Authorizer = authorizer
 
 	schemaExtensions, _, err := schemaExtensionsClient.List(ctx, odata.Query{Filter: fmt.Sprintf("status eq '%s'", msgraph.SchemaExtensionStatusInDevelopment)})

--- a/internal/cmd/test-cleanup/serviceprincipals.go
+++ b/internal/cmd/test-cleanup/serviceprincipals.go
@@ -9,7 +9,7 @@ import (
 )
 
 func cleanupServicePrincipals() {
-	servicePrincipalsClient := msgraph.NewServicePrincipalsClient(tenantId)
+	servicePrincipalsClient := msgraph.NewServicePrincipalsClient()
 	servicePrincipalsClient.BaseClient.Authorizer = authorizer
 
 	servicePrincipals, _, err := servicePrincipalsClient.List(ctx, odata.Query{Filter: fmt.Sprintf("startsWith(displayName, '%s')", displayNamePrefix)})

--- a/internal/cmd/test-cleanup/termsofuse.go
+++ b/internal/cmd/test-cleanup/termsofuse.go
@@ -8,7 +8,7 @@ import (
 )
 
 func cleanupTermsOfUseAgreements() {
-	client := msgraph.NewTermsOfUseAgreementClient(tenantId)
+	client := msgraph.NewTermsOfUseAgreementClient()
 	client.BaseClient.Authorizer = authorizer
 
 	result, _, err := client.List(ctx, fmt.Sprintf("startsWith(displayName, '%s')", displayNamePrefix))

--- a/internal/cmd/test-cleanup/users.go
+++ b/internal/cmd/test-cleanup/users.go
@@ -9,7 +9,7 @@ import (
 )
 
 func cleanupUsers() {
-	usersClient := msgraph.NewUsersClient(tenantId)
+	usersClient := msgraph.NewUsersClient()
 	usersClient.BaseClient.Authorizer = authorizer
 
 	users, _, err := usersClient.List(ctx, odata.Query{Filter: fmt.Sprintf("startsWith(displayName, '%s')", displayNamePrefix)})

--- a/internal/test/testing.go
+++ b/internal/test/testing.go
@@ -182,214 +182,214 @@ func NewTest(t *testing.T) (c *Test) {
 		t.Fatalf("could not configure MS Graph endpoint for environment %q", c.Connections["default"].AuthConfig.Environment.Name)
 	}
 
-	c.AccessPackageAssignmentPolicyClient = msgraph.NewAccessPackageAssignmentPolicyClient(c.Connections["default"].AuthConfig.TenantID)
+	c.AccessPackageAssignmentPolicyClient = msgraph.NewAccessPackageAssignmentPolicyClient()
 	c.AccessPackageAssignmentPolicyClient.BaseClient.Authorizer = c.Connections["default"].Authorizer
 	c.AccessPackageAssignmentPolicyClient.BaseClient.Endpoint = *endpoint
 	c.AccessPackageAssignmentPolicyClient.BaseClient.RetryableClient.RetryMax = retry
 
-	c.AccessPackageAssignmentRequestClient = msgraph.NewAccessPackageAssignmentRequestClient(c.Connections["default"].AuthConfig.TenantID)
+	c.AccessPackageAssignmentRequestClient = msgraph.NewAccessPackageAssignmentRequestClient()
 	c.AccessPackageAssignmentRequestClient.BaseClient.Authorizer = c.Connections["default"].Authorizer
 	c.AccessPackageAssignmentRequestClient.BaseClient.Endpoint = *endpoint
 	c.AccessPackageAssignmentRequestClient.BaseClient.RetryableClient.RetryMax = retry
 
-	c.AccessPackageCatalogClient = msgraph.NewAccessPackageCatalogClient(c.Connections["default"].AuthConfig.TenantID)
+	c.AccessPackageCatalogClient = msgraph.NewAccessPackageCatalogClient()
 	c.AccessPackageCatalogClient.BaseClient.Authorizer = c.Connections["default"].Authorizer
 	c.AccessPackageCatalogClient.BaseClient.Endpoint = *endpoint
 	c.AccessPackageCatalogClient.BaseClient.RetryableClient.RetryMax = retry
 
-	c.AccessPackageClient = msgraph.NewAccessPackageClient(c.Connections["default"].AuthConfig.TenantID)
+	c.AccessPackageClient = msgraph.NewAccessPackageClient()
 	c.AccessPackageClient.BaseClient.Authorizer = c.Connections["default"].Authorizer
 	c.AccessPackageClient.BaseClient.Endpoint = *endpoint
 	c.AccessPackageClient.BaseClient.RetryableClient.RetryMax = retry
 
-	c.AccessPackageResourceClient = msgraph.NewAccessPackageResourceClient(c.Connections["default"].AuthConfig.TenantID)
+	c.AccessPackageResourceClient = msgraph.NewAccessPackageResourceClient()
 	c.AccessPackageResourceClient.BaseClient.Authorizer = c.Connections["default"].Authorizer
 	c.AccessPackageResourceClient.BaseClient.Endpoint = *endpoint
 	c.AccessPackageResourceClient.BaseClient.RetryableClient.RetryMax = retry
 
-	c.AccessPackageResourceRequestClient = msgraph.NewAccessPackageResourceRequestClient(c.Connections["default"].AuthConfig.TenantID)
+	c.AccessPackageResourceRequestClient = msgraph.NewAccessPackageResourceRequestClient()
 	c.AccessPackageResourceRequestClient.BaseClient.Authorizer = c.Connections["default"].Authorizer
 	c.AccessPackageResourceRequestClient.BaseClient.Endpoint = *endpoint
 	c.AccessPackageAssignmentPolicyClient.BaseClient.RetryableClient.RetryMax = retry
 
-	c.AccessPackageResourceRoleScopeClient = msgraph.NewAccessPackageResourceRoleScopeClient(c.Connections["default"].AuthConfig.TenantID)
+	c.AccessPackageResourceRoleScopeClient = msgraph.NewAccessPackageResourceRoleScopeClient()
 	c.AccessPackageResourceRoleScopeClient.BaseClient.Authorizer = c.Connections["default"].Authorizer
 	c.AccessPackageResourceRoleScopeClient.BaseClient.Endpoint = *endpoint
 	c.AccessPackageResourceRoleScopeClient.BaseClient.RetryableClient.RetryMax = retry
 
-	c.AdministrativeUnitsClient = msgraph.NewAdministrativeUnitsClient(c.Connections["default"].AuthConfig.TenantID)
+	c.AdministrativeUnitsClient = msgraph.NewAdministrativeUnitsClient()
 	c.AdministrativeUnitsClient.BaseClient.Authorizer = c.Connections["default"].Authorizer
 	c.AdministrativeUnitsClient.BaseClient.Endpoint = *endpoint
 	c.AdministrativeUnitsClient.BaseClient.RetryableClient.RetryMax = retry
 
-	c.ApplicationTemplatesClient = msgraph.NewApplicationTemplatesClient(c.Connections["default"].AuthConfig.TenantID)
+	c.ApplicationTemplatesClient = msgraph.NewApplicationTemplatesClient()
 	c.ApplicationTemplatesClient.BaseClient.Authorizer = c.Connections["default"].Authorizer
 	c.ApplicationTemplatesClient.BaseClient.Endpoint = *endpoint
 	c.ApplicationTemplatesClient.BaseClient.RetryableClient.RetryMax = retry
 
-	c.ApplicationsClient = msgraph.NewApplicationsClient(c.Connections["default"].AuthConfig.TenantID)
+	c.ApplicationsClient = msgraph.NewApplicationsClient()
 	c.ApplicationsClient.BaseClient.Authorizer = c.Connections["default"].Authorizer
 	c.ApplicationsClient.BaseClient.Endpoint = *endpoint
 	c.ApplicationsClient.BaseClient.RetryableClient.RetryMax = retry
 	c.ApplicationsClient.BaseClient.ApiVersion = msgraph.Version10
 
-	c.AppRoleAssignedToClient = msgraph.NewAppRoleAssignedToClient(c.Connections["default"].AuthConfig.TenantID)
+	c.AppRoleAssignedToClient = msgraph.NewAppRoleAssignedToClient()
 	c.AppRoleAssignedToClient.BaseClient.Authorizer = c.Connections["default"].Authorizer
 	c.AppRoleAssignedToClient.BaseClient.Endpoint = *endpoint
 	c.AppRoleAssignedToClient.BaseClient.RetryableClient.RetryMax = retry
 
-	c.AuthenticationMethodsClient = msgraph.NewAuthenticationMethodsClient(c.Connections["default"].AuthConfig.TenantID)
+	c.AuthenticationMethodsClient = msgraph.NewAuthenticationMethodsClient()
 	c.AuthenticationMethodsClient.BaseClient.Authorizer = c.Connections["default"].Authorizer
 	c.AuthenticationMethodsClient.BaseClient.Endpoint = *endpoint
 	c.AuthenticationMethodsClient.BaseClient.RetryableClient.RetryMax = retry
 
-	c.B2CUserFlowClient = msgraph.NewB2CUserFlowClient(c.Connections["b2c"].AuthConfig.TenantID)
+	c.B2CUserFlowClient = msgraph.NewB2CUserFlowClient()
 	c.B2CUserFlowClient.BaseClient.Authorizer = c.Connections["b2c"].Authorizer
 	c.B2CUserFlowClient.BaseClient.Endpoint = *endpoint
 	c.B2CUserFlowClient.BaseClient.RetryableClient.RetryMax = retry
 
-	c.ClaimsMappingPolicyClient = msgraph.NewClaimsMappingPolicyClient(c.Connections["default"].AuthConfig.TenantID)
+	c.ClaimsMappingPolicyClient = msgraph.NewClaimsMappingPolicyClient()
 	c.ClaimsMappingPolicyClient.BaseClient.Authorizer = c.Connections["default"].Authorizer
 	c.ClaimsMappingPolicyClient.BaseClient.Endpoint = *endpoint
 	c.ClaimsMappingPolicyClient.BaseClient.RetryableClient.RetryMax = retry
 
-	c.ConditionalAccessPoliciesClient = msgraph.NewConditionalAccessPoliciesClient(c.Connections["default"].AuthConfig.TenantID)
+	c.ConditionalAccessPoliciesClient = msgraph.NewConditionalAccessPoliciesClient()
 	c.ConditionalAccessPoliciesClient.BaseClient.Authorizer = c.Connections["default"].Authorizer
 	c.ConditionalAccessPoliciesClient.BaseClient.Endpoint = *endpoint
 	c.ConditionalAccessPoliciesClient.BaseClient.RetryableClient.RetryMax = retry
 
-	c.ConnectedOrganizationClient = msgraph.NewConnectedOrganizationClient(c.Connections["default"].AuthConfig.TenantID)
+	c.ConnectedOrganizationClient = msgraph.NewConnectedOrganizationClient()
 	c.ConnectedOrganizationClient.BaseClient.Authorizer = c.Connections["default"].Authorizer
 	c.ConnectedOrganizationClient.BaseClient.Endpoint = *endpoint
 	c.ConnectedOrganizationClient.BaseClient.RetryableClient.RetryMax = retry
 
-	c.DelegatedPermissionGrantsClient = msgraph.NewDelegatedPermissionGrantsClient(c.Connections["default"].AuthConfig.TenantID)
+	c.DelegatedPermissionGrantsClient = msgraph.NewDelegatedPermissionGrantsClient()
 	c.DelegatedPermissionGrantsClient.BaseClient.Authorizer = c.Connections["default"].Authorizer
 	c.DelegatedPermissionGrantsClient.BaseClient.Endpoint = *endpoint
 	c.DelegatedPermissionGrantsClient.BaseClient.RetryableClient.RetryMax = retry
 
-	c.DirectoryAuditReportsClient = msgraph.NewDirectoryAuditReportsClient(c.Connections["default"].AuthConfig.TenantID)
+	c.DirectoryAuditReportsClient = msgraph.NewDirectoryAuditReportsClient()
 	c.DirectoryAuditReportsClient.BaseClient.Authorizer = c.Connections["default"].Authorizer
 	c.DirectoryAuditReportsClient.BaseClient.Endpoint = *endpoint
 	c.DirectoryAuditReportsClient.BaseClient.RetryableClient.RetryMax = retry
 
-	c.DirectoryObjectsClient = msgraph.NewDirectoryObjectsClient(c.Connections["default"].AuthConfig.TenantID)
+	c.DirectoryObjectsClient = msgraph.NewDirectoryObjectsClient()
 	c.DirectoryObjectsClient.BaseClient.Authorizer = c.Connections["default"].Authorizer
 	c.DirectoryObjectsClient.BaseClient.Endpoint = *endpoint
 	c.DirectoryObjectsClient.BaseClient.RetryableClient.RetryMax = retry
 
-	c.DirectoryRoleTemplatesClient = msgraph.NewDirectoryRoleTemplatesClient(c.Connections["default"].AuthConfig.TenantID)
+	c.DirectoryRoleTemplatesClient = msgraph.NewDirectoryRoleTemplatesClient()
 	c.DirectoryRoleTemplatesClient.BaseClient.Authorizer = c.Connections["default"].Authorizer
 	c.DirectoryRoleTemplatesClient.BaseClient.Endpoint = *endpoint
 	c.DirectoryRoleTemplatesClient.BaseClient.RetryableClient.RetryMax = retry
 
-	c.DirectoryRolesClient = msgraph.NewDirectoryRolesClient(c.Connections["default"].AuthConfig.TenantID)
+	c.DirectoryRolesClient = msgraph.NewDirectoryRolesClient()
 	c.DirectoryRolesClient.BaseClient.Authorizer = c.Connections["default"].Authorizer
 	c.DirectoryRolesClient.BaseClient.Endpoint = *endpoint
 	c.DirectoryRolesClient.BaseClient.RetryableClient.RetryMax = retry
 
-	c.DomainsClient = msgraph.NewDomainsClient(c.Connections["default"].AuthConfig.TenantID)
+	c.DomainsClient = msgraph.NewDomainsClient()
 	c.DomainsClient.BaseClient.Authorizer = c.Connections["default"].Authorizer
 	c.DomainsClient.BaseClient.Endpoint = *endpoint
 	c.DomainsClient.BaseClient.RetryableClient.RetryMax = retry
 
-	c.EntitlementRoleAssignmentsClient = msgraph.NewEntitlementRoleAssignmentsClient(c.Connections["default"].AuthConfig.TenantID)
+	c.EntitlementRoleAssignmentsClient = msgraph.NewEntitlementRoleAssignmentsClient()
 	c.EntitlementRoleAssignmentsClient.BaseClient.Authorizer = c.Connections["default"].Authorizer
 	c.EntitlementRoleAssignmentsClient.BaseClient.Endpoint = *endpoint
 	c.EntitlementRoleAssignmentsClient.BaseClient.RetryableClient.RetryMax = retry
 
-	c.EntitlementRoleDefinitionsClient = msgraph.NewEntitlementRoleDefinitionsClient(c.Connections["default"].AuthConfig.TenantID)
+	c.EntitlementRoleDefinitionsClient = msgraph.NewEntitlementRoleDefinitionsClient()
 	c.EntitlementRoleDefinitionsClient.BaseClient.Authorizer = c.Connections["default"].Authorizer
 	c.EntitlementRoleDefinitionsClient.BaseClient.Endpoint = *endpoint
 	c.EntitlementRoleDefinitionsClient.BaseClient.RetryableClient.RetryMax = retry
 
-	c.GroupsAppRoleAssignmentsClient = msgraph.NewGroupsAppRoleAssignmentsClient(c.Connections["default"].AuthConfig.TenantID)
+	c.GroupsAppRoleAssignmentsClient = msgraph.NewGroupsAppRoleAssignmentsClient()
 	c.GroupsAppRoleAssignmentsClient.BaseClient.Authorizer = c.Connections["default"].Authorizer
 	c.GroupsAppRoleAssignmentsClient.BaseClient.Endpoint = *endpoint
 	c.GroupsAppRoleAssignmentsClient.BaseClient.RetryableClient.RetryMax = retry
 
-	c.GroupsClient = msgraph.NewGroupsClient(c.Connections["default"].AuthConfig.TenantID)
+	c.GroupsClient = msgraph.NewGroupsClient()
 	c.GroupsClient.BaseClient.Authorizer = c.Connections["default"].Authorizer
 	c.GroupsClient.BaseClient.Endpoint = *endpoint
 	c.GroupsClient.BaseClient.RetryableClient.RetryMax = retry
 
-	c.IdentityProvidersClient = msgraph.NewIdentityProvidersClient(c.Connections["default"].AuthConfig.TenantID)
+	c.IdentityProvidersClient = msgraph.NewIdentityProvidersClient()
 	c.IdentityProvidersClient.BaseClient.Authorizer = c.Connections["default"].Authorizer
 	c.IdentityProvidersClient.BaseClient.Endpoint = *endpoint
 	c.IdentityProvidersClient.BaseClient.RetryableClient.RetryMax = retry
 
-	c.InvitationsClient = msgraph.NewInvitationsClient(c.Connections["default"].AuthConfig.TenantID)
+	c.InvitationsClient = msgraph.NewInvitationsClient()
 	c.InvitationsClient.BaseClient.Authorizer = c.Connections["default"].Authorizer
 	c.InvitationsClient.BaseClient.Endpoint = *endpoint
 	c.InvitationsClient.BaseClient.RetryableClient.RetryMax = retry
 
-	c.MeClient = msgraph.NewMeClient(c.Connections["default"].AuthConfig.TenantID)
+	c.MeClient = msgraph.NewMeClient()
 	c.MeClient.BaseClient.Authorizer = c.Connections["default"].Authorizer
 	c.MeClient.BaseClient.Endpoint = *endpoint
 	c.MeClient.BaseClient.RetryableClient.RetryMax = retry
 
-	c.NamedLocationsClient = msgraph.NewNamedLocationsClient(c.Connections["default"].AuthConfig.TenantID)
+	c.NamedLocationsClient = msgraph.NewNamedLocationsClient()
 	c.NamedLocationsClient.BaseClient.Authorizer = c.Connections["default"].Authorizer
 	c.NamedLocationsClient.BaseClient.Endpoint = *endpoint
 	c.NamedLocationsClient.BaseClient.RetryableClient.RetryMax = retry
 
-	c.ReportsClient = msgraph.NewReportsClient(c.Connections["default"].AuthConfig.TenantID)
+	c.ReportsClient = msgraph.NewReportsClient()
 	c.ReportsClient.BaseClient.Authorizer = c.Connections["default"].Authorizer
 	c.ReportsClient.BaseClient.Endpoint = *endpoint
 	c.ReportsClient.BaseClient.RetryableClient.RetryMax = retry
 
-	c.RoleAssignmentsClient = msgraph.NewRoleAssignmentsClient(c.Connections["default"].AuthConfig.TenantID)
+	c.RoleAssignmentsClient = msgraph.NewRoleAssignmentsClient()
 	c.RoleAssignmentsClient.BaseClient.Authorizer = c.Connections["default"].Authorizer
 	c.RoleAssignmentsClient.BaseClient.Endpoint = *endpoint
 	c.RoleAssignmentsClient.BaseClient.RetryableClient.RetryMax = retry
 
-	c.RoleDefinitionsClient = msgraph.NewRoleDefinitionsClient(c.Connections["default"].AuthConfig.TenantID)
+	c.RoleDefinitionsClient = msgraph.NewRoleDefinitionsClient()
 	c.RoleDefinitionsClient.BaseClient.Authorizer = c.Connections["default"].Authorizer
 	c.RoleDefinitionsClient.BaseClient.Endpoint = *endpoint
 	c.RoleDefinitionsClient.BaseClient.RetryableClient.RetryMax = retry
 
-	c.SchemaExtensionsClient = msgraph.NewSchemaExtensionsClient(c.Connections["default"].AuthConfig.TenantID)
+	c.SchemaExtensionsClient = msgraph.NewSchemaExtensionsClient()
 	c.SchemaExtensionsClient.BaseClient.Authorizer = c.Connections["default"].Authorizer
 	c.SchemaExtensionsClient.BaseClient.Endpoint = *endpoint
 	c.SchemaExtensionsClient.BaseClient.RetryableClient.RetryMax = retry
 
-	c.ServicePrincipalsAppRoleAssignmentsClient = msgraph.NewServicePrincipalsAppRoleAssignmentsClient(c.Connections["default"].AuthConfig.TenantID)
+	c.ServicePrincipalsAppRoleAssignmentsClient = msgraph.NewServicePrincipalsAppRoleAssignmentsClient()
 	c.ServicePrincipalsAppRoleAssignmentsClient.BaseClient.Authorizer = c.Connections["default"].Authorizer
 	c.ServicePrincipalsAppRoleAssignmentsClient.BaseClient.Endpoint = *endpoint
 	c.ServicePrincipalsAppRoleAssignmentsClient.BaseClient.RetryableClient.RetryMax = retry
 
-	c.ServicePrincipalsClient = msgraph.NewServicePrincipalsClient(c.Connections["default"].AuthConfig.TenantID)
+	c.ServicePrincipalsClient = msgraph.NewServicePrincipalsClient()
 	c.ServicePrincipalsClient.BaseClient.Authorizer = c.Connections["default"].Authorizer
 	c.ServicePrincipalsClient.BaseClient.Endpoint = *endpoint
 	c.ServicePrincipalsClient.BaseClient.RetryableClient.RetryMax = retry
 	c.ServicePrincipalsClient.BaseClient.ApiVersion = msgraph.Version10
 
-	c.SignInReportsClient = msgraph.NewSignInReportsClient(c.Connections["default"].AuthConfig.TenantID)
+	c.SignInReportsClient = msgraph.NewSignInReportsClient()
 	c.SignInReportsClient.BaseClient.Authorizer = c.Connections["default"].Authorizer
 	c.SignInReportsClient.BaseClient.Endpoint = *endpoint
 	c.SignInReportsClient.BaseClient.RetryableClient.RetryMax = retry
 
-	c.SynchronizationJobClient = msgraph.NewSynchronizationJobClient(c.Connections["default"].AuthConfig.TenantID)
+	c.SynchronizationJobClient = msgraph.NewSynchronizationJobClient()
 	c.SynchronizationJobClient.BaseClient.Authorizer = c.Connections["default"].Authorizer
 	c.SynchronizationJobClient.BaseClient.Endpoint = *endpoint
 	c.SynchronizationJobClient.BaseClient.RetryableClient.RetryMax = retry
 
-	c.TermsOfUseAgreementClient = msgraph.NewTermsOfUseAgreementClient(c.Connections["default"].AuthConfig.TenantID)
+	c.TermsOfUseAgreementClient = msgraph.NewTermsOfUseAgreementClient()
 	c.TermsOfUseAgreementClient.BaseClient.Authorizer = c.Connections["default"].Authorizer
 	c.TermsOfUseAgreementClient.BaseClient.Endpoint = *endpoint
 	c.TermsOfUseAgreementClient.BaseClient.RetryableClient.RetryMax = retry
 
-	c.UserFlowAttributesClient = msgraph.NewUserFlowAttributesClient(c.Connections["b2c"].AuthConfig.TenantID)
+	c.UserFlowAttributesClient = msgraph.NewUserFlowAttributesClient()
 	c.UserFlowAttributesClient.BaseClient.Authorizer = c.Connections["b2c"].Authorizer
 	c.UserFlowAttributesClient.BaseClient.Endpoint = *endpoint
 	c.UserFlowAttributesClient.BaseClient.RetryableClient.RetryMax = retry
 
-	c.UsersAppRoleAssignmentsClient = msgraph.NewUsersAppRoleAssignmentsClient(c.Connections["default"].AuthConfig.TenantID)
+	c.UsersAppRoleAssignmentsClient = msgraph.NewUsersAppRoleAssignmentsClient()
 	c.UsersAppRoleAssignmentsClient.BaseClient.Authorizer = c.Connections["default"].Authorizer
 	c.UsersAppRoleAssignmentsClient.BaseClient.Endpoint = *endpoint
 	c.UsersAppRoleAssignmentsClient.BaseClient.RetryableClient.RetryMax = retry
 
-	c.UsersClient = msgraph.NewUsersClient(c.Connections["default"].AuthConfig.TenantID)
+	c.UsersClient = msgraph.NewUsersClient()
 	c.UsersClient.BaseClient.Authorizer = c.Connections["default"].Authorizer
 	c.UsersClient.BaseClient.Endpoint = *endpoint
 	c.UsersClient.BaseClient.RetryableClient.RetryMax = retry

--- a/msgraph/accesspackage.go
+++ b/msgraph/accesspackage.go
@@ -17,7 +17,7 @@ type AccessPackageClient struct {
 
 func NewAccessPackageClient(tenantId string) *AccessPackageClient {
 	return &AccessPackageClient{
-		BaseClient: NewClient(Version10, tenantId),
+		BaseClient: NewClient(Version10),
 	}
 }
 
@@ -28,8 +28,7 @@ func (c *AccessPackageClient) List(ctx context.Context, query odata.Query) (*[]A
 		OData:            query,
 		ValidStatusCodes: []int{http.StatusOK},
 		Uri: Uri{
-			Entity:      "/identityGovernance/entitlementManagement/accessPackages",
-			HasTenantId: true,
+			Entity: "/identityGovernance/entitlementManagement/accessPackages",
 		},
 	})
 	if err != nil {
@@ -64,8 +63,7 @@ func (c *AccessPackageClient) Create(ctx context.Context, accessPackage AccessPa
 		Body:             body,
 		ValidStatusCodes: []int{http.StatusCreated},
 		Uri: Uri{
-			Entity:      "/identityGovernance/entitlementManagement/accessPackages",
-			HasTenantId: true,
+			Entity: "/identityGovernance/entitlementManagement/accessPackages",
 		},
 	})
 	if err != nil {
@@ -99,8 +97,7 @@ func (c *AccessPackageClient) Get(ctx context.Context, id string, query odata.Qu
 		OData:                  query,
 		ValidStatusCodes:       []int{http.StatusOK},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/identityGovernance/entitlementManagement/accessPackages/%s", id),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/identityGovernance/entitlementManagement/accessPackages/%s", id),
 		},
 	})
 	if err != nil {
@@ -139,8 +136,7 @@ func (c *AccessPackageClient) Update(ctx context.Context, accessPackage AccessPa
 		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
 		ValidStatusCodes:       []int{http.StatusNoContent},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/identityGovernance/entitlementManagement/accessPackages/%s", *accessPackage.ID),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/identityGovernance/entitlementManagement/accessPackages/%s", *accessPackage.ID),
 		},
 	})
 	if err != nil {
@@ -156,8 +152,7 @@ func (c *AccessPackageClient) Delete(ctx context.Context, id string) (int, error
 		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
 		ValidStatusCodes:       []int{http.StatusNoContent},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/identityGovernance/entitlementManagement/accessPackages/%s", id),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/identityGovernance/entitlementManagement/accessPackages/%s", id),
 		},
 	})
 	if err != nil {

--- a/msgraph/accesspackage.go
+++ b/msgraph/accesspackage.go
@@ -15,7 +15,7 @@ type AccessPackageClient struct {
 	BaseClient Client
 }
 
-func NewAccessPackageClient(tenantId string) *AccessPackageClient {
+func NewAccessPackageClient() *AccessPackageClient {
 	return &AccessPackageClient{
 		BaseClient: NewClient(Version10),
 	}

--- a/msgraph/accesspackageassignmentpolicy.go
+++ b/msgraph/accesspackageassignmentpolicy.go
@@ -15,7 +15,7 @@ type AccessPackageAssignmentPolicyClient struct {
 	BaseClient Client
 }
 
-func NewAccessPackageAssignmentPolicyClient(tenantId string) *AccessPackageAssignmentPolicyClient {
+func NewAccessPackageAssignmentPolicyClient() *AccessPackageAssignmentPolicyClient {
 	return &AccessPackageAssignmentPolicyClient{
 		BaseClient: NewClient(VersionBeta),
 	}

--- a/msgraph/accesspackageassignmentpolicy.go
+++ b/msgraph/accesspackageassignmentpolicy.go
@@ -17,7 +17,7 @@ type AccessPackageAssignmentPolicyClient struct {
 
 func NewAccessPackageAssignmentPolicyClient(tenantId string) *AccessPackageAssignmentPolicyClient {
 	return &AccessPackageAssignmentPolicyClient{
-		BaseClient: NewClient(VersionBeta, tenantId),
+		BaseClient: NewClient(VersionBeta),
 	}
 }
 
@@ -28,8 +28,7 @@ func (c *AccessPackageAssignmentPolicyClient) List(ctx context.Context, query od
 		OData:            query,
 		ValidStatusCodes: []int{http.StatusOK},
 		Uri: Uri{
-			Entity:      "/identityGovernance/entitlementManagement/accessPackageAssignmentPolicies",
-			HasTenantId: true,
+			Entity: "/identityGovernance/entitlementManagement/accessPackageAssignmentPolicies",
 		},
 	})
 	if err != nil {
@@ -64,8 +63,7 @@ func (c *AccessPackageAssignmentPolicyClient) Create(ctx context.Context, access
 		Body:             body,
 		ValidStatusCodes: []int{http.StatusCreated},
 		Uri: Uri{
-			Entity:      "/identityGovernance/entitlementManagement/accessPackageAssignmentPolicies",
-			HasTenantId: true,
+			Entity: "/identityGovernance/entitlementManagement/accessPackageAssignmentPolicies",
 		},
 	})
 	if err != nil {
@@ -93,8 +91,7 @@ func (c *AccessPackageAssignmentPolicyClient) Get(ctx context.Context, id string
 		OData:                  query,
 		ValidStatusCodes:       []int{http.StatusOK},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/identityGovernance/entitlementManagement/accessPackageAssignmentPolicies/%s", id),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/identityGovernance/entitlementManagement/accessPackageAssignmentPolicies/%s", id),
 		},
 	})
 	if err != nil {
@@ -133,8 +130,7 @@ func (c *AccessPackageAssignmentPolicyClient) Update(ctx context.Context, access
 		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
 		ValidStatusCodes:       []int{http.StatusOK},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/identityGovernance/entitlementManagement/accessPackageAssignmentPolicies/%s", *accessPackageAssignmentPolicy.ID),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/identityGovernance/entitlementManagement/accessPackageAssignmentPolicies/%s", *accessPackageAssignmentPolicy.ID),
 		},
 	})
 	if err != nil {
@@ -150,8 +146,7 @@ func (c *AccessPackageAssignmentPolicyClient) Delete(ctx context.Context, id str
 		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
 		ValidStatusCodes:       []int{http.StatusNoContent},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/identityGovernance/entitlementManagement/accessPackageAssignmentPolicies/%s", id),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/identityGovernance/entitlementManagement/accessPackageAssignmentPolicies/%s", id),
 		},
 	})
 	if err != nil {

--- a/msgraph/accesspackageassignmentrequest.go
+++ b/msgraph/accesspackageassignmentrequest.go
@@ -16,7 +16,7 @@ type AccessPackageAssignmentRequestClient struct {
 
 func NewAccessPackageAssignmentRequestClient(tenantId string) *AccessPackageAssignmentRequestClient {
 	return &AccessPackageAssignmentRequestClient{
-		BaseClient: NewClient(Version10, tenantId),
+		BaseClient: NewClient(Version10),
 	}
 }
 
@@ -28,9 +28,8 @@ func (c *AccessPackageAssignmentRequestClient) List(ctx context.Context, query o
 		DisablePaging:    query.Top > 0,
 		ValidStatusCodes: []int{http.StatusOK},
 		Uri: Uri{
-			Entity:      entity,
-			Params:      query.Values(),
-			HasTenantId: true,
+			Entity: entity,
+			Params: query.Values(),
 		},
 	})
 	if err != nil {
@@ -60,8 +59,7 @@ func (c *AccessPackageAssignmentRequestClient) Get(ctx context.Context, id strin
 		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
 		ValidStatusCodes:       []int{http.StatusOK},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("%s/%s", entity, id),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("%s/%s", entity, id),
 		},
 	})
 	if err != nil {
@@ -95,8 +93,7 @@ func (c *AccessPackageAssignmentRequestClient) Create(ctx context.Context, acces
 		Body:             body,
 		ValidStatusCodes: []int{http.StatusOK},
 		Uri: Uri{
-			Entity:      entity,
-			HasTenantId: true,
+			Entity: entity,
 		},
 	})
 	if err != nil {
@@ -124,8 +121,7 @@ func (c *AccessPackageAssignmentRequestClient) Delete(ctx context.Context, id st
 		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
 		ValidStatusCodes:       []int{http.StatusNoContent},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("%s/%s", entity, id),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("%s/%s", entity, id),
 		},
 	})
 	if err != nil {
@@ -143,8 +139,7 @@ func (c *AccessPackageAssignmentRequestClient) Cancel(ctx context.Context, id st
 	_, status, _, err := c.BaseClient.Post(ctx, PostHttpRequestInput{
 		ValidStatusCodes: []int{http.StatusOK},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("%s/%s/cancel", entity, id),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("%s/%s/cancel", entity, id),
 		},
 	})
 	if err != nil {
@@ -161,8 +156,7 @@ func (c *AccessPackageAssignmentRequestClient) Reprocess(ctx context.Context, id
 	_, status, _, err := c.BaseClient.Post(ctx, PostHttpRequestInput{
 		ValidStatusCodes: []int{http.StatusAccepted},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/%s/%s/reprocess", entity, id),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/%s/%s/reprocess", entity, id),
 		},
 	})
 	if err != nil {

--- a/msgraph/accesspackageassignmentrequest.go
+++ b/msgraph/accesspackageassignmentrequest.go
@@ -14,7 +14,7 @@ type AccessPackageAssignmentRequestClient struct {
 	BaseClient Client
 }
 
-func NewAccessPackageAssignmentRequestClient(tenantId string) *AccessPackageAssignmentRequestClient {
+func NewAccessPackageAssignmentRequestClient() *AccessPackageAssignmentRequestClient {
 	return &AccessPackageAssignmentRequestClient{
 		BaseClient: NewClient(Version10),
 	}

--- a/msgraph/accesspackagecatalog.go
+++ b/msgraph/accesspackagecatalog.go
@@ -15,7 +15,7 @@ type AccessPackageCatalogClient struct {
 	BaseClient Client
 }
 
-func NewAccessPackageCatalogClient(tenantId string) *AccessPackageCatalogClient {
+func NewAccessPackageCatalogClient() *AccessPackageCatalogClient {
 	return &AccessPackageCatalogClient{
 		BaseClient: NewClient(Version10),
 	}

--- a/msgraph/accesspackagecatalog.go
+++ b/msgraph/accesspackagecatalog.go
@@ -17,7 +17,7 @@ type AccessPackageCatalogClient struct {
 
 func NewAccessPackageCatalogClient(tenantId string) *AccessPackageCatalogClient {
 	return &AccessPackageCatalogClient{
-		BaseClient: NewClient(Version10, tenantId),
+		BaseClient: NewClient(Version10),
 	}
 }
 
@@ -28,8 +28,7 @@ func (c *AccessPackageCatalogClient) List(ctx context.Context, query odata.Query
 		OData:            query,
 		ValidStatusCodes: []int{http.StatusOK},
 		Uri: Uri{
-			Entity:      "/identityGovernance/entitlementManagement/catalogs",
-			HasTenantId: true,
+			Entity: "/identityGovernance/entitlementManagement/catalogs",
 		},
 	})
 	if err != nil {
@@ -64,8 +63,7 @@ func (c *AccessPackageCatalogClient) Create(ctx context.Context, accessPackageCa
 		Body:             body,
 		ValidStatusCodes: []int{http.StatusCreated},
 		Uri: Uri{
-			Entity:      "/identityGovernance/entitlementManagement/catalogs",
-			HasTenantId: true,
+			Entity: "/identityGovernance/entitlementManagement/catalogs",
 		},
 	})
 	if err != nil {
@@ -93,8 +91,7 @@ func (c *AccessPackageCatalogClient) Get(ctx context.Context, id string, query o
 		OData:                  query,
 		ValidStatusCodes:       []int{http.StatusOK},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/identityGovernance/entitlementManagement/catalogs/%s", id),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/identityGovernance/entitlementManagement/catalogs/%s", id),
 		},
 	})
 	if err != nil {
@@ -133,8 +130,7 @@ func (c *AccessPackageCatalogClient) Update(ctx context.Context, accessPackageCa
 		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
 		ValidStatusCodes:       []int{http.StatusNoContent},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/identityGovernance/entitlementManagement/catalogs/%s", *accessPackageCatalog.ID),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/identityGovernance/entitlementManagement/catalogs/%s", *accessPackageCatalog.ID),
 		},
 	})
 	if err != nil {
@@ -150,8 +146,7 @@ func (c *AccessPackageCatalogClient) Delete(ctx context.Context, id string) (int
 		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
 		ValidStatusCodes:       []int{http.StatusNoContent},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/identityGovernance/entitlementManagement/catalogs/%s", id),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/identityGovernance/entitlementManagement/catalogs/%s", id),
 		},
 	})
 	if err != nil {

--- a/msgraph/accesspackageresource.go
+++ b/msgraph/accesspackageresource.go
@@ -14,7 +14,7 @@ type AccessPackageResourceClient struct {
 	BaseClient Client
 }
 
-func NewAccessPackageResourceClient(tenantId string) *AccessPackageResourceClient {
+func NewAccessPackageResourceClient() *AccessPackageResourceClient {
 	return &AccessPackageResourceClient{
 		BaseClient: NewClient(VersionBeta),
 	}

--- a/msgraph/accesspackageresource.go
+++ b/msgraph/accesspackageresource.go
@@ -16,7 +16,7 @@ type AccessPackageResourceClient struct {
 
 func NewAccessPackageResourceClient(tenantId string) *AccessPackageResourceClient {
 	return &AccessPackageResourceClient{
-		BaseClient: NewClient(VersionBeta, tenantId),
+		BaseClient: NewClient(VersionBeta),
 	}
 }
 
@@ -27,8 +27,7 @@ func (c *AccessPackageResourceClient) List(ctx context.Context, catalogId string
 		OData:            query,
 		ValidStatusCodes: []int{http.StatusOK},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/identityGovernance/entitlementManagement/accessPackageCatalogs/%s/accessPackageResources", catalogId),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/identityGovernance/entitlementManagement/accessPackageCatalogs/%s/accessPackageResources", catalogId),
 		},
 	})
 	if err != nil {
@@ -61,8 +60,7 @@ func (c *AccessPackageResourceClient) Get(ctx context.Context, catalogId string,
 		},
 		ValidStatusCodes: []int{http.StatusOK},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/identityGovernance/entitlementManagement/accessPackageCatalogs/%s/accessPackageResources", catalogId),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/identityGovernance/entitlementManagement/accessPackageCatalogs/%s/accessPackageResources", catalogId),
 		},
 	})
 	if err != nil {

--- a/msgraph/accesspackageresourcerequest.go
+++ b/msgraph/accesspackageresourcerequest.go
@@ -16,7 +16,7 @@ type AccessPackageResourceRequestClient struct {
 	BaseClient Client
 }
 
-func NewAccessPackageResourceRequestClient(tenantId string) *AccessPackageResourceRequestClient {
+func NewAccessPackageResourceRequestClient() *AccessPackageResourceRequestClient {
 	return &AccessPackageResourceRequestClient{
 		BaseClient: NewClient(VersionBeta),
 	}

--- a/msgraph/accesspackageresourcerequest.go
+++ b/msgraph/accesspackageresourcerequest.go
@@ -18,7 +18,7 @@ type AccessPackageResourceRequestClient struct {
 
 func NewAccessPackageResourceRequestClient(tenantId string) *AccessPackageResourceRequestClient {
 	return &AccessPackageResourceRequestClient{
-		BaseClient: NewClient(VersionBeta, tenantId),
+		BaseClient: NewClient(VersionBeta),
 	}
 }
 
@@ -28,9 +28,8 @@ func (c *AccessPackageResourceRequestClient) List(ctx context.Context, query oda
 		DisablePaging:    query.Top > 0,
 		ValidStatusCodes: []int{http.StatusOK},
 		Uri: Uri{
-			Entity:      "/identityGovernance/entitlementManagement/accessPackageResourceRequests",
-			Params:      query.Values(),
-			HasTenantId: true,
+			Entity: "/identityGovernance/entitlementManagement/accessPackageResourceRequests",
+			Params: query.Values(),
 		},
 	})
 	if err != nil {
@@ -73,8 +72,7 @@ func (c *AccessPackageResourceRequestClient) Create(ctx context.Context, accessP
 		ConsistencyFailureFunc: resourceDoesNotExist,
 		ValidStatusCodes:       []int{http.StatusCreated},
 		Uri: Uri{
-			Entity:      "/identityGovernance/entitlementManagement/accessPackageResourceRequests",
-			HasTenantId: true,
+			Entity: "/identityGovernance/entitlementManagement/accessPackageResourceRequests",
 		},
 	})
 
@@ -117,7 +115,6 @@ func (c *AccessPackageResourceRequestClient) Create(ctx context.Context, accessP
 				Params: odata.Query{
 					Filter: fmt.Sprintf("startswith(originId,'%s')", *newAccessPackageResourceRequest.AccessPackageResource.OriginId),
 				}.Values(), // The Resource we made a request to add
-				HasTenantId: true,
 			},
 		})
 		if err != nil {
@@ -160,7 +157,6 @@ func (c *AccessPackageResourceRequestClient) Get(ctx context.Context, id string)
 			Params: odata.Query{
 				Filter: fmt.Sprintf("startswith(id,'%s')", id),
 			}.Values(),
-			HasTenantId: true,
 		},
 	})
 	if err != nil {
@@ -207,8 +203,7 @@ func (c *AccessPackageResourceRequestClient) Delete(ctx context.Context, accessP
 		Body:             body,
 		ValidStatusCodes: []int{http.StatusCreated},
 		Uri: Uri{
-			Entity:      "/identityGovernance/entitlementManagement/accessPackageResourceRequests",
-			HasTenantId: true,
+			Entity: "/identityGovernance/entitlementManagement/accessPackageResourceRequests",
 		},
 	})
 	if err != nil {

--- a/msgraph/accesspackageresourcerolescope.go
+++ b/msgraph/accesspackageresourcerolescope.go
@@ -17,7 +17,7 @@ type AccessPackageResourceRoleScopeClient struct {
 	BaseClient Client
 }
 
-func NewAccessPackageResourceRoleScopeClient(tenantId string) *AccessPackageResourceRoleScopeClient {
+func NewAccessPackageResourceRoleScopeClient() *AccessPackageResourceRoleScopeClient {
 	return &AccessPackageResourceRoleScopeClient{
 		BaseClient: NewClient(VersionBeta),
 	}

--- a/msgraph/accesspackageresourcerolescope.go
+++ b/msgraph/accesspackageresourcerolescope.go
@@ -19,7 +19,7 @@ type AccessPackageResourceRoleScopeClient struct {
 
 func NewAccessPackageResourceRoleScopeClient(tenantId string) *AccessPackageResourceRoleScopeClient {
 	return &AccessPackageResourceRoleScopeClient{
-		BaseClient: NewClient(VersionBeta, tenantId),
+		BaseClient: NewClient(VersionBeta),
 	}
 }
 
@@ -34,8 +34,7 @@ func (c *AccessPackageResourceRoleScopeClient) List(ctx context.Context, query o
 		OData:            query,
 		ValidStatusCodes: []int{http.StatusOK},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/identityGovernance/entitlementManagement/accessPackages/%s", accessPackageId),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/identityGovernance/entitlementManagement/accessPackages/%s", accessPackageId),
 		},
 	})
 	if err != nil {
@@ -75,8 +74,7 @@ func (c *AccessPackageResourceRoleScopeClient) Create(ctx context.Context, acces
 		Body:             body,
 		ValidStatusCodes: []int{http.StatusCreated},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/identityGovernance/entitlementManagement/accessPackages/%s/accessPackageResourceRoleScopes", *accessPackageResourceRoleScope.AccessPackageId),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/identityGovernance/entitlementManagement/accessPackages/%s/accessPackageResourceRoleScopes", *accessPackageResourceRoleScope.AccessPackageId),
 		},
 	})
 	if err != nil {
@@ -119,8 +117,7 @@ func (c *AccessPackageResourceRoleScopeClient) Get(ctx context.Context, accessPa
 		}, //The Resource we made a request to add
 		ValidStatusCodes: []int{http.StatusOK},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/identityGovernance/entitlementManagement/accessPackages/%s", accessPackageId),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/identityGovernance/entitlementManagement/accessPackages/%s", accessPackageId),
 		},
 	})
 	if err != nil {

--- a/msgraph/administrative_units.go
+++ b/msgraph/administrative_units.go
@@ -16,7 +16,7 @@ type AdministrativeUnitsClient struct {
 }
 
 // NewAdministrativeUnitsClient returns a new AdministrativeUnitsClient.
-func NewAdministrativeUnitsClient(tenantId string) *AdministrativeUnitsClient {
+func NewAdministrativeUnitsClient() *AdministrativeUnitsClient {
 	return &AdministrativeUnitsClient{
 		BaseClient: NewClient(VersionBeta),
 	}

--- a/msgraph/administrative_units.go
+++ b/msgraph/administrative_units.go
@@ -18,7 +18,7 @@ type AdministrativeUnitsClient struct {
 // NewAdministrativeUnitsClient returns a new AdministrativeUnitsClient.
 func NewAdministrativeUnitsClient(tenantId string) *AdministrativeUnitsClient {
 	return &AdministrativeUnitsClient{
-		BaseClient: NewClient(VersionBeta, tenantId),
+		BaseClient: NewClient(VersionBeta),
 	}
 }
 
@@ -29,8 +29,7 @@ func (c *AdministrativeUnitsClient) List(ctx context.Context, query odata.Query)
 		OData:            query,
 		ValidStatusCodes: []int{http.StatusOK},
 		Uri: Uri{
-			Entity:      "/administrativeUnits",
-			HasTenantId: true,
+			Entity: "/administrativeUnits",
 		},
 	})
 	if err != nil {
@@ -69,8 +68,7 @@ func (c *AdministrativeUnitsClient) Create(ctx context.Context, administrativeUn
 		},
 		ValidStatusCodes: []int{http.StatusCreated},
 		Uri: Uri{
-			Entity:      "/administrativeUnits",
-			HasTenantId: true,
+			Entity: "/administrativeUnits",
 		},
 	})
 	if err != nil {
@@ -100,8 +98,7 @@ func (c *AdministrativeUnitsClient) Get(ctx context.Context, id string, query od
 		OData:                  query,
 		ValidStatusCodes:       []int{http.StatusOK},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/administrativeUnits/%s", id),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/administrativeUnits/%s", id),
 		},
 	})
 	if err != nil {
@@ -136,8 +133,7 @@ func (c *AdministrativeUnitsClient) Update(ctx context.Context, administrativeUn
 		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
 		ValidStatusCodes:       []int{http.StatusNoContent},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/administrativeUnits/%s", *administrativeUnit.ID),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/administrativeUnits/%s", *administrativeUnit.ID),
 		},
 	})
 	if err != nil {
@@ -153,8 +149,7 @@ func (c *AdministrativeUnitsClient) Delete(ctx context.Context, id string) (int,
 		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
 		ValidStatusCodes:       []int{http.StatusNoContent},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/administrativeUnits/%s", id),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/administrativeUnits/%s", id),
 		},
 	})
 	if err != nil {
@@ -173,8 +168,7 @@ func (c *AdministrativeUnitsClient) ListMembers(ctx context.Context, administrat
 		},
 		ValidStatusCodes: []int{http.StatusOK},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/administrativeUnits/%s/members", administrativeUnitId),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/administrativeUnits/%s/members", administrativeUnitId),
 		},
 	})
 	if err != nil {
@@ -214,8 +208,7 @@ func (c *AdministrativeUnitsClient) GetMember(ctx context.Context, administrativ
 		},
 		ValidStatusCodes: []int{http.StatusOK},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/administrativeUnits/%s/members/%s/$ref", administrativeUnitId, memberId),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/administrativeUnits/%s/members/%s/$ref", administrativeUnitId, memberId),
 		},
 	})
 	if err != nil {
@@ -254,8 +247,7 @@ func (c *AdministrativeUnitsClient) CreateGroup(ctx context.Context, administrat
 		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
 		ValidStatusCodes:       []int{http.StatusCreated},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/administrativeUnits/%s/members", administrativeUnitId),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/administrativeUnits/%s/members", administrativeUnitId),
 		},
 	})
 	if err != nil {
@@ -304,8 +296,7 @@ func (c *AdministrativeUnitsClient) AddMembers(ctx context.Context, administrati
 			ValidStatusCodes:       []int{http.StatusNoContent},
 			ValidStatusFunc:        checkMemberAlreadyExists,
 			Uri: Uri{
-				Entity:      fmt.Sprintf("/administrativeUnits/%s/members/$ref", administrativeUnitId),
-				HasTenantId: true,
+				Entity: fmt.Sprintf("/administrativeUnits/%s/members/$ref", administrativeUnitId),
 			},
 		})
 		if err != nil {
@@ -347,8 +338,7 @@ func (c *AdministrativeUnitsClient) RemoveMembers(ctx context.Context, administr
 			ValidStatusCodes:       []int{http.StatusNoContent},
 			ValidStatusFunc:        checkMemberGone,
 			Uri: Uri{
-				Entity:      fmt.Sprintf("/administrativeUnits/%s/members/%s/$ref", administrativeUnitId, memberId),
-				HasTenantId: true,
+				Entity: fmt.Sprintf("/administrativeUnits/%s/members/%s/$ref", administrativeUnitId, memberId),
 			},
 		})
 		if err != nil {
@@ -366,8 +356,7 @@ func (c *AdministrativeUnitsClient) ListScopedRoleMembers(ctx context.Context, a
 		OData:                  query,
 		ValidStatusCodes:       []int{http.StatusOK},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/administrativeUnits/%s/scopedRoleMembers", administrativeUnitId),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/administrativeUnits/%s/scopedRoleMembers", administrativeUnitId),
 		},
 	})
 	if err != nil {
@@ -397,8 +386,7 @@ func (c *AdministrativeUnitsClient) GetScopedRoleMember(ctx context.Context, adm
 		OData:                  query,
 		ValidStatusCodes:       []int{http.StatusOK},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/administrativeUnits/%s/scopedRoleMembers/%s", administrativeUnitId, scopedRoleMembershipId),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/administrativeUnits/%s/scopedRoleMembers/%s", administrativeUnitId, scopedRoleMembershipId),
 		},
 	})
 	if err != nil {
@@ -433,8 +421,7 @@ func (c *AdministrativeUnitsClient) AddScopedRoleMember(ctx context.Context, adm
 		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
 		ValidStatusCodes:       []int{http.StatusCreated},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/administrativeUnits/%s/scopedRoleMembers", administrativeUnitId),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/administrativeUnits/%s/scopedRoleMembers", administrativeUnitId),
 		},
 	})
 	if err != nil {
@@ -464,8 +451,7 @@ func (c *AdministrativeUnitsClient) RemoveScopedRoleMembers(ctx context.Context,
 		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
 		ValidStatusCodes:       []int{http.StatusNoContent},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/administrativeUnits/%s/scopedRoleMembers/%s", administrativeUnitId, scopedRoleMembershipId),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/administrativeUnits/%s/scopedRoleMembers/%s", administrativeUnitId, scopedRoleMembershipId),
 		},
 	})
 	if err != nil {

--- a/msgraph/app_role_assignments.go
+++ b/msgraph/app_role_assignments.go
@@ -28,7 +28,7 @@ type AppRoleAssignmentsClient struct {
 // NewUsersAppRoleAssignmentsClient returns a new AppRoleAssignmentsClient for users assignments
 func NewUsersAppRoleAssignmentsClient(tenantId string) *AppRoleAssignmentsClient {
 	return &AppRoleAssignmentsClient{
-		BaseClient:   NewClient(Version10, tenantId),
+		BaseClient:   NewClient(Version10),
 		resourceType: usersAppRoleAssignmentsResource,
 	}
 }
@@ -36,7 +36,7 @@ func NewUsersAppRoleAssignmentsClient(tenantId string) *AppRoleAssignmentsClient
 // NewGroupsAppRoleAssignmentsClient returns a new AppRoleAssignmentsClient for groups assignments
 func NewGroupsAppRoleAssignmentsClient(tenantId string) *AppRoleAssignmentsClient {
 	return &AppRoleAssignmentsClient{
-		BaseClient:   NewClient(Version10, tenantId),
+		BaseClient:   NewClient(Version10),
 		resourceType: groupsAppRoleAssignmentsResource,
 	}
 }
@@ -44,7 +44,7 @@ func NewGroupsAppRoleAssignmentsClient(tenantId string) *AppRoleAssignmentsClien
 // NewServicePrincipalsAppRoleAssignmentsClient returns a new AppRoleAssignmentsClient for service principal assignments
 func NewServicePrincipalsAppRoleAssignmentsClient(tenantId string) *AppRoleAssignmentsClient {
 	return &AppRoleAssignmentsClient{
-		BaseClient:   NewClient(Version10, tenantId),
+		BaseClient:   NewClient(Version10),
 		resourceType: servicePrincipalsAppRoleAssignmentsResource,
 	}
 }
@@ -55,8 +55,7 @@ func (c *AppRoleAssignmentsClient) List(ctx context.Context, id string, query od
 		ValidStatusCodes: []int{http.StatusOK},
 		OData:            query,
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/%s/%s/appRoleAssignments", c.resourceType, id),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/%s/%s/appRoleAssignments", c.resourceType, id),
 		},
 	})
 	if err != nil {
@@ -85,8 +84,7 @@ func (c *AppRoleAssignmentsClient) Remove(ctx context.Context, id, appRoleAssign
 		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
 		ValidStatusCodes:       []int{http.StatusNoContent},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/%s/%s/appRoleAssignments/%s", c.resourceType, id, appRoleAssignmentId),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/%s/%s/appRoleAssignments/%s", c.resourceType, id, appRoleAssignmentId),
 		},
 	})
 	if err != nil {
@@ -120,8 +118,7 @@ func (c *AppRoleAssignmentsClient) Assign(ctx context.Context, clientServicePrin
 		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
 		ValidStatusCodes:       []int{http.StatusCreated},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/%s/%s/appRoleAssignments", c.resourceType, clientServicePrincipalId),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/%s/%s/appRoleAssignments", c.resourceType, clientServicePrincipalId),
 		},
 	})
 	if err != nil {
@@ -150,7 +147,7 @@ type AppRoleAssignedToClient struct {
 // NewAppRoleAssignedToClient returns a new AppRoleAssignedToClient
 func NewAppRoleAssignedToClient(tenantId string) *AppRoleAssignedToClient {
 	return &AppRoleAssignedToClient{
-		BaseClient: NewClient(Version10, tenantId),
+		BaseClient: NewClient(Version10),
 	}
 }
 
@@ -160,8 +157,7 @@ func (c *AppRoleAssignedToClient) List(ctx context.Context, id string, query oda
 		OData:            query,
 		ValidStatusCodes: []int{http.StatusOK},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/servicePrincipals/%s/appRoleAssignedTo", id),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/servicePrincipals/%s/appRoleAssignedTo", id),
 		},
 	})
 	if err != nil {
@@ -190,8 +186,7 @@ func (c *AppRoleAssignedToClient) Remove(ctx context.Context, resourceId, appRol
 		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
 		ValidStatusCodes:       []int{http.StatusNoContent},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/servicePrincipals/%s/appRoleAssignedTo/%s", resourceId, appRoleAssignmentId),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/servicePrincipals/%s/appRoleAssignedTo/%s", resourceId, appRoleAssignmentId),
 		},
 	})
 	if err != nil {
@@ -236,8 +231,7 @@ func (c *AppRoleAssignedToClient) Assign(ctx context.Context, appRoleAssignment 
 		ConsistencyFailureFunc: consistencyFunc,
 		ValidStatusCodes:       []int{http.StatusCreated},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/servicePrincipals/%s/appRoleAssignedTo", *appRoleAssignment.ResourceId),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/servicePrincipals/%s/appRoleAssignedTo", *appRoleAssignment.ResourceId),
 		},
 	})
 	if err != nil {

--- a/msgraph/app_role_assignments.go
+++ b/msgraph/app_role_assignments.go
@@ -26,7 +26,7 @@ type AppRoleAssignmentsClient struct {
 }
 
 // NewUsersAppRoleAssignmentsClient returns a new AppRoleAssignmentsClient for users assignments
-func NewUsersAppRoleAssignmentsClient(tenantId string) *AppRoleAssignmentsClient {
+func NewUsersAppRoleAssignmentsClient() *AppRoleAssignmentsClient {
 	return &AppRoleAssignmentsClient{
 		BaseClient:   NewClient(Version10),
 		resourceType: usersAppRoleAssignmentsResource,
@@ -34,7 +34,7 @@ func NewUsersAppRoleAssignmentsClient(tenantId string) *AppRoleAssignmentsClient
 }
 
 // NewGroupsAppRoleAssignmentsClient returns a new AppRoleAssignmentsClient for groups assignments
-func NewGroupsAppRoleAssignmentsClient(tenantId string) *AppRoleAssignmentsClient {
+func NewGroupsAppRoleAssignmentsClient() *AppRoleAssignmentsClient {
 	return &AppRoleAssignmentsClient{
 		BaseClient:   NewClient(Version10),
 		resourceType: groupsAppRoleAssignmentsResource,
@@ -42,7 +42,7 @@ func NewGroupsAppRoleAssignmentsClient(tenantId string) *AppRoleAssignmentsClien
 }
 
 // NewServicePrincipalsAppRoleAssignmentsClient returns a new AppRoleAssignmentsClient for service principal assignments
-func NewServicePrincipalsAppRoleAssignmentsClient(tenantId string) *AppRoleAssignmentsClient {
+func NewServicePrincipalsAppRoleAssignmentsClient() *AppRoleAssignmentsClient {
 	return &AppRoleAssignmentsClient{
 		BaseClient:   NewClient(Version10),
 		resourceType: servicePrincipalsAppRoleAssignmentsResource,
@@ -145,7 +145,7 @@ type AppRoleAssignedToClient struct {
 }
 
 // NewAppRoleAssignedToClient returns a new AppRoleAssignedToClient
-func NewAppRoleAssignedToClient(tenantId string) *AppRoleAssignedToClient {
+func NewAppRoleAssignedToClient() *AppRoleAssignedToClient {
 	return &AppRoleAssignedToClient{
 		BaseClient: NewClient(Version10),
 	}

--- a/msgraph/application_templates.go
+++ b/msgraph/application_templates.go
@@ -19,7 +19,7 @@ type ApplicationTemplatesClient struct {
 // NewApplicationTemplatesClient returns a new ApplicationTemplatesClient
 func NewApplicationTemplatesClient(tenantId string) *ApplicationTemplatesClient {
 	return &ApplicationTemplatesClient{
-		BaseClient: NewClient(Version10, tenantId),
+		BaseClient: NewClient(Version10),
 	}
 }
 
@@ -30,8 +30,7 @@ func (c *ApplicationTemplatesClient) List(ctx context.Context, query odata.Query
 		OData:            query,
 		ValidStatusCodes: []int{http.StatusOK},
 		Uri: Uri{
-			Entity:      "/applicationTemplates",
-			HasTenantId: true,
+			Entity: "/applicationTemplates",
 		},
 	})
 	if err != nil {
@@ -60,8 +59,7 @@ func (c *ApplicationTemplatesClient) Get(ctx context.Context, id string, query o
 		OData:            query,
 		ValidStatusCodes: []int{http.StatusOK},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/applicationTemplates/%s", id),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/applicationTemplates/%s", id),
 		},
 	})
 	if err != nil {
@@ -100,8 +98,7 @@ func (c *ApplicationTemplatesClient) Instantiate(ctx context.Context, applicatio
 		Body:             body,
 		ValidStatusCodes: []int{http.StatusCreated},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/applicationTemplates/%s/instantiate", *applicationTemplate.ID),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/applicationTemplates/%s/instantiate", *applicationTemplate.ID),
 		},
 	})
 	if err != nil {

--- a/msgraph/application_templates.go
+++ b/msgraph/application_templates.go
@@ -17,7 +17,7 @@ type ApplicationTemplatesClient struct {
 }
 
 // NewApplicationTemplatesClient returns a new ApplicationTemplatesClient
-func NewApplicationTemplatesClient(tenantId string) *ApplicationTemplatesClient {
+func NewApplicationTemplatesClient() *ApplicationTemplatesClient {
 	return &ApplicationTemplatesClient{
 		BaseClient: NewClient(Version10),
 	}

--- a/msgraph/applications.go
+++ b/msgraph/applications.go
@@ -19,7 +19,7 @@ type ApplicationsClient struct {
 // NewApplicationsClient returns a new ApplicationsClient
 func NewApplicationsClient(tenantId string) *ApplicationsClient {
 	return &ApplicationsClient{
-		BaseClient: NewClient(VersionBeta, tenantId),
+		BaseClient: NewClient(VersionBeta),
 	}
 }
 
@@ -30,8 +30,7 @@ func (c *ApplicationsClient) List(ctx context.Context, query odata.Query) (*[]Ap
 		OData:            query,
 		ValidStatusCodes: []int{http.StatusOK},
 		Uri: Uri{
-			Entity:      "/applications",
-			HasTenantId: true,
+			Entity: "/applications",
 		},
 	})
 	if err != nil {
@@ -70,8 +69,7 @@ func (c *ApplicationsClient) Create(ctx context.Context, application Application
 		},
 		ValidStatusCodes: []int{http.StatusCreated},
 		Uri: Uri{
-			Entity:      "/applications",
-			HasTenantId: true,
+			Entity: "/applications",
 		},
 	})
 	if err != nil {
@@ -99,8 +97,7 @@ func (c *ApplicationsClient) Get(ctx context.Context, id string, query odata.Que
 		OData:                  query,
 		ValidStatusCodes:       []int{http.StatusOK},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/applications/%s", id),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/applications/%s", id),
 		},
 	})
 	if err != nil {
@@ -129,8 +126,7 @@ func (c *ApplicationsClient) GetDeleted(ctx context.Context, id string, query od
 		OData:                  query,
 		ValidStatusCodes:       []int{http.StatusOK},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/directory/deletedItems/%s", id),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/directory/deletedItems/%s", id),
 		},
 	})
 	if err != nil {
@@ -182,8 +178,7 @@ func (c *ApplicationsClient) Update(ctx context.Context, application Application
 		ConsistencyFailureFunc: checkApplicationConsistency,
 		ValidStatusCodes:       []int{http.StatusNoContent},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/applications/%s", *application.ID()),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/applications/%s", *application.ID()),
 		},
 	})
 	if err != nil {
@@ -199,8 +194,7 @@ func (c *ApplicationsClient) Delete(ctx context.Context, id string) (int, error)
 		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
 		ValidStatusCodes:       []int{http.StatusNoContent},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/applications/%s", id),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/applications/%s", id),
 		},
 	})
 	if err != nil {
@@ -217,8 +211,7 @@ func (c *ApplicationsClient) DeletePermanently(ctx context.Context, id string) (
 		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
 		ValidStatusCodes:       []int{http.StatusNoContent},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/directory/deletedItems/%s", id),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/directory/deletedItems/%s", id),
 		},
 	})
 	if err != nil {
@@ -235,8 +228,7 @@ func (c *ApplicationsClient) ListDeleted(ctx context.Context, query odata.Query)
 		OData:            query,
 		ValidStatusCodes: []int{http.StatusOK},
 		Uri: Uri{
-			Entity:      "/directory/deleteditems/microsoft.graph.application",
-			HasTenantId: true,
+			Entity: "/directory/deleteditems/microsoft.graph.application",
 		},
 	})
 	if err != nil {
@@ -262,8 +254,7 @@ func (c *ApplicationsClient) RestoreDeleted(ctx context.Context, id string) (*Ap
 		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
 		ValidStatusCodes:       []int{http.StatusOK},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/directory/deletedItems/%s/restore", id),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/directory/deletedItems/%s/restore", id),
 		},
 	})
 	if err != nil {
@@ -302,8 +293,7 @@ func (c *ApplicationsClient) AddPassword(ctx context.Context, applicationId stri
 		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
 		ValidStatusCodes:       []int{http.StatusOK, http.StatusCreated},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/applications/%s/addPassword", applicationId),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/applications/%s/addPassword", applicationId),
 		},
 	})
 	if err != nil {
@@ -342,8 +332,7 @@ func (c *ApplicationsClient) RemovePassword(ctx context.Context, applicationId s
 		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
 		ValidStatusCodes:       []int{http.StatusOK, http.StatusNoContent},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/applications/%s/removePassword", applicationId),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/applications/%s/removePassword", applicationId),
 		},
 	})
 	if err != nil {
@@ -363,8 +352,7 @@ func (c *ApplicationsClient) ListOwners(ctx context.Context, id string) (*[]stri
 		},
 		ValidStatusCodes: []int{http.StatusOK},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/applications/%s/owners", id),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/applications/%s/owners", id),
 		},
 	})
 	if err != nil {
@@ -405,8 +393,7 @@ func (c *ApplicationsClient) GetOwner(ctx context.Context, applicationId, ownerI
 		},
 		ValidStatusCodes: []int{http.StatusOK},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/applications/%s/owners/%s/$ref", applicationId, ownerId),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/applications/%s/owners/%s/$ref", applicationId, ownerId),
 		},
 	})
 	if err != nil {
@@ -464,8 +451,7 @@ func (c *ApplicationsClient) AddOwners(ctx context.Context, application *Applica
 			ValidStatusCodes:       []int{http.StatusNoContent},
 			ValidStatusFunc:        checkOwnerAlreadyExists,
 			Uri: Uri{
-				Entity:      fmt.Sprintf("/applications/%s/owners/$ref", *application.ID()),
-				HasTenantId: true,
+				Entity: fmt.Sprintf("/applications/%s/owners/$ref", *application.ID()),
 			},
 		})
 		if err != nil {
@@ -509,8 +495,7 @@ func (c *ApplicationsClient) RemoveOwners(ctx context.Context, applicationId str
 			ValidStatusCodes:       []int{http.StatusNoContent},
 			ValidStatusFunc:        checkOwnerGone,
 			Uri: Uri{
-				Entity:      fmt.Sprintf("/applications/%s/owners/%s/$ref", applicationId, ownerId),
-				HasTenantId: true,
+				Entity: fmt.Sprintf("/applications/%s/owners/%s/$ref", applicationId, ownerId),
 			},
 		})
 		if err != nil {
@@ -527,8 +512,7 @@ func (c *ApplicationsClient) ListExtensions(ctx context.Context, id string, quer
 		OData:                  query,
 		ValidStatusCodes:       []int{http.StatusOK},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/applications/%s/extensionProperties", id),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/applications/%s/extensionProperties", id),
 		},
 	})
 	if err != nil {
@@ -564,8 +548,7 @@ func (c *ApplicationsClient) CreateExtension(ctx context.Context, applicationExt
 		Body:             body,
 		ValidStatusCodes: []int{http.StatusCreated},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/applications/%s/extensionProperties", id),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/applications/%s/extensionProperties", id),
 		},
 	})
 	if err != nil {
@@ -592,8 +575,7 @@ func (c *ApplicationsClient) DeleteExtension(ctx context.Context, applicationId,
 		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
 		ValidStatusCodes:       []int{http.StatusNoContent},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/applications/%s/extensionProperties/%s", applicationId, extensionId),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/applications/%s/extensionProperties/%s", applicationId, extensionId),
 		},
 	})
 	if err != nil {
@@ -613,8 +595,7 @@ func (c *ApplicationsClient) UploadLogo(ctx context.Context, applicationId, cont
 		ContentType:            contentType,
 		ValidStatusCodes:       []int{http.StatusNoContent},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/applications/%s/logo", applicationId),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/applications/%s/logo", applicationId),
 		},
 	})
 	if err != nil {
@@ -631,8 +612,7 @@ func (c *ApplicationsClient) ListFederatedIdentityCredentials(ctx context.Contex
 		OData:                  query,
 		ValidStatusCodes:       []int{http.StatusOK},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/applications/%s/federatedIdentityCredentials", applicationId),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/applications/%s/federatedIdentityCredentials", applicationId),
 		},
 	})
 	if err != nil {
@@ -662,8 +642,7 @@ func (c *ApplicationsClient) GetFederatedIdentityCredential(ctx context.Context,
 		OData:                  query,
 		ValidStatusCodes:       []int{http.StatusOK},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/applications/%s/federatedIdentityCredentials/%s", applicationId, credentialId),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/applications/%s/federatedIdentityCredentials/%s", applicationId, credentialId),
 		},
 	})
 	if err != nil {
@@ -697,8 +676,7 @@ func (c *ApplicationsClient) CreateFederatedIdentityCredential(ctx context.Conte
 		Body:             body,
 		ValidStatusCodes: []int{http.StatusCreated},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/applications/%s/federatedIdentityCredentials", applicationId),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/applications/%s/federatedIdentityCredentials", applicationId),
 		},
 	})
 	if err != nil {
@@ -736,8 +714,7 @@ func (c *ApplicationsClient) UpdateFederatedIdentityCredential(ctx context.Conte
 		Body:             body,
 		ValidStatusCodes: []int{http.StatusNoContent},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/applications/%s/federatedIdentityCredentials/%s", applicationId, *credential.ID),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/applications/%s/federatedIdentityCredentials/%s", applicationId, *credential.ID),
 		},
 	})
 	if err != nil {
@@ -753,8 +730,7 @@ func (c *ApplicationsClient) DeleteFederatedIdentityCredential(ctx context.Conte
 		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
 		ValidStatusCodes:       []int{http.StatusNoContent},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/applications/%s/federatedIdentityCredentials/%s", applicationId, credentialId),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/applications/%s/federatedIdentityCredentials/%s", applicationId, credentialId),
 		},
 	})
 	if err != nil {

--- a/msgraph/applications.go
+++ b/msgraph/applications.go
@@ -17,7 +17,7 @@ type ApplicationsClient struct {
 }
 
 // NewApplicationsClient returns a new ApplicationsClient
-func NewApplicationsClient(tenantId string) *ApplicationsClient {
+func NewApplicationsClient() *ApplicationsClient {
 	return &ApplicationsClient{
 		BaseClient: NewClient(VersionBeta),
 	}

--- a/msgraph/authentication_methods.go
+++ b/msgraph/authentication_methods.go
@@ -19,7 +19,7 @@ type AuthenticationMethodsClient struct {
 // NewAuthenticationMethodsClient returns a new AuthenticationMethodsClient
 func NewAuthenticationMethodsClient(tenantId string) *AuthenticationMethodsClient {
 	return &AuthenticationMethodsClient{
-		BaseClient: NewClient(VersionBeta, tenantId),
+		BaseClient: NewClient(VersionBeta),
 	}
 }
 
@@ -30,8 +30,7 @@ func (c *AuthenticationMethodsClient) List(ctx context.Context, userID string, q
 		OData:            query,
 		ValidStatusCodes: []int{http.StatusOK},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/users/%s/authentication/methods", userID),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/users/%s/authentication/methods", userID),
 		},
 	})
 	if err != nil {
@@ -124,8 +123,7 @@ func (c *AuthenticationMethodsClient) ListFido2Methods(ctx context.Context, user
 		OData:            query,
 		ValidStatusCodes: []int{http.StatusOK},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/users/%s/authentication/fido2Methods", userID),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/users/%s/authentication/fido2Methods", userID),
 		},
 	})
 	if err != nil {
@@ -154,8 +152,7 @@ func (c *AuthenticationMethodsClient) GetFido2Method(ctx context.Context, userID
 		OData:                  query,
 		ValidStatusCodes:       []int{http.StatusOK},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/users/%s/authentication/fido2Methods/%s", userID, id),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/users/%s/authentication/fido2Methods/%s", userID, id),
 		},
 	})
 	if err != nil {
@@ -181,8 +178,7 @@ func (c *AuthenticationMethodsClient) DeleteFido2Method(ctx context.Context, use
 		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
 		ValidStatusCodes:       []int{http.StatusNoContent},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/users/%s/authentication/fido2Methods/%s", userID, id),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/users/%s/authentication/fido2Methods/%s", userID, id),
 		},
 	})
 	if err != nil {
@@ -198,8 +194,7 @@ func (c *AuthenticationMethodsClient) ListMicrosoftAuthenticatorMethods(ctx cont
 		OData:            query,
 		ValidStatusCodes: []int{http.StatusOK},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/users/%s/authentication/microsoftAuthenticatorMethods", userID),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/users/%s/authentication/microsoftAuthenticatorMethods", userID),
 		},
 	})
 	if err != nil {
@@ -228,8 +223,7 @@ func (c *AuthenticationMethodsClient) GetMicrosoftAuthenticatorMethod(ctx contex
 		OData:                  query,
 		ValidStatusCodes:       []int{http.StatusOK},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/users/%s/authentication/microsoftAuthenticatorMethods/%s", userID, id),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/users/%s/authentication/microsoftAuthenticatorMethods/%s", userID, id),
 		},
 	})
 	if err != nil {
@@ -255,8 +249,7 @@ func (c *AuthenticationMethodsClient) DeleteMicrosoftAuthenticatorMethod(ctx con
 		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
 		ValidStatusCodes:       []int{http.StatusNoContent},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/users/%s/authentication/microsoftAuthenticatorMethods/%s", userID, id),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/users/%s/authentication/microsoftAuthenticatorMethods/%s", userID, id),
 		},
 	})
 	if err != nil {
@@ -272,8 +265,7 @@ func (c *AuthenticationMethodsClient) ListWindowsHelloMethods(ctx context.Contex
 		OData:            query,
 		ValidStatusCodes: []int{http.StatusOK},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/users/%s/authentication/windowsHelloForBusinessMethods", userID),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/users/%s/authentication/windowsHelloForBusinessMethods", userID),
 		},
 	})
 	if err != nil {
@@ -302,8 +294,7 @@ func (c *AuthenticationMethodsClient) GetWindowsHelloMethod(ctx context.Context,
 		OData:                  query,
 		ValidStatusCodes:       []int{http.StatusOK},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/users/%s/authentication/windowsHelloForBusinessMethods/%s", userID, id),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/users/%s/authentication/windowsHelloForBusinessMethods/%s", userID, id),
 		},
 	})
 	if err != nil {
@@ -329,8 +320,7 @@ func (c *AuthenticationMethodsClient) DeleteWindowsHelloMethod(ctx context.Conte
 		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
 		ValidStatusCodes:       []int{http.StatusNoContent},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/users/%s/authentication/windowsHelloForBusinessMethods/%s", userID, id),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/users/%s/authentication/windowsHelloForBusinessMethods/%s", userID, id),
 		},
 	})
 	if err != nil {
@@ -346,8 +336,7 @@ func (c *AuthenticationMethodsClient) ListTemporaryAccessPassMethods(ctx context
 		OData:            query,
 		ValidStatusCodes: []int{http.StatusOK},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/users/%s/authentication/temporaryAccessPassMethods", userID),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/users/%s/authentication/temporaryAccessPassMethods", userID),
 		},
 	})
 	if err != nil {
@@ -376,8 +365,7 @@ func (c *AuthenticationMethodsClient) GetTemporaryAccessPassMethod(ctx context.C
 		OData:                  query,
 		ValidStatusCodes:       []int{http.StatusOK},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/users/%s/authentication/temporaryAccessPassMethods/%s", userID, id),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/users/%s/authentication/temporaryAccessPassMethods/%s", userID, id),
 		},
 	})
 	if err != nil {
@@ -411,8 +399,7 @@ func (c *AuthenticationMethodsClient) CreateTemporaryAccessPassMethod(ctx contex
 		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
 		ValidStatusCodes:       []int{http.StatusCreated},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/users/%s/authentication/temporaryAccessPassMethods", userID),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/users/%s/authentication/temporaryAccessPassMethods", userID),
 		},
 	})
 	if err != nil {
@@ -438,8 +425,7 @@ func (c *AuthenticationMethodsClient) DeleteTemporaryAccessPassMethod(ctx contex
 		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
 		ValidStatusCodes:       []int{http.StatusNoContent},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/users/%s/authentication/temporaryAccessPassMethods/%s", userID, id),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/users/%s/authentication/temporaryAccessPassMethods/%s", userID, id),
 		},
 	})
 	if err != nil {
@@ -455,8 +441,7 @@ func (c *AuthenticationMethodsClient) ListPhoneMethods(ctx context.Context, user
 		OData:            query,
 		ValidStatusCodes: []int{http.StatusOK},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/users/%s/authentication/phoneMethods", userID),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/users/%s/authentication/phoneMethods", userID),
 		},
 	})
 	if err != nil {
@@ -485,8 +470,7 @@ func (c *AuthenticationMethodsClient) GetPhoneMethod(ctx context.Context, userID
 		OData:                  query,
 		ValidStatusCodes:       []int{http.StatusOK},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/users/%s/authentication/phoneMethods/%s", userID, id),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/users/%s/authentication/phoneMethods/%s", userID, id),
 		},
 	})
 	if err != nil {
@@ -520,8 +504,7 @@ func (c *AuthenticationMethodsClient) CreatePhoneMethod(ctx context.Context, use
 		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
 		ValidStatusCodes:       []int{http.StatusCreated},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/users/%s/authentication/phoneMethods", userID),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/users/%s/authentication/phoneMethods", userID),
 		},
 	})
 	if err != nil {
@@ -547,8 +530,7 @@ func (c *AuthenticationMethodsClient) DeletePhoneMethod(ctx context.Context, use
 		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
 		ValidStatusCodes:       []int{http.StatusNoContent},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/users/%s/authentication/phoneMethods/%s", userID, id),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/users/%s/authentication/phoneMethods/%s", userID, id),
 		},
 	})
 	if err != nil {
@@ -575,8 +557,7 @@ func (c *AuthenticationMethodsClient) UpdatePhoneMethod(ctx context.Context, use
 		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
 		ValidStatusCodes:       []int{http.StatusOK},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/users/%s/authentication/phoneMethods/%s", userID, *phone.ID),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/users/%s/authentication/phoneMethods/%s", userID, *phone.ID),
 		},
 	})
 	if err != nil {
@@ -593,8 +574,7 @@ func (c *AuthenticationMethodsClient) EnablePhoneSMS(ctx context.Context, userID
 		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
 		ValidStatusCodes:       []int{http.StatusNoContent},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/users/%s/authentication/phoneMethods/%s/enableSmsSignIn", userID, id),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/users/%s/authentication/phoneMethods/%s/enableSmsSignIn", userID, id),
 		},
 	})
 	if err != nil {
@@ -611,8 +591,7 @@ func (c *AuthenticationMethodsClient) DisablePhoneSMS(ctx context.Context, userI
 		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
 		ValidStatusCodes:       []int{http.StatusNoContent},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/users/%s/authentication/phoneMethods/%s/disableSmsSignIn", userID, id),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/users/%s/authentication/phoneMethods/%s/disableSmsSignIn", userID, id),
 		},
 	})
 	if err != nil {
@@ -628,8 +607,7 @@ func (c *AuthenticationMethodsClient) ListEmailMethods(ctx context.Context, user
 		OData:            query,
 		ValidStatusCodes: []int{http.StatusOK},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/users/%s/authentication/emailMethods", userID),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/users/%s/authentication/emailMethods", userID),
 		},
 	})
 	if err != nil {
@@ -658,8 +636,7 @@ func (c *AuthenticationMethodsClient) GetEmailMethod(ctx context.Context, userID
 		OData:                  query,
 		ValidStatusCodes:       []int{http.StatusOK},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/users/%s/authentication/emailMethods/%s", userID, id),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/users/%s/authentication/emailMethods/%s", userID, id),
 		},
 	})
 	if err != nil {
@@ -697,8 +674,7 @@ func (c *AuthenticationMethodsClient) UpdateEmailMethod(ctx context.Context, use
 		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
 		ValidStatusCodes:       []int{http.StatusOK},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/users/%s/authentication/emailMethods/%s", userID, *email.ID),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/users/%s/authentication/emailMethods/%s", userID, *email.ID),
 		},
 	})
 	if err != nil {
@@ -713,8 +689,7 @@ func (c *AuthenticationMethodsClient) DeleteEmailMethod(ctx context.Context, use
 		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
 		ValidStatusCodes:       []int{http.StatusNoContent},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/users/%s/authentication/emailMethods/%s", userID, id),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/users/%s/authentication/emailMethods/%s", userID, id),
 		},
 	})
 	if err != nil {
@@ -737,8 +712,7 @@ func (c *AuthenticationMethodsClient) CreateEmailMethod(ctx context.Context, use
 		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
 		ValidStatusCodes:       []int{http.StatusCreated},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/users/%s/authentication/emailMethods", userID),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/users/%s/authentication/emailMethods", userID),
 		},
 	})
 	if err != nil {
@@ -765,8 +739,7 @@ func (c *AuthenticationMethodsClient) ListPasswordMethods(ctx context.Context, u
 		OData:            query,
 		ValidStatusCodes: []int{http.StatusOK},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/users/%s/authentication/passwordMethods", userID),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/users/%s/authentication/passwordMethods", userID),
 		},
 	})
 	if err != nil {
@@ -794,9 +767,7 @@ func (c *AuthenticationMethodsClient) GetPasswordMethod(ctx context.Context, use
 		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
 		OData:                  query,
 		ValidStatusCodes:       []int{http.StatusOK},
-		Uri: Uri{
-			HasTenantId: true,
-		},
+		Uri:                    Uri{},
 	})
 	if err != nil {
 		return nil, status, fmt.Errorf("AuthenticationMethodsClient.BaseClient.Get(): %v", err)

--- a/msgraph/authentication_methods.go
+++ b/msgraph/authentication_methods.go
@@ -17,7 +17,7 @@ type AuthenticationMethodsClient struct {
 }
 
 // NewAuthenticationMethodsClient returns a new AuthenticationMethodsClient
-func NewAuthenticationMethodsClient(tenantId string) *AuthenticationMethodsClient {
+func NewAuthenticationMethodsClient() *AuthenticationMethodsClient {
 	return &AuthenticationMethodsClient{
 		BaseClient: NewClient(VersionBeta),
 	}

--- a/msgraph/b2c_userflow.go
+++ b/msgraph/b2c_userflow.go
@@ -18,7 +18,7 @@ type B2CUserFlowClient struct {
 // NewB2CUserFlowClient returns a new B2CUserFlowClient.
 func NewB2CUserFlowClient(tenantId string) *B2CUserFlowClient {
 	return &B2CUserFlowClient{
-		BaseClient: NewClient(VersionBeta, tenantId),
+		BaseClient: NewClient(VersionBeta),
 	}
 }
 
@@ -28,8 +28,7 @@ func (c *B2CUserFlowClient) List(ctx context.Context, query odata.Query) (*[]B2C
 		OData:            query,
 		ValidStatusCodes: []int{http.StatusOK},
 		Uri: Uri{
-			Entity:      "/identity/b2cUserFlows",
-			HasTenantId: true,
+			Entity: "/identity/b2cUserFlows",
 		},
 	})
 	if err != nil {
@@ -68,8 +67,7 @@ func (c *B2CUserFlowClient) Create(ctx context.Context, userflow B2CUserFlow) (*
 		},
 		ValidStatusCodes: []int{http.StatusCreated},
 		Uri: Uri{
-			Entity:      "/identity/b2cUserFlows",
-			HasTenantId: true,
+			Entity: "/identity/b2cUserFlows",
 		},
 	})
 	if err != nil {
@@ -97,8 +95,7 @@ func (c *B2CUserFlowClient) Get(ctx context.Context, id string, query odata.Quer
 		OData:                  query,
 		ValidStatusCodes:       []int{http.StatusOK},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/identity/b2cUserFlows/%s", id),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/identity/b2cUserFlows/%s", id),
 		},
 	})
 	if err != nil {
@@ -142,8 +139,7 @@ func (c *B2CUserFlowClient) Update(ctx context.Context, userflow B2CUserFlow) (i
 			http.StatusNoContent,
 		},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/identity/b2cUserFlows//%s", userflowID),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/identity/b2cUserFlows//%s", userflowID),
 		},
 	})
 	if err != nil {
@@ -159,8 +155,7 @@ func (c *B2CUserFlowClient) Delete(ctx context.Context, id string) (int, error) 
 		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
 		ValidStatusCodes:       []int{http.StatusNoContent},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/identity/b2cUserFlows/%s", id),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/identity/b2cUserFlows/%s", id),
 		},
 	})
 	if err != nil {

--- a/msgraph/b2c_userflow.go
+++ b/msgraph/b2c_userflow.go
@@ -16,7 +16,7 @@ type B2CUserFlowClient struct {
 }
 
 // NewB2CUserFlowClient returns a new B2CUserFlowClient.
-func NewB2CUserFlowClient(tenantId string) *B2CUserFlowClient {
+func NewB2CUserFlowClient() *B2CUserFlowClient {
 	return &B2CUserFlowClient{
 		BaseClient: NewClient(VersionBeta),
 	}

--- a/msgraph/claims_mapping_policy.go
+++ b/msgraph/claims_mapping_policy.go
@@ -15,7 +15,7 @@ type ClaimsMappingPolicyClient struct {
 }
 
 // NewClaimsMappingPolicyClient returns a new ClaimsMappingPolicyClient
-func NewClaimsMappingPolicyClient(tenantId string) *ClaimsMappingPolicyClient {
+func NewClaimsMappingPolicyClient() *ClaimsMappingPolicyClient {
 	return &ClaimsMappingPolicyClient{
 		BaseClient: NewClient(Version10),
 	}

--- a/msgraph/claims_mapping_policy.go
+++ b/msgraph/claims_mapping_policy.go
@@ -17,7 +17,7 @@ type ClaimsMappingPolicyClient struct {
 // NewClaimsMappingPolicyClient returns a new ClaimsMappingPolicyClient
 func NewClaimsMappingPolicyClient(tenantId string) *ClaimsMappingPolicyClient {
 	return &ClaimsMappingPolicyClient{
-		BaseClient: NewClient(Version10, tenantId),
+		BaseClient: NewClient(Version10),
 	}
 }
 
@@ -35,8 +35,7 @@ func (c *ClaimsMappingPolicyClient) Create(ctx context.Context, policy ClaimsMap
 		OData:            odata.Query{Metadata: odata.MetadataFull},
 		ValidStatusCodes: []int{http.StatusCreated},
 		Uri: Uri{
-			Entity:      "/policies/claimsMappingPolicies",
-			HasTenantId: false,
+			Entity: "/policies/claimsMappingPolicies",
 		},
 	})
 	if err != nil {
@@ -66,8 +65,7 @@ func (c *ClaimsMappingPolicyClient) List(ctx context.Context, query odata.Query)
 		OData:            query,
 		ValidStatusCodes: []int{http.StatusOK},
 		Uri: Uri{
-			Entity:      "/policies/claimsMappingPolicies",
-			HasTenantId: false,
+			Entity: "/policies/claimsMappingPolicies",
 		},
 	})
 	if err != nil {
@@ -99,8 +97,7 @@ func (c *ClaimsMappingPolicyClient) Get(ctx context.Context, id string, query od
 		OData:                  query,
 		ValidStatusCodes:       []int{http.StatusOK},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/policies/claimsMappingPolicies/%s", id),
-			HasTenantId: false,
+			Entity: fmt.Sprintf("/policies/claimsMappingPolicies/%s", id),
 		},
 	})
 	if err != nil {
@@ -146,8 +143,7 @@ func (c *ClaimsMappingPolicyClient) Update(ctx context.Context, claimsMappingPol
 			http.StatusNoContent,
 		},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/policies/claimsMappingPolicies/%s", claimsMappingPolicyId),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/policies/claimsMappingPolicies/%s", claimsMappingPolicyId),
 		},
 	})
 	if err != nil {
@@ -163,8 +159,7 @@ func (c *ClaimsMappingPolicyClient) Delete(ctx context.Context, id string) (int,
 		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
 		ValidStatusCodes:       []int{http.StatusNoContent},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/policies/claimsMappingPolicies/%s", id),
-			HasTenantId: false,
+			Entity: fmt.Sprintf("/policies/claimsMappingPolicies/%s", id),
 		},
 	})
 	if err != nil {

--- a/msgraph/client.go
+++ b/msgraph/client.go
@@ -51,9 +51,8 @@ type HttpRequestInput interface {
 
 // Uri represents a Microsoft Graph endpoint.
 type Uri struct {
-	Entity      string
-	Params      url.Values
-	HasTenantId bool
+	Entity string
+	Params url.Values
 }
 
 // RetryableErrorHandler ensures that the response is returned after exhausting retries for a request
@@ -70,9 +69,6 @@ type Client struct {
 
 	// ApiVersion is the Microsoft Graph API version to use.
 	ApiVersion ApiVersion
-
-	// TenantId is the tenant ID to use in requests.
-	TenantId string
 
 	// UserAgent is the HTTP user agent string to send in requests.
 	UserAgent string
@@ -96,7 +92,7 @@ type Client struct {
 }
 
 // NewClient returns a new Client configured with the specified API version and tenant ID.
-func NewClient(apiVersion ApiVersion, tenantId string) Client {
+func NewClient(apiVersion ApiVersion) Client {
 	r := retryablehttp.NewClient()
 	r.ErrorHandler = RetryableErrorHandler
 	r.Logger = nil
@@ -109,7 +105,6 @@ func NewClient(apiVersion ApiVersion, tenantId string) Client {
 	return Client{
 		Endpoint:        endpoint,
 		ApiVersion:      apiVersion,
-		TenantId:        tenantId,
 		UserAgent:       "Hamilton (Go-http-client/1.1)",
 		HttpClient:      r.StandardClient(),
 		RetryableClient: r,
@@ -123,9 +118,6 @@ func (c Client) buildUri(uri Uri) (string, error) {
 		return "", err
 	}
 	newUrl.Path = "/" + string(c.ApiVersion)
-	if uri.HasTenantId {
-		newUrl.Path = fmt.Sprintf("%s/%s", newUrl.Path, c.TenantId)
-	}
 	newUrl.Path = fmt.Sprintf("%s/%s", newUrl.Path, strings.TrimLeft(uri.Entity, "/"))
 	if uri.Params != nil {
 		newUrl.RawQuery = uri.Params.Encode()

--- a/msgraph/conditionalaccesspolicy.go
+++ b/msgraph/conditionalaccesspolicy.go
@@ -17,7 +17,7 @@ type ConditionalAccessPoliciesClient struct {
 }
 
 // NewConditionalAccessPoliciesClient returns a new ConditionalAccessPoliciesClient
-func NewConditionalAccessPoliciesClient(tenantId string) *ConditionalAccessPoliciesClient {
+func NewConditionalAccessPoliciesClient() *ConditionalAccessPoliciesClient {
 	return &ConditionalAccessPoliciesClient{
 		BaseClient: NewClient(VersionBeta),
 	}

--- a/msgraph/conditionalaccesspolicy.go
+++ b/msgraph/conditionalaccesspolicy.go
@@ -19,7 +19,7 @@ type ConditionalAccessPoliciesClient struct {
 // NewConditionalAccessPoliciesClient returns a new ConditionalAccessPoliciesClient
 func NewConditionalAccessPoliciesClient(tenantId string) *ConditionalAccessPoliciesClient {
 	return &ConditionalAccessPoliciesClient{
-		BaseClient: NewClient(VersionBeta, tenantId),
+		BaseClient: NewClient(VersionBeta),
 	}
 }
 
@@ -30,8 +30,7 @@ func (c *ConditionalAccessPoliciesClient) List(ctx context.Context, query odata.
 		OData:            query,
 		ValidStatusCodes: []int{http.StatusOK},
 		Uri: Uri{
-			Entity:      "/identity/conditionalAccess/policies",
-			HasTenantId: true,
+			Entity: "/identity/conditionalAccess/policies",
 		},
 	})
 	if err != nil {
@@ -66,8 +65,7 @@ func (c *ConditionalAccessPoliciesClient) Create(ctx context.Context, conditiona
 		Body:             body,
 		ValidStatusCodes: []int{http.StatusCreated},
 		Uri: Uri{
-			Entity:      "/identity/conditionalAccess/policies",
-			HasTenantId: true,
+			Entity: "/identity/conditionalAccess/policies",
 		},
 	})
 	if err != nil {
@@ -95,8 +93,7 @@ func (c *ConditionalAccessPoliciesClient) Get(ctx context.Context, id string, qu
 		OData:                  query,
 		ValidStatusCodes:       []int{http.StatusOK},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/identity/conditionalAccess/policies/%s", id),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/identity/conditionalAccess/policies/%s", id),
 		},
 	})
 	if err != nil {
@@ -135,8 +132,7 @@ func (c *ConditionalAccessPoliciesClient) Update(ctx context.Context, conditiona
 		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
 		ValidStatusCodes:       []int{http.StatusNoContent},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/identity/conditionalAccess/policies/%s", *conditionalAccessPolicy.ID),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/identity/conditionalAccess/policies/%s", *conditionalAccessPolicy.ID),
 		},
 	})
 	if err != nil {
@@ -152,8 +148,7 @@ func (c *ConditionalAccessPoliciesClient) Delete(ctx context.Context, id string)
 		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
 		ValidStatusCodes:       []int{http.StatusNoContent},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/identity/conditionalAccess/policies/%s", id),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/identity/conditionalAccess/policies/%s", id),
 		},
 	})
 	if err != nil {

--- a/msgraph/connectedorganization.go
+++ b/msgraph/connectedorganization.go
@@ -18,7 +18,7 @@ type ConnectedOrganizationClient struct {
 
 func NewConnectedOrganizationClient(tenantId string) *ConnectedOrganizationClient {
 	return &ConnectedOrganizationClient{
-		BaseClient: NewClient(Version10, tenantId),
+		BaseClient: NewClient(Version10),
 	}
 }
 
@@ -30,8 +30,7 @@ func (c *ConnectedOrganizationClient) List(ctx context.Context, query odata.Quer
 		OData:            query,
 		ValidStatusCodes: []int{http.StatusOK},
 		Uri: Uri{
-			Entity:      "/identityGovernance/entitlementManagement/connectedOrganizations",
-			HasTenantId: true,
+			Entity: "/identityGovernance/entitlementManagement/connectedOrganizations",
 		},
 	})
 	if err != nil {
@@ -67,8 +66,7 @@ func (c *ConnectedOrganizationClient) Create(ctx context.Context, connectedOrgan
 		Body:             body,
 		ValidStatusCodes: []int{http.StatusCreated},
 		Uri: Uri{
-			Entity:      "/identityGovernance/entitlementManagement/connectedOrganizations",
-			HasTenantId: true,
+			Entity: "/identityGovernance/entitlementManagement/connectedOrganizations",
 		},
 	})
 	if err != nil {
@@ -97,8 +95,7 @@ func (c *ConnectedOrganizationClient) Get(ctx context.Context, id string, query 
 		OData:                  query,
 		ValidStatusCodes:       []int{http.StatusOK},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/identityGovernance/entitlementManagement/connectedOrganizations/%s", id),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/identityGovernance/entitlementManagement/connectedOrganizations/%s", id),
 		},
 	})
 	if err != nil {
@@ -145,8 +142,7 @@ func (c *ConnectedOrganizationClient) Update(ctx context.Context, connectedOrgan
 		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
 		ValidStatusCodes:       []int{http.StatusNoContent},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/identityGovernance/entitlementManagement/connectedOrganizations/%s", *connectedOrganization.ID),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/identityGovernance/entitlementManagement/connectedOrganizations/%s", *connectedOrganization.ID),
 		},
 	})
 	if err != nil {
@@ -163,8 +159,7 @@ func (c *ConnectedOrganizationClient) Delete(ctx context.Context, id string) (in
 		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
 		ValidStatusCodes:       []int{http.StatusNoContent},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/identityGovernance/entitlementManagement/connectedOrganizations/%s", id),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/identityGovernance/entitlementManagement/connectedOrganizations/%s", id),
 		},
 	})
 	if err != nil {
@@ -255,8 +250,7 @@ func addSponsor(client *Client, ctx context.Context, orgId string, userOrGroupId
 
 	_, status, _, err := client.Post(ctx, PostHttpRequestInput{
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/identityGovernance/entitlementManagement/connectedOrganizations/%s/%s/$ref", orgId, internalOrExternal),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/identityGovernance/entitlementManagement/connectedOrganizations/%s/%s/$ref", orgId, internalOrExternal),
 		},
 		ValidStatusCodes: []int{http.StatusNoContent},
 		Body:             body,
@@ -287,8 +281,7 @@ func listSponsors(c *Client, ctx context.Context, query odata.Query, id string, 
 		OData:            query,
 		ValidStatusCodes: []int{http.StatusOK},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/identityGovernance/entitlementManagement/connectedOrganizations/%s/%s", id, internalOrExternal),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/identityGovernance/entitlementManagement/connectedOrganizations/%s/%s", id, internalOrExternal),
 		},
 	})
 	if err != nil {
@@ -327,8 +320,7 @@ func deleteSponsor(c *Client, ctx context.Context, orgId string, id string, exte
 
 	_, status, _, err := c.Delete(ctx, DeleteHttpRequestInput{
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/identityGovernance/entitlementManagement/connectedOrganizations/%s/%s/%s/$ref", orgId, internalOrExternal, id),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/identityGovernance/entitlementManagement/connectedOrganizations/%s/%s/%s/$ref", orgId, internalOrExternal, id),
 		},
 		ValidStatusCodes: []int{http.StatusNoContent},
 	})

--- a/msgraph/connectedorganization.go
+++ b/msgraph/connectedorganization.go
@@ -16,7 +16,7 @@ type ConnectedOrganizationClient struct {
 	BaseClient Client
 }
 
-func NewConnectedOrganizationClient(tenantId string) *ConnectedOrganizationClient {
+func NewConnectedOrganizationClient() *ConnectedOrganizationClient {
 	return &ConnectedOrganizationClient{
 		BaseClient: NewClient(Version10),
 	}

--- a/msgraph/delegated_permission_grants_client.go
+++ b/msgraph/delegated_permission_grants_client.go
@@ -17,7 +17,7 @@ type DelegatedPermissionGrantsClient struct {
 }
 
 // NewDelegatedPermissionGrantsClient returns a new DelegatedPermissionGrantsClient
-func NewDelegatedPermissionGrantsClient(tenantId string) *DelegatedPermissionGrantsClient {
+func NewDelegatedPermissionGrantsClient() *DelegatedPermissionGrantsClient {
 	return &DelegatedPermissionGrantsClient{
 		BaseClient: NewClient(Version10),
 	}

--- a/msgraph/delegated_permission_grants_client.go
+++ b/msgraph/delegated_permission_grants_client.go
@@ -19,7 +19,7 @@ type DelegatedPermissionGrantsClient struct {
 // NewDelegatedPermissionGrantsClient returns a new DelegatedPermissionGrantsClient
 func NewDelegatedPermissionGrantsClient(tenantId string) *DelegatedPermissionGrantsClient {
 	return &DelegatedPermissionGrantsClient{
-		BaseClient: NewClient(Version10, tenantId),
+		BaseClient: NewClient(Version10),
 	}
 }
 
@@ -29,8 +29,7 @@ func (c *DelegatedPermissionGrantsClient) List(ctx context.Context, query odata.
 		OData:            query,
 		ValidStatusCodes: []int{http.StatusOK},
 		Uri: Uri{
-			Entity:      "/oauth2PermissionGrants",
-			HasTenantId: true,
+			Entity: "/oauth2PermissionGrants",
 		},
 	})
 	if err != nil {
@@ -82,8 +81,7 @@ func (c *DelegatedPermissionGrantsClient) Create(ctx context.Context, delegatedP
 		ConsistencyFailureFunc: consistencyFunc,
 		ValidStatusCodes:       []int{http.StatusCreated},
 		Uri: Uri{
-			Entity:      "/oauth2PermissionGrants",
-			HasTenantId: true,
+			Entity: "/oauth2PermissionGrants",
 		},
 	})
 	if err != nil {
@@ -110,8 +108,7 @@ func (c *DelegatedPermissionGrantsClient) Get(ctx context.Context, id string, qu
 		OData:            query,
 		ValidStatusCodes: []int{http.StatusOK},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/oauth2PermissionGrants/%s", id),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/oauth2PermissionGrants/%s", id),
 		},
 	})
 	if err != nil {
@@ -150,8 +147,7 @@ func (c *DelegatedPermissionGrantsClient) Update(ctx context.Context, delegatedP
 		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
 		ValidStatusCodes:       []int{http.StatusNoContent},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/oauth2PermissionGrants/%s", *delegatedPermissionGrant.Id),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/oauth2PermissionGrants/%s", *delegatedPermissionGrant.Id),
 		},
 	})
 	if err != nil {
@@ -167,8 +163,7 @@ func (c *DelegatedPermissionGrantsClient) Delete(ctx context.Context, id string)
 		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
 		ValidStatusCodes:       []int{http.StatusNoContent},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/oauth2PermissionGrants/%s", id),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/oauth2PermissionGrants/%s", id),
 		},
 	})
 	if err != nil {

--- a/msgraph/directory_audit_reports.go
+++ b/msgraph/directory_audit_reports.go
@@ -16,7 +16,7 @@ type DirectoryAuditReportsClient struct {
 }
 
 // NewDirectoryAuditReportsClient returns a new DirectoryAuditReportsClient.
-func NewDirectoryAuditReportsClient(tenantId string) *DirectoryAuditReportsClient {
+func NewDirectoryAuditReportsClient() *DirectoryAuditReportsClient {
 	return &DirectoryAuditReportsClient{
 		BaseClient: NewClient(VersionBeta),
 	}

--- a/msgraph/directory_audit_reports.go
+++ b/msgraph/directory_audit_reports.go
@@ -18,7 +18,7 @@ type DirectoryAuditReportsClient struct {
 // NewDirectoryAuditReportsClient returns a new DirectoryAuditReportsClient.
 func NewDirectoryAuditReportsClient(tenantId string) *DirectoryAuditReportsClient {
 	return &DirectoryAuditReportsClient{
-		BaseClient: NewClient(VersionBeta, tenantId),
+		BaseClient: NewClient(VersionBeta),
 	}
 }
 
@@ -29,8 +29,7 @@ func (c *DirectoryAuditReportsClient) List(ctx context.Context, query odata.Quer
 		OData:            query,
 		ValidStatusCodes: []int{http.StatusOK},
 		Uri: Uri{
-			Entity:      "/auditLogs/directoryAudits",
-			HasTenantId: true,
+			Entity: "/auditLogs/directoryAudits",
 		},
 	})
 	if err != nil {
@@ -60,8 +59,7 @@ func (c *DirectoryAuditReportsClient) Get(ctx context.Context, id string, query 
 		OData:                  query,
 		ValidStatusCodes:       []int{http.StatusOK},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/auditLogs/directoryAudits/%s", id),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/auditLogs/directoryAudits/%s", id),
 		},
 	})
 	if err != nil {

--- a/msgraph/directory_objects.go
+++ b/msgraph/directory_objects.go
@@ -17,7 +17,7 @@ type DirectoryObjectsClient struct {
 }
 
 // NewDirectoryObjectsClient returns a new DirectoryObjectsClient.
-func NewDirectoryObjectsClient(tenantId string) *DirectoryObjectsClient {
+func NewDirectoryObjectsClient() *DirectoryObjectsClient {
 	return &DirectoryObjectsClient{
 		BaseClient: NewClient(Version10),
 	}

--- a/msgraph/directory_objects.go
+++ b/msgraph/directory_objects.go
@@ -19,7 +19,7 @@ type DirectoryObjectsClient struct {
 // NewDirectoryObjectsClient returns a new DirectoryObjectsClient.
 func NewDirectoryObjectsClient(tenantId string) *DirectoryObjectsClient {
 	return &DirectoryObjectsClient{
-		BaseClient: NewClient(Version10, tenantId),
+		BaseClient: NewClient(Version10),
 	}
 }
 
@@ -32,8 +32,7 @@ func (c *DirectoryObjectsClient) Get(ctx context.Context, id string, query odata
 		OData:                  query,
 		ValidStatusCodes:       []int{http.StatusOK},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/directoryObjects/%s", id),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/directoryObjects/%s", id),
 		},
 	})
 	if err != nil {
@@ -74,8 +73,7 @@ func (c *DirectoryObjectsClient) GetByIds(ctx context.Context, ids []string, typ
 		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
 		ValidStatusCodes:       []int{http.StatusOK},
 		Uri: Uri{
-			Entity:      "/directoryObjects/getByIds",
-			HasTenantId: true,
+			Entity: "/directoryObjects/getByIds",
 		},
 	})
 	if err != nil {
@@ -116,8 +114,7 @@ func (c *DirectoryObjectsClient) Delete(ctx context.Context, id string) (int, er
 		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
 		ValidStatusCodes:       []int{http.StatusNoContent},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/directoryObjects/%s", id),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/directoryObjects/%s", id),
 		},
 	})
 	if err != nil {
@@ -146,8 +143,7 @@ func (c *DirectoryObjectsClient) GetMemberGroups(ctx context.Context, id string,
 		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
 		ValidStatusCodes:       []int{http.StatusOK},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/directoryObjects/%s/getMemberGroups", id),
-			HasTenantId: false,
+			Entity: fmt.Sprintf("/directoryObjects/%s/getMemberGroups", id),
 		},
 	})
 	if err != nil {
@@ -194,8 +190,7 @@ func (c *DirectoryObjectsClient) GetMemberObjects(ctx context.Context, id string
 		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
 		ValidStatusCodes:       []int{http.StatusOK},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/directoryObjects/%s/getMemberObjects", id),
-			HasTenantId: false,
+			Entity: fmt.Sprintf("/directoryObjects/%s/getMemberObjects", id),
 		},
 	})
 	if err != nil {

--- a/msgraph/directory_role_templates.go
+++ b/msgraph/directory_role_templates.go
@@ -16,7 +16,7 @@ type DirectoryRoleTemplatesClient struct {
 // NewDirectoryRoleTemplatesClient returns a new DirectoryRoleTemplatesClient
 func NewDirectoryRoleTemplatesClient(tenantId string) *DirectoryRoleTemplatesClient {
 	return &DirectoryRoleTemplatesClient{
-		BaseClient: NewClient(Version10, tenantId),
+		BaseClient: NewClient(Version10),
 	}
 }
 
@@ -25,8 +25,7 @@ func (c *DirectoryRoleTemplatesClient) List(ctx context.Context) (*[]DirectoryRo
 	resp, status, _, err := c.BaseClient.Get(ctx, GetHttpRequestInput{
 		ValidStatusCodes: []int{http.StatusOK},
 		Uri: Uri{
-			Entity:      "/directoryRoleTemplates",
-			HasTenantId: true,
+			Entity: "/directoryRoleTemplates",
 		},
 	})
 	if err != nil {
@@ -55,8 +54,7 @@ func (c *DirectoryRoleTemplatesClient) Get(ctx context.Context, id string) (*Dir
 		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
 		ValidStatusCodes:       []int{http.StatusOK},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/directoryRoleTemplates/%s", id),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/directoryRoleTemplates/%s", id),
 		},
 	})
 	if err != nil {

--- a/msgraph/directory_role_templates.go
+++ b/msgraph/directory_role_templates.go
@@ -14,7 +14,7 @@ type DirectoryRoleTemplatesClient struct {
 }
 
 // NewDirectoryRoleTemplatesClient returns a new DirectoryRoleTemplatesClient
-func NewDirectoryRoleTemplatesClient(tenantId string) *DirectoryRoleTemplatesClient {
+func NewDirectoryRoleTemplatesClient() *DirectoryRoleTemplatesClient {
 	return &DirectoryRoleTemplatesClient{
 		BaseClient: NewClient(Version10),
 	}

--- a/msgraph/directory_roles.go
+++ b/msgraph/directory_roles.go
@@ -17,7 +17,7 @@ type DirectoryRolesClient struct {
 }
 
 // NewDirectoryRolesClient returns a new DirectoryRolesClient
-func NewDirectoryRolesClient(tenantId string) *DirectoryRolesClient {
+func NewDirectoryRolesClient() *DirectoryRolesClient {
 	return &DirectoryRolesClient{
 		BaseClient: NewClient(Version10),
 	}

--- a/msgraph/directory_roles.go
+++ b/msgraph/directory_roles.go
@@ -19,7 +19,7 @@ type DirectoryRolesClient struct {
 // NewDirectoryRolesClient returns a new DirectoryRolesClient
 func NewDirectoryRolesClient(tenantId string) *DirectoryRolesClient {
 	return &DirectoryRolesClient{
-		BaseClient: NewClient(Version10, tenantId),
+		BaseClient: NewClient(Version10),
 	}
 }
 
@@ -28,8 +28,7 @@ func (c *DirectoryRolesClient) List(ctx context.Context) (*[]DirectoryRole, int,
 	resp, status, _, err := c.BaseClient.Get(ctx, GetHttpRequestInput{
 		ValidStatusCodes: []int{http.StatusOK},
 		Uri: Uri{
-			Entity:      "/directoryRoles",
-			HasTenantId: true,
+			Entity: "/directoryRoles",
 		},
 	})
 	if err != nil {
@@ -57,8 +56,7 @@ func (c *DirectoryRolesClient) Get(ctx context.Context, id string) (*DirectoryRo
 	resp, status, _, err := c.BaseClient.Get(ctx, GetHttpRequestInput{
 		ValidStatusCodes: []int{http.StatusOK},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/directoryRoles/%s", id),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/directoryRoles/%s", id),
 		},
 	})
 	if err != nil {
@@ -84,8 +82,7 @@ func (c *DirectoryRolesClient) GetByTemplateId(ctx context.Context, templateId s
 	resp, status, _, err := c.BaseClient.Get(ctx, GetHttpRequestInput{
 		ValidStatusCodes: []int{http.StatusOK},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/directoryRoles/roleTemplateId=%s", templateId),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/directoryRoles/roleTemplateId=%s", templateId),
 		},
 	})
 	if err != nil {
@@ -115,8 +112,7 @@ func (c *DirectoryRolesClient) ListMembers(ctx context.Context, id string) (*[]s
 		},
 		ValidStatusCodes: []int{http.StatusOK},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/directoryRoles/%s/members", id),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/directoryRoles/%s/members", id),
 		},
 	})
 	if err != nil {
@@ -178,8 +174,7 @@ func (c *DirectoryRolesClient) AddMembers(ctx context.Context, directoryRole *Di
 			ValidStatusCodes: []int{http.StatusNoContent},
 			ValidStatusFunc:  checkMemberAlreadyExists,
 			Uri: Uri{
-				Entity:      fmt.Sprintf("/directoryRoles/%s/members/$ref", *directoryRole.ID()),
-				HasTenantId: true,
+				Entity: fmt.Sprintf("/directoryRoles/%s/members/$ref", *directoryRole.ID()),
 			},
 		})
 		if err != nil {
@@ -213,8 +208,7 @@ func (c *DirectoryRolesClient) RemoveMembers(ctx context.Context, directoryRoleI
 		_, status, _, err = c.BaseClient.Delete(ctx, DeleteHttpRequestInput{
 			ValidStatusCodes: []int{http.StatusNoContent},
 			Uri: Uri{
-				Entity:      fmt.Sprintf("/directoryRoles/%s/members/%s/$ref", directoryRoleId, memberId),
-				HasTenantId: true,
+				Entity: fmt.Sprintf("/directoryRoles/%s/members/%s/$ref", directoryRoleId, memberId),
 			},
 		})
 		if err != nil {
@@ -235,8 +229,7 @@ func (c *DirectoryRolesClient) GetMember(ctx context.Context, directoryRoleId, m
 		},
 		ValidStatusCodes: []int{http.StatusOK},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/directoryRoles/%s/members/%s/$ref", directoryRoleId, memberId),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/directoryRoles/%s/members/%s/$ref", directoryRoleId, memberId),
 		},
 	})
 	if err != nil {
@@ -290,8 +283,7 @@ func (c *DirectoryRolesClient) Activate(ctx context.Context, roleTemplateID stri
 		ValidStatusCodes: []int{http.StatusCreated},
 		ValidStatusFunc:  checkRoleAlreadyActivated,
 		Uri: Uri{
-			Entity:      "/directoryRoles",
-			HasTenantId: true,
+			Entity: "/directoryRoles",
 		},
 	})
 	if err != nil {

--- a/msgraph/domains.go
+++ b/msgraph/domains.go
@@ -18,7 +18,7 @@ type DomainsClient struct {
 // NewDomainsClient returns a new DomainsClient.
 func NewDomainsClient(tenantId string) *DomainsClient {
 	return &DomainsClient{
-		BaseClient: NewClient(Version10, tenantId),
+		BaseClient: NewClient(Version10),
 	}
 }
 
@@ -29,8 +29,7 @@ func (c *DomainsClient) List(ctx context.Context, query odata.Query) (*[]Domain,
 		ValidStatusCodes: []int{http.StatusOK},
 		OData:            query,
 		Uri: Uri{
-			Entity:      "/domains",
-			HasTenantId: true,
+			Entity: "/domains",
 		},
 	})
 	if err != nil {
@@ -62,8 +61,7 @@ func (c *DomainsClient) Get(ctx context.Context, id string, query odata.Query) (
 		OData:                  query,
 		ValidStatusCodes:       []int{http.StatusOK},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/domains/%s", id),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/domains/%s", id),
 		},
 	})
 	if err != nil {

--- a/msgraph/domains.go
+++ b/msgraph/domains.go
@@ -16,7 +16,7 @@ type DomainsClient struct {
 }
 
 // NewDomainsClient returns a new DomainsClient.
-func NewDomainsClient(tenantId string) *DomainsClient {
+func NewDomainsClient() *DomainsClient {
 	return &DomainsClient{
 		BaseClient: NewClient(Version10),
 	}

--- a/msgraph/entitlement_role_assignments.go
+++ b/msgraph/entitlement_role_assignments.go
@@ -18,7 +18,7 @@ type EntitlementRoleAssignmentsClient struct {
 // NewEntitlementRoleAssignmentsClient returns a new EntitlementRoleAssignmentsClient
 func NewEntitlementRoleAssignmentsClient(tenantId string) *EntitlementRoleAssignmentsClient {
 	return &EntitlementRoleAssignmentsClient{
-		BaseClient: NewClient(Version10, tenantId),
+		BaseClient: NewClient(Version10),
 	}
 }
 
@@ -28,8 +28,7 @@ func (c *EntitlementRoleAssignmentsClient) List(ctx context.Context, query odata
 		OData:            query,
 		ValidStatusCodes: []int{http.StatusOK},
 		Uri: Uri{
-			Entity:      "/roleManagement/entitlementManagement/roleAssignments",
-			HasTenantId: true,
+			Entity: "/roleManagement/entitlementManagement/roleAssignments",
 		},
 	})
 	if err != nil {
@@ -59,8 +58,7 @@ func (c *EntitlementRoleAssignmentsClient) Get(ctx context.Context, id string, q
 		OData:                  query,
 		ValidStatusCodes:       []int{http.StatusOK},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/roleManagement/entitlementManagement/roleAssignments/%s", id),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/roleManagement/entitlementManagement/roleAssignments/%s", id),
 		},
 	})
 	if err != nil {
@@ -94,8 +92,7 @@ func (c *EntitlementRoleAssignmentsClient) Create(ctx context.Context, roleAssig
 		Body:             body,
 		ValidStatusCodes: []int{http.StatusOK},
 		Uri: Uri{
-			Entity:      "/roleManagement/entitlementManagement/roleAssignments",
-			HasTenantId: true,
+			Entity: "/roleManagement/entitlementManagement/roleAssignments",
 		},
 	})
 	if err != nil {
@@ -122,8 +119,7 @@ func (c *EntitlementRoleAssignmentsClient) Delete(ctx context.Context, id string
 		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
 		ValidStatusCodes:       []int{http.StatusNoContent},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/roleManagement/entitlementManagement/roleAssignments/%s", id),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/roleManagement/entitlementManagement/roleAssignments/%s", id),
 		},
 	})
 	if err != nil {

--- a/msgraph/entitlement_role_assignments.go
+++ b/msgraph/entitlement_role_assignments.go
@@ -16,7 +16,7 @@ type EntitlementRoleAssignmentsClient struct {
 }
 
 // NewEntitlementRoleAssignmentsClient returns a new EntitlementRoleAssignmentsClient
-func NewEntitlementRoleAssignmentsClient(tenantId string) *EntitlementRoleAssignmentsClient {
+func NewEntitlementRoleAssignmentsClient() *EntitlementRoleAssignmentsClient {
 	return &EntitlementRoleAssignmentsClient{
 		BaseClient: NewClient(Version10),
 	}

--- a/msgraph/entitlement_role_definitions.go
+++ b/msgraph/entitlement_role_definitions.go
@@ -16,7 +16,7 @@ type EntitlementRoleDefinitionsClient struct {
 }
 
 // NewEntitlementRoleDefinitionsClient returns a new EntitlementRoleDefinitionsClient
-func NewEntitlementRoleDefinitionsClient(tenantId string) *EntitlementRoleDefinitionsClient {
+func NewEntitlementRoleDefinitionsClient() *EntitlementRoleDefinitionsClient {
 	return &EntitlementRoleDefinitionsClient{
 		BaseClient: NewClient(Version10),
 	}

--- a/msgraph/entitlement_role_definitions.go
+++ b/msgraph/entitlement_role_definitions.go
@@ -18,7 +18,7 @@ type EntitlementRoleDefinitionsClient struct {
 // NewEntitlementRoleDefinitionsClient returns a new EntitlementRoleDefinitionsClient
 func NewEntitlementRoleDefinitionsClient(tenantId string) *EntitlementRoleDefinitionsClient {
 	return &EntitlementRoleDefinitionsClient{
-		BaseClient: NewClient(Version10, tenantId),
+		BaseClient: NewClient(Version10),
 	}
 }
 
@@ -28,8 +28,7 @@ func (c *EntitlementRoleDefinitionsClient) List(ctx context.Context, query odata
 		OData:            query,
 		ValidStatusCodes: []int{http.StatusOK},
 		Uri: Uri{
-			Entity:      "/roleManagement/entitlementManagement/roleDefinitions",
-			HasTenantId: true,
+			Entity: "/roleManagement/entitlementManagement/roleDefinitions",
 		},
 	})
 	if err != nil {
@@ -58,8 +57,7 @@ func (c *EntitlementRoleDefinitionsClient) Get(ctx context.Context, id string, q
 		OData:            query,
 		ValidStatusCodes: []int{http.StatusOK},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/roleManagement/entitlementManagement/roleDefinitions/%s", id),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/roleManagement/entitlementManagement/roleDefinitions/%s", id),
 		},
 	})
 	if err != nil {

--- a/msgraph/groups.go
+++ b/msgraph/groups.go
@@ -18,7 +18,7 @@ type GroupsClient struct {
 // NewGroupsClient returns a new GroupsClient.
 func NewGroupsClient(tenantId string) *GroupsClient {
 	return &GroupsClient{
-		BaseClient: NewClient(VersionBeta, tenantId),
+		BaseClient: NewClient(VersionBeta),
 	}
 }
 
@@ -29,8 +29,7 @@ func (c *GroupsClient) List(ctx context.Context, query odata.Query) (*[]Group, i
 		OData:            query,
 		ValidStatusCodes: []int{http.StatusOK},
 		Uri: Uri{
-			Entity:      "/groups",
-			HasTenantId: true,
+			Entity: "/groups",
 		},
 	})
 	if err != nil {
@@ -77,8 +76,7 @@ func (c *GroupsClient) Create(ctx context.Context, group Group) (*Group, int, er
 		},
 		ValidStatusCodes: []int{http.StatusCreated},
 		Uri: Uri{
-			Entity:      "/groups",
-			HasTenantId: true,
+			Entity: "/groups",
 		},
 	})
 	if err != nil {
@@ -106,8 +104,7 @@ func (c *GroupsClient) Get(ctx context.Context, id string, query odata.Query) (*
 		OData:                  query,
 		ValidStatusCodes:       []int{http.StatusOK},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/groups/%s", id),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/groups/%s", id),
 		},
 	})
 	if err != nil {
@@ -151,8 +148,7 @@ func (c *GroupsClient) GetWithSchemaExtensions(ctx context.Context, id string, q
 		OData:                  query,
 		ValidStatusCodes:       []int{http.StatusOK},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/groups/%s", id),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/groups/%s", id),
 		},
 	})
 	if err != nil {
@@ -180,8 +176,7 @@ func (c *GroupsClient) GetDeleted(ctx context.Context, id string, query odata.Qu
 		OData:                  query,
 		ValidStatusCodes:       []int{http.StatusOK},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/directory/deletedItems/%s", id),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/directory/deletedItems/%s", id),
 		},
 	})
 	if err != nil {
@@ -227,8 +222,7 @@ func (c *GroupsClient) Update(ctx context.Context, group Group) (int, error) {
 			http.StatusNoContent,
 		},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/groups/%s", groupId),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/groups/%s", groupId),
 		},
 	})
 	if err != nil {
@@ -244,8 +238,7 @@ func (c *GroupsClient) Delete(ctx context.Context, id string) (int, error) {
 		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
 		ValidStatusCodes:       []int{http.StatusNoContent},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/groups/%s", id),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/groups/%s", id),
 		},
 	})
 	if err != nil {
@@ -261,8 +254,7 @@ func (c *GroupsClient) DeletePermanently(ctx context.Context, id string) (int, e
 		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
 		ValidStatusCodes:       []int{http.StatusNoContent},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/directory/deletedItems/%s", id),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/directory/deletedItems/%s", id),
 		},
 	})
 	if err != nil {
@@ -279,8 +271,7 @@ func (c *GroupsClient) ListDeleted(ctx context.Context, query odata.Query) (*[]G
 		OData:            query,
 		ValidStatusCodes: []int{http.StatusOK},
 		Uri: Uri{
-			Entity:      "/directory/deleteditems/microsoft.graph.group",
-			HasTenantId: true,
+			Entity: "/directory/deleteditems/microsoft.graph.group",
 		},
 	})
 	if err != nil {
@@ -305,8 +296,7 @@ func (c *GroupsClient) RestoreDeleted(ctx context.Context, id string) (*Group, i
 		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
 		ValidStatusCodes:       []int{http.StatusOK},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/directory/deletedItems/%s/restore", id),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/directory/deletedItems/%s/restore", id),
 		},
 	})
 	if err != nil {
@@ -337,8 +327,7 @@ func (c *GroupsClient) ListMembers(ctx context.Context, id string) (*[]string, i
 		},
 		ValidStatusCodes: []int{http.StatusOK},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/groups/%s/members", id),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/groups/%s/members", id),
 		},
 	})
 	if err != nil {
@@ -379,8 +368,7 @@ func (c *GroupsClient) ListTransitiveMembers(ctx context.Context, id string) (*[
 		},
 		ValidStatusCodes: []int{http.StatusOK},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/groups/%s/transitiveMembers", id),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/groups/%s/transitiveMembers", id),
 		},
 	})
 	if err != nil {
@@ -422,8 +410,7 @@ func (c *GroupsClient) GetMember(ctx context.Context, groupId, memberId string) 
 		},
 		ValidStatusCodes: []int{http.StatusOK},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/groups/%s/members/%s/$ref", groupId, memberId),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/groups/%s/members/%s/$ref", groupId, memberId),
 		},
 	})
 	if err != nil {
@@ -478,8 +465,7 @@ func (c *GroupsClient) AddMembers(ctx context.Context, group *Group) (int, error
 			ValidStatusCodes:       []int{http.StatusNoContent},
 			ValidStatusFunc:        checkMemberAlreadyExists,
 			Uri: Uri{
-				Entity:      fmt.Sprintf("/groups/%s/members/$ref", *group.ID()),
-				HasTenantId: true,
+				Entity: fmt.Sprintf("/groups/%s/members/$ref", *group.ID()),
 			},
 		})
 		if err != nil {
@@ -523,8 +509,7 @@ func (c *GroupsClient) RemoveMembers(ctx context.Context, id string, memberIds *
 			ValidStatusCodes:       []int{http.StatusNoContent},
 			ValidStatusFunc:        checkMemberGone,
 			Uri: Uri{
-				Entity:      fmt.Sprintf("/groups/%s/members/%s/$ref", id, memberId),
-				HasTenantId: true,
+				Entity: fmt.Sprintf("/groups/%s/members/%s/$ref", id, memberId),
 			},
 		})
 		if err != nil {
@@ -545,8 +530,7 @@ func (c *GroupsClient) ListOwners(ctx context.Context, id string) (*[]string, in
 		},
 		ValidStatusCodes: []int{http.StatusOK},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/groups/%s/owners", id),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/groups/%s/owners", id),
 		},
 	})
 	if err != nil {
@@ -588,8 +572,7 @@ func (c *GroupsClient) GetOwner(ctx context.Context, groupId, ownerId string) (*
 		},
 		ValidStatusCodes: []int{http.StatusOK},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/groups/%s/owners/%s/$ref", groupId, ownerId),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/groups/%s/owners/%s/$ref", groupId, ownerId),
 		},
 	})
 	if err != nil {
@@ -644,8 +627,7 @@ func (c *GroupsClient) AddOwners(ctx context.Context, group *Group) (int, error)
 			ValidStatusCodes:       []int{http.StatusNoContent},
 			ValidStatusFunc:        checkOwnerAlreadyExists,
 			Uri: Uri{
-				Entity:      fmt.Sprintf("/groups/%s/owners/$ref", *group.ID()),
-				HasTenantId: true,
+				Entity: fmt.Sprintf("/groups/%s/owners/$ref", *group.ID()),
 			},
 		})
 		if err != nil {
@@ -689,8 +671,7 @@ func (c *GroupsClient) RemoveOwners(ctx context.Context, id string, ownerIds *[]
 			ValidStatusCodes:       []int{http.StatusNoContent},
 			ValidStatusFunc:        checkOwnerGone,
 			Uri: Uri{
-				Entity:      fmt.Sprintf("/groups/%s/owners/%s/$ref", id, ownerId),
-				HasTenantId: true,
+				Entity: fmt.Sprintf("/groups/%s/owners/%s/$ref", id, ownerId),
 			},
 		})
 		if err != nil {
@@ -709,8 +690,7 @@ func (c *GroupsClient) ListAdministrativeUnitMemberships(ctx context.Context, id
 		},
 		ValidStatusCodes: []int{http.StatusOK},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/groups/%s/memberOf/microsoft.graph.administrativeUnit", id),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/groups/%s/memberOf/microsoft.graph.administrativeUnit", id),
 		},
 	})
 	if err != nil {

--- a/msgraph/groups.go
+++ b/msgraph/groups.go
@@ -16,7 +16,7 @@ type GroupsClient struct {
 }
 
 // NewGroupsClient returns a new GroupsClient.
-func NewGroupsClient(tenantId string) *GroupsClient {
+func NewGroupsClient() *GroupsClient {
 	return &GroupsClient{
 		BaseClient: NewClient(VersionBeta),
 	}

--- a/msgraph/identity_providers.go
+++ b/msgraph/identity_providers.go
@@ -15,7 +15,7 @@ type IdentityProvidersClient struct {
 }
 
 // NewIdentityProvidersClient returns a new IdentityProvidersClient
-func NewIdentityProvidersClient(tenantId string) *IdentityProvidersClient {
+func NewIdentityProvidersClient() *IdentityProvidersClient {
 	return &IdentityProvidersClient{
 		BaseClient: NewClient(VersionBeta),
 	}

--- a/msgraph/identity_providers.go
+++ b/msgraph/identity_providers.go
@@ -17,7 +17,7 @@ type IdentityProvidersClient struct {
 // NewIdentityProvidersClient returns a new IdentityProvidersClient
 func NewIdentityProvidersClient(tenantId string) *IdentityProvidersClient {
 	return &IdentityProvidersClient{
-		BaseClient: NewClient(VersionBeta, tenantId),
+		BaseClient: NewClient(VersionBeta),
 	}
 }
 
@@ -26,8 +26,7 @@ func (c *IdentityProvidersClient) List(ctx context.Context) (*[]IdentityProvider
 	resp, status, _, err := c.BaseClient.Get(ctx, GetHttpRequestInput{
 		ValidStatusCodes: []int{http.StatusOK},
 		Uri: Uri{
-			Entity:      "/identity/identityProviders",
-			HasTenantId: true,
+			Entity: "/identity/identityProviders",
 		},
 	})
 	if err != nil {
@@ -63,8 +62,7 @@ func (c *IdentityProvidersClient) Create(ctx context.Context, provider IdentityP
 		Body:             body,
 		ValidStatusCodes: []int{http.StatusCreated},
 		Uri: Uri{
-			Entity:      "/identity/identityProviders",
-			HasTenantId: true,
+			Entity: "/identity/identityProviders",
 		},
 	})
 	if err != nil {
@@ -91,8 +89,7 @@ func (c *IdentityProvidersClient) Get(ctx context.Context, id string) (*Identity
 		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
 		ValidStatusCodes:       []int{http.StatusOK},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/identity/identityProviders/%s", id),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/identity/identityProviders/%s", id),
 		},
 	})
 	if err != nil {
@@ -131,8 +128,7 @@ func (c *IdentityProvidersClient) Update(ctx context.Context, provider IdentityP
 		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
 		ValidStatusCodes:       []int{http.StatusNoContent},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/identity/identityProviders/%s", *provider.ID),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/identity/identityProviders/%s", *provider.ID),
 		},
 	})
 	if err != nil {
@@ -148,8 +144,7 @@ func (c *IdentityProvidersClient) Delete(ctx context.Context, id string) (int, e
 		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
 		ValidStatusCodes:       []int{http.StatusNoContent},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/identity/identityProviders/%s", id),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/identity/identityProviders/%s", id),
 		},
 	})
 	if err != nil {
@@ -164,8 +159,7 @@ func (c *IdentityProvidersClient) ListAvailableProviderTypes(ctx context.Context
 	resp, status, _, err := c.BaseClient.Get(ctx, GetHttpRequestInput{
 		ValidStatusCodes: []int{http.StatusOK},
 		Uri: Uri{
-			Entity:      "/identity/identityProviders/availableProviderTypes",
-			HasTenantId: true,
+			Entity: "/identity/identityProviders/availableProviderTypes",
 		},
 	})
 	if err != nil {

--- a/msgraph/invitations.go
+++ b/msgraph/invitations.go
@@ -14,7 +14,7 @@ type InvitationsClient struct {
 }
 
 // NewInvitationsClient returns a new InvitationsClient.
-func NewInvitationsClient(tenantId string) *InvitationsClient {
+func NewInvitationsClient() *InvitationsClient {
 	return &InvitationsClient{
 		BaseClient: NewClient(VersionBeta),
 	}

--- a/msgraph/invitations.go
+++ b/msgraph/invitations.go
@@ -16,7 +16,7 @@ type InvitationsClient struct {
 // NewInvitationsClient returns a new InvitationsClient.
 func NewInvitationsClient(tenantId string) *InvitationsClient {
 	return &InvitationsClient{
-		BaseClient: NewClient(VersionBeta, tenantId),
+		BaseClient: NewClient(VersionBeta),
 	}
 }
 
@@ -33,8 +33,7 @@ func (c *InvitationsClient) Create(ctx context.Context, invitation Invitation) (
 		Body:             body,
 		ValidStatusCodes: []int{http.StatusCreated},
 		Uri: Uri{
-			Entity:      "/invitations",
-			HasTenantId: true,
+			Entity: "/invitations",
 		},
 	})
 	if err != nil {

--- a/msgraph/me.go
+++ b/msgraph/me.go
@@ -18,7 +18,7 @@ type MeClient struct {
 // NewMeClient returns a new MeClient.
 func NewMeClient(tenantId string) *MeClient {
 	return &MeClient{
-		BaseClient: NewClient(VersionBeta, tenantId),
+		BaseClient: NewClient(VersionBeta),
 	}
 }
 
@@ -30,8 +30,7 @@ func (c *MeClient) Get(ctx context.Context, query odata.Query) (*Me, int, error)
 		OData:            query,
 		ValidStatusCodes: []int{http.StatusOK},
 		Uri: Uri{
-			Entity:      "/me",
-			HasTenantId: false,
+			Entity: "/me",
 		},
 	})
 	if err != nil {
@@ -60,8 +59,7 @@ func (c *MeClient) GetProfile(ctx context.Context, query odata.Query) (*Me, int,
 		OData:            query,
 		ValidStatusCodes: []int{http.StatusOK},
 		Uri: Uri{
-			Entity:      "/me/profile",
-			HasTenantId: false,
+			Entity: "/me/profile",
 		},
 	})
 	if err != nil {
@@ -96,8 +94,7 @@ func (c *MeClient) Sendmail(ctx context.Context, message MailMessage) (int, erro
 		Body:             body,
 		ValidStatusCodes: []int{http.StatusOK, http.StatusAccepted},
 		Uri: Uri{
-			Entity:      "/me/sendMail",
-			HasTenantId: false,
+			Entity: "/me/sendMail",
 		},
 	})
 	if err != nil {

--- a/msgraph/me.go
+++ b/msgraph/me.go
@@ -16,7 +16,7 @@ type MeClient struct {
 }
 
 // NewMeClient returns a new MeClient.
-func NewMeClient(tenantId string) *MeClient {
+func NewMeClient() *MeClient {
 	return &MeClient{
 		BaseClient: NewClient(VersionBeta),
 	}

--- a/msgraph/namedlocations.go
+++ b/msgraph/namedlocations.go
@@ -19,7 +19,7 @@ type NamedLocationsClient struct {
 // NewNamedLocationsClient returns a new NamedLocationsClient.
 func NewNamedLocationsClient(tenantId string) *NamedLocationsClient {
 	return &NamedLocationsClient{
-		BaseClient: NewClient(Version10, tenantId),
+		BaseClient: NewClient(Version10),
 	}
 }
 
@@ -30,8 +30,7 @@ func (c *NamedLocationsClient) List(ctx context.Context, query odata.Query) (*[]
 		OData:            query,
 		ValidStatusCodes: []int{http.StatusOK},
 		Uri: Uri{
-			Entity:      "/identity/conditionalAccess/namedLocations",
-			HasTenantId: true,
+			Entity: "/identity/conditionalAccess/namedLocations",
 		},
 	})
 
@@ -96,8 +95,7 @@ func (c *NamedLocationsClient) Delete(ctx context.Context, id string) (int, erro
 		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
 		ValidStatusCodes:       []int{http.StatusNoContent},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/identity/conditionalAccess/namedLocations/%s", id),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/identity/conditionalAccess/namedLocations/%s", id),
 		},
 	})
 	if err != nil {
@@ -121,8 +119,7 @@ func (c *NamedLocationsClient) CreateIP(ctx context.Context, ipNamedLocation IPN
 		Body:             body,
 		ValidStatusCodes: []int{http.StatusCreated},
 		Uri: Uri{
-			Entity:      "/identity/conditionalAccess/namedLocations",
-			HasTenantId: true,
+			Entity: "/identity/conditionalAccess/namedLocations",
 		},
 	})
 	if err != nil {
@@ -157,8 +154,7 @@ func (c *NamedLocationsClient) CreateCountry(ctx context.Context, countryNamedLo
 		Body:             body,
 		ValidStatusCodes: []int{http.StatusCreated},
 		Uri: Uri{
-			Entity:      "/identity/conditionalAccess/namedLocations",
-			HasTenantId: true,
+			Entity: "/identity/conditionalAccess/namedLocations",
 		},
 	})
 	if err != nil {
@@ -186,8 +182,7 @@ func (c *NamedLocationsClient) GetIP(ctx context.Context, id string, query odata
 		OData:                  query,
 		ValidStatusCodes:       []int{http.StatusOK},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/identity/conditionalAccess/namedLocations/%s", id),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/identity/conditionalAccess/namedLocations/%s", id),
 		},
 	})
 	if err != nil {
@@ -215,8 +210,7 @@ func (c *NamedLocationsClient) Get(ctx context.Context, id string, query odata.Q
 		OData:                  query,
 		ValidStatusCodes:       []int{http.StatusOK},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/identity/conditionalAccess/namedLocations/%s", id),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/identity/conditionalAccess/namedLocations/%s", id),
 		},
 	})
 	if err != nil {
@@ -268,8 +262,7 @@ func (c *NamedLocationsClient) GetCountry(ctx context.Context, id string, query 
 		OData:                  query,
 		ValidStatusCodes:       []int{http.StatusOK},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/identity/conditionalAccess/namedLocations/%s", id),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/identity/conditionalAccess/namedLocations/%s", id),
 		},
 	})
 	if err != nil {
@@ -305,8 +298,7 @@ func (c *NamedLocationsClient) UpdateIP(ctx context.Context, ipNamedLocation IPN
 		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
 		ValidStatusCodes:       []int{http.StatusNoContent},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/identity/conditionalAccess/namedLocations/%s", *ipNamedLocation.ID),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/identity/conditionalAccess/namedLocations/%s", *ipNamedLocation.ID),
 		},
 	})
 	if err != nil {
@@ -331,8 +323,7 @@ func (c *NamedLocationsClient) UpdateCountry(ctx context.Context, countryNamedLo
 		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
 		ValidStatusCodes:       []int{http.StatusNoContent},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/identity/conditionalAccess/namedLocations/%s", *countryNamedLocation.ID),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/identity/conditionalAccess/namedLocations/%s", *countryNamedLocation.ID),
 		},
 	})
 	if err != nil {

--- a/msgraph/namedlocations.go
+++ b/msgraph/namedlocations.go
@@ -17,7 +17,7 @@ type NamedLocationsClient struct {
 }
 
 // NewNamedLocationsClient returns a new NamedLocationsClient.
-func NewNamedLocationsClient(tenantId string) *NamedLocationsClient {
+func NewNamedLocationsClient() *NamedLocationsClient {
 	return &NamedLocationsClient{
 		BaseClient: NewClient(Version10),
 	}

--- a/msgraph/reports.go
+++ b/msgraph/reports.go
@@ -16,7 +16,7 @@ type ReportsClient struct {
 }
 
 // NewReportsClient returns a new ReportsClient.
-func NewReportsClient(tenantId string) *ReportsClient {
+func NewReportsClient() *ReportsClient {
 	return &ReportsClient{
 		BaseClient: NewClient(VersionBeta),
 	}

--- a/msgraph/reports.go
+++ b/msgraph/reports.go
@@ -18,7 +18,7 @@ type ReportsClient struct {
 // NewReportsClient returns a new ReportsClient.
 func NewReportsClient(tenantId string) *ReportsClient {
 	return &ReportsClient{
-		BaseClient: NewClient(VersionBeta, tenantId),
+		BaseClient: NewClient(VersionBeta),
 	}
 }
 
@@ -28,8 +28,7 @@ func (c *ReportsClient) GetCredentialUserRegistrationCount(ctx context.Context, 
 		OData:            query,
 		ValidStatusCodes: []int{http.StatusOK},
 		Uri: Uri{
-			Entity:      "/reports/getCredentialUserRegistrationCount",
-			HasTenantId: true,
+			Entity: "/reports/getCredentialUserRegistrationCount",
 		},
 	})
 	if err != nil {
@@ -58,8 +57,7 @@ func (c *ReportsClient) GetCredentialUserRegistrationDetails(ctx context.Context
 		OData:            query,
 		ValidStatusCodes: []int{http.StatusOK},
 		Uri: Uri{
-			Entity:      "/reports/credentialUserRegistrationDetails",
-			HasTenantId: true,
+			Entity: "/reports/credentialUserRegistrationDetails",
 		},
 	})
 	if err != nil {
@@ -88,8 +86,7 @@ func (c *ReportsClient) GetUserCredentialUsageDetails(ctx context.Context, query
 		OData:            query,
 		ValidStatusCodes: []int{http.StatusOK},
 		Uri: Uri{
-			Entity:      "/reports/userCredentialUsageDetails",
-			HasTenantId: true,
+			Entity: "/reports/userCredentialUsageDetails",
 		},
 	})
 	if err != nil {
@@ -118,8 +115,7 @@ func (c *ReportsClient) GetCredentialUsageSummary(ctx context.Context, period Cr
 		OData:            query,
 		ValidStatusCodes: []int{http.StatusOK},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/reports/getCredentialUsageSummary(period='%s')", period),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/reports/getCredentialUsageSummary(period='%s')", period),
 		},
 	})
 	if err != nil {
@@ -148,8 +144,7 @@ func (c *ReportsClient) GetAuthenticationMethodsUsersRegisteredByFeature(ctx con
 		OData:            query,
 		ValidStatusCodes: []int{http.StatusOK},
 		Uri: Uri{
-			Entity:      "/reports/authenticationMethods/usersRegisteredByFeature",
-			HasTenantId: true,
+			Entity: "/reports/authenticationMethods/usersRegisteredByFeature",
 		},
 	})
 	if err != nil {
@@ -176,8 +171,7 @@ func (c *ReportsClient) GetAuthenticationMethodsUsersRegisteredByMethod(ctx cont
 		OData:            query,
 		ValidStatusCodes: []int{http.StatusOK},
 		Uri: Uri{
-			Entity:      "/reports/authenticationMethods/usersRegisteredByMethod",
-			HasTenantId: true,
+			Entity: "/reports/authenticationMethods/usersRegisteredByMethod",
 		},
 	})
 	if err != nil {

--- a/msgraph/role_assignments.go
+++ b/msgraph/role_assignments.go
@@ -18,7 +18,7 @@ type RoleAssignmentsClient struct {
 // NewRoleAssignmentsClient returns a new RoleAssignmentsClient
 func NewRoleAssignmentsClient(tenantId string) *RoleAssignmentsClient {
 	return &RoleAssignmentsClient{
-		BaseClient: NewClient(Version10, tenantId),
+		BaseClient: NewClient(Version10),
 	}
 }
 
@@ -28,8 +28,7 @@ func (c *RoleAssignmentsClient) List(ctx context.Context, query odata.Query) (*[
 		OData:            query,
 		ValidStatusCodes: []int{http.StatusOK},
 		Uri: Uri{
-			Entity:      "/roleManagement/directory/roleAssignments",
-			HasTenantId: true,
+			Entity: "/roleManagement/directory/roleAssignments",
 		},
 	})
 	if err != nil {
@@ -58,8 +57,7 @@ func (c *RoleAssignmentsClient) Get(ctx context.Context, id string, query odata.
 		OData:            query,
 		ValidStatusCodes: []int{http.StatusOK},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/roleManagement/directory/roleAssignments/%s", id),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/roleManagement/directory/roleAssignments/%s", id),
 		},
 	})
 	if err != nil {
@@ -93,8 +91,7 @@ func (c *RoleAssignmentsClient) Create(ctx context.Context, roleAssignment Unifi
 		Body:             body,
 		ValidStatusCodes: []int{http.StatusCreated},
 		Uri: Uri{
-			Entity:      "/roleManagement/directory/roleAssignments",
-			HasTenantId: true,
+			Entity: "/roleManagement/directory/roleAssignments",
 		},
 	})
 	if err != nil {
@@ -121,8 +118,7 @@ func (c *RoleAssignmentsClient) Delete(ctx context.Context, id string) (int, err
 		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
 		ValidStatusCodes:       []int{http.StatusNoContent},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/roleManagement/directory/roleAssignments/%s", id),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/roleManagement/directory/roleAssignments/%s", id),
 		},
 	})
 	if err != nil {

--- a/msgraph/role_assignments.go
+++ b/msgraph/role_assignments.go
@@ -16,7 +16,7 @@ type RoleAssignmentsClient struct {
 }
 
 // NewRoleAssignmentsClient returns a new RoleAssignmentsClient
-func NewRoleAssignmentsClient(tenantId string) *RoleAssignmentsClient {
+func NewRoleAssignmentsClient() *RoleAssignmentsClient {
 	return &RoleAssignmentsClient{
 		BaseClient: NewClient(Version10),
 	}

--- a/msgraph/role_definitions.go
+++ b/msgraph/role_definitions.go
@@ -18,7 +18,7 @@ type RoleDefinitionsClient struct {
 // NewRoleDefinitionsClient returns a new RoleDefinitionsClient
 func NewRoleDefinitionsClient(tenantId string) *RoleDefinitionsClient {
 	return &RoleDefinitionsClient{
-		BaseClient: NewClient(Version10, tenantId),
+		BaseClient: NewClient(Version10),
 	}
 }
 
@@ -28,8 +28,7 @@ func (c *RoleDefinitionsClient) List(ctx context.Context, query odata.Query) (*[
 		OData:            query,
 		ValidStatusCodes: []int{http.StatusOK},
 		Uri: Uri{
-			Entity:      "/roleManagement/directory/roleDefinitions",
-			HasTenantId: true,
+			Entity: "/roleManagement/directory/roleDefinitions",
 		},
 	})
 	if err != nil {
@@ -58,8 +57,7 @@ func (c *RoleDefinitionsClient) Get(ctx context.Context, id string, query odata.
 		OData:            query,
 		ValidStatusCodes: []int{http.StatusOK},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/roleManagement/directory/roleDefinitions/%s", id),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/roleManagement/directory/roleDefinitions/%s", id),
 		},
 	})
 	if err != nil {
@@ -93,8 +91,7 @@ func (c *RoleDefinitionsClient) Create(ctx context.Context, roleDefinition Unifi
 		Body:             body,
 		ValidStatusCodes: []int{http.StatusCreated},
 		Uri: Uri{
-			Entity:      "/roleManagement/directory/roleDefinitions",
-			HasTenantId: true,
+			Entity: "/roleManagement/directory/roleDefinitions",
 		},
 	})
 	if err != nil {
@@ -129,8 +126,7 @@ func (c *RoleDefinitionsClient) Update(ctx context.Context, roleDefinition Unifi
 		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
 		ValidStatusCodes:       []int{http.StatusNoContent},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/roleManagement/directory/roleDefinitions/%s", *roleDefinition.ID()),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/roleManagement/directory/roleDefinitions/%s", *roleDefinition.ID()),
 		},
 	})
 	if err != nil {
@@ -146,8 +142,7 @@ func (c *RoleDefinitionsClient) Delete(ctx context.Context, id string) (int, err
 		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
 		ValidStatusCodes:       []int{http.StatusNoContent},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/roleManagement/directory/roleDefinitions/%s", id),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/roleManagement/directory/roleDefinitions/%s", id),
 		},
 	})
 	if err != nil {

--- a/msgraph/role_definitions.go
+++ b/msgraph/role_definitions.go
@@ -16,7 +16,7 @@ type RoleDefinitionsClient struct {
 }
 
 // NewRoleDefinitionsClient returns a new RoleDefinitionsClient
-func NewRoleDefinitionsClient(tenantId string) *RoleDefinitionsClient {
+func NewRoleDefinitionsClient() *RoleDefinitionsClient {
 	return &RoleDefinitionsClient{
 		BaseClient: NewClient(Version10),
 	}

--- a/msgraph/schema_extensions.go
+++ b/msgraph/schema_extensions.go
@@ -16,7 +16,7 @@ type SchemaExtensionsClient struct {
 }
 
 // NewSchemaExtensionsClient returns a new SchemaExtensionsClient.
-func NewSchemaExtensionsClient(tenantId string) *SchemaExtensionsClient {
+func NewSchemaExtensionsClient() *SchemaExtensionsClient {
 	return &SchemaExtensionsClient{
 		BaseClient: NewClient(VersionBeta),
 	}

--- a/msgraph/schema_extensions.go
+++ b/msgraph/schema_extensions.go
@@ -18,7 +18,7 @@ type SchemaExtensionsClient struct {
 // NewSchemaExtensionsClient returns a new SchemaExtensionsClient.
 func NewSchemaExtensionsClient(tenantId string) *SchemaExtensionsClient {
 	return &SchemaExtensionsClient{
-		BaseClient: NewClient(VersionBeta, tenantId),
+		BaseClient: NewClient(VersionBeta),
 	}
 }
 
@@ -29,8 +29,7 @@ func (c *SchemaExtensionsClient) List(ctx context.Context, query odata.Query) (*
 		OData:            query,
 		ValidStatusCodes: []int{http.StatusOK},
 		Uri: Uri{
-			Entity:      "/schemaExtensions",
-			HasTenantId: true,
+			Entity: "/schemaExtensions",
 		},
 	})
 	if err != nil {
@@ -60,8 +59,7 @@ func (c *SchemaExtensionsClient) Get(ctx context.Context, id string, query odata
 		OData:                  query,
 		ValidStatusCodes:       []int{http.StatusOK},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/schemaExtensions/%s", id),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/schemaExtensions/%s", id),
 		},
 	})
 	if err != nil {
@@ -96,8 +94,7 @@ func (c *SchemaExtensionsClient) Update(ctx context.Context, schemaExtension Sch
 		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
 		ValidStatusCodes:       []int{http.StatusNoContent},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/schemaExtensions/%s", *schemaExtension.ID),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/schemaExtensions/%s", *schemaExtension.ID),
 		},
 	})
 	if err != nil {
@@ -120,8 +117,7 @@ func (c *SchemaExtensionsClient) Create(ctx context.Context, schemaExtension Sch
 		Body:             body,
 		ValidStatusCodes: []int{http.StatusCreated},
 		Uri: Uri{
-			Entity:      "/schemaExtensions",
-			HasTenantId: true,
+			Entity: "/schemaExtensions",
 		},
 	})
 	if err != nil {
@@ -148,8 +144,7 @@ func (c *SchemaExtensionsClient) Delete(ctx context.Context, id string) (int, er
 		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
 		ValidStatusCodes:       []int{http.StatusNoContent},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/schemaExtensions/%s", id),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/schemaExtensions/%s", id),
 		},
 	})
 	if err != nil {

--- a/msgraph/serviceprincipals.go
+++ b/msgraph/serviceprincipals.go
@@ -19,7 +19,7 @@ type ServicePrincipalsClient struct {
 // NewServicePrincipalsClient returns a new ServicePrincipalsClient.
 func NewServicePrincipalsClient(tenantId string) *ServicePrincipalsClient {
 	return &ServicePrincipalsClient{
-		BaseClient: NewClient(VersionBeta, tenantId),
+		BaseClient: NewClient(VersionBeta),
 	}
 }
 
@@ -30,8 +30,7 @@ func (c *ServicePrincipalsClient) List(ctx context.Context, query odata.Query) (
 		OData:            query,
 		ValidStatusCodes: []int{http.StatusOK},
 		Uri: Uri{
-			Entity:      "/servicePrincipals",
-			HasTenantId: true,
+			Entity: "/servicePrincipals",
 		},
 	})
 	if err != nil {
@@ -83,8 +82,7 @@ func (c *ServicePrincipalsClient) Create(ctx context.Context, servicePrincipal S
 		},
 		ValidStatusCodes: []int{http.StatusCreated},
 		Uri: Uri{
-			Entity:      "/servicePrincipals",
-			HasTenantId: true,
+			Entity: "/servicePrincipals",
 		},
 	})
 	if err != nil {
@@ -112,8 +110,7 @@ func (c *ServicePrincipalsClient) Get(ctx context.Context, id string, query odat
 		OData:                  query,
 		ValidStatusCodes:       []int{http.StatusOK},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/servicePrincipals/%s", id),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/servicePrincipals/%s", id),
 		},
 	})
 	if err != nil {
@@ -152,8 +149,7 @@ func (c *ServicePrincipalsClient) Update(ctx context.Context, servicePrincipal S
 		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
 		ValidStatusCodes:       []int{http.StatusNoContent},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/servicePrincipals/%s", *servicePrincipal.ID()),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/servicePrincipals/%s", *servicePrincipal.ID()),
 		},
 	})
 	if err != nil {
@@ -169,8 +165,7 @@ func (c *ServicePrincipalsClient) Delete(ctx context.Context, id string) (int, e
 		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
 		ValidStatusCodes:       []int{http.StatusNoContent},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/servicePrincipals/%s", id),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/servicePrincipals/%s", id),
 		},
 	})
 	if err != nil {
@@ -190,8 +185,7 @@ func (c *ServicePrincipalsClient) ListOwners(ctx context.Context, id string) (*[
 		},
 		ValidStatusCodes: []int{http.StatusOK},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/servicePrincipals/%s/owners", id),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/servicePrincipals/%s/owners", id),
 		},
 	})
 	if err != nil {
@@ -233,8 +227,7 @@ func (c *ServicePrincipalsClient) GetOwner(ctx context.Context, servicePrincipal
 		},
 		ValidStatusCodes: []int{http.StatusOK},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/servicePrincipals/%s/owners/%s/$ref", servicePrincipalId, ownerId),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/servicePrincipals/%s/owners/%s/$ref", servicePrincipalId, ownerId),
 		},
 	})
 	if err != nil {
@@ -292,8 +285,7 @@ func (c *ServicePrincipalsClient) AddOwners(ctx context.Context, servicePrincipa
 			ValidStatusCodes:       []int{http.StatusNoContent},
 			ValidStatusFunc:        checkOwnerAlreadyExists,
 			Uri: Uri{
-				Entity:      fmt.Sprintf("/servicePrincipals/%s/owners/$ref", *servicePrincipal.ID()),
-				HasTenantId: true,
+				Entity: fmt.Sprintf("/servicePrincipals/%s/owners/$ref", *servicePrincipal.ID()),
 			},
 		})
 		if err != nil {
@@ -336,8 +328,7 @@ func (c *ServicePrincipalsClient) RemoveOwners(ctx context.Context, servicePrinc
 			ValidStatusCodes:       []int{http.StatusNoContent},
 			ValidStatusFunc:        checkOwnerGone,
 			Uri: Uri{
-				Entity:      fmt.Sprintf("/servicePrincipals/%s/owners/%s/$ref", servicePrincipalId, ownerId),
-				HasTenantId: true,
+				Entity: fmt.Sprintf("/servicePrincipals/%s/owners/%s/$ref", servicePrincipalId, ownerId),
 			},
 		})
 		if err != nil {
@@ -379,8 +370,7 @@ func (c *ServicePrincipalsClient) AssignClaimsMappingPolicy(ctx context.Context,
 			ValidStatusCodes:       []int{http.StatusNoContent},
 			ValidStatusFunc:        checkPolicyAlreadyExists,
 			Uri: Uri{
-				Entity:      fmt.Sprintf("/servicePrincipals/%s/claimsMappingPolicies/$ref", *servicePrincipal.ID()),
-				HasTenantId: false,
+				Entity: fmt.Sprintf("/servicePrincipals/%s/claimsMappingPolicies/$ref", *servicePrincipal.ID()),
 			},
 		})
 		if err != nil {
@@ -398,8 +388,7 @@ func (c *ServicePrincipalsClient) ListClaimsMappingPolicy(ctx context.Context, i
 		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
 		ValidStatusCodes:       []int{http.StatusOK},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/servicePrincipals/%s/claimsMappingPolicies", id),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/servicePrincipals/%s/claimsMappingPolicies", id),
 		},
 	})
 	if err != nil {
@@ -465,8 +454,7 @@ func (c *ServicePrincipalsClient) RemoveClaimsMappingPolicy(ctx context.Context,
 			ValidStatusCodes:       []int{http.StatusNoContent},
 			ValidStatusFunc:        checkPolicyStatus,
 			Uri: Uri{
-				Entity:      fmt.Sprintf("/servicePrincipals/%s/claimsMappingPolicies/%s/$ref", *servicePrincipal.ID(), policyId),
-				HasTenantId: false,
+				Entity: fmt.Sprintf("/servicePrincipals/%s/claimsMappingPolicies/%s/$ref", *servicePrincipal.ID(), policyId),
 			},
 		})
 		if err != nil {
@@ -485,8 +473,7 @@ func (c *ServicePrincipalsClient) ListGroupMemberships(ctx context.Context, id s
 		OData:                  query,
 		ValidStatusCodes:       []int{http.StatusOK},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/servicePrincipals/%s/transitiveMemberOf", id),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/servicePrincipals/%s/transitiveMemberOf", id),
 		},
 	})
 	if err != nil {
@@ -527,8 +514,7 @@ func (c *ServicePrincipalsClient) AddPassword(ctx context.Context, servicePrinci
 		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
 		ValidStatusCodes:       []int{http.StatusOK, http.StatusCreated},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/servicePrincipals/%s/addPassword", servicePrincipalId),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/servicePrincipals/%s/addPassword", servicePrincipalId),
 		},
 	})
 	if err != nil {
@@ -567,8 +553,7 @@ func (c *ServicePrincipalsClient) RemovePassword(ctx context.Context, servicePri
 		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
 		ValidStatusCodes:       []int{http.StatusOK, http.StatusNoContent},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/servicePrincipals/%s/removePassword", servicePrincipalId),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/servicePrincipals/%s/removePassword", servicePrincipalId),
 		},
 	})
 	if err != nil {
@@ -592,8 +577,7 @@ func (c *ServicePrincipalsClient) AddTokenSigningCertificate(ctx context.Context
 		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
 		ValidStatusCodes:       []int{http.StatusOK, http.StatusCreated},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/servicePrincipals/%s/addTokenSigningCertificate", servicePrincipalId),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/servicePrincipals/%s/addTokenSigningCertificate", servicePrincipalId),
 		},
 	})
 	if err != nil {
@@ -632,8 +616,7 @@ func (c *ServicePrincipalsClient) SetPreferredTokenSigningKeyThumbprint(ctx cont
 		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
 		ValidStatusCodes:       []int{http.StatusNoContent},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/servicePrincipals/%s", servicePrincipalId),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/servicePrincipals/%s", servicePrincipalId),
 		},
 	})
 	if err != nil {
@@ -653,8 +636,7 @@ func (c *ServicePrincipalsClient) ListOwnedObjects(ctx context.Context, id strin
 		},
 		ValidStatusCodes: []int{http.StatusOK},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/servicePrincipals/%s/ownedObjects", id),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/servicePrincipals/%s/ownedObjects", id),
 		},
 	})
 	if err != nil {
@@ -688,8 +670,7 @@ func (c *ServicePrincipalsClient) ListAppRoleAssignments(ctx context.Context, re
 		OData:                  query,
 		ValidStatusCodes:       []int{http.StatusOK},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/servicePrincipals/%s/appRoleAssignedTo", resourceId),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/servicePrincipals/%s/appRoleAssignedTo", resourceId),
 		},
 	})
 	if err != nil {
@@ -718,8 +699,7 @@ func (c *ServicePrincipalsClient) RemoveAppRoleAssignment(ctx context.Context, r
 		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
 		ValidStatusCodes:       []int{http.StatusNoContent},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/servicePrincipals/%s/appRoleAssignedTo/%s", resourceId, appRoleAssignmentId),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/servicePrincipals/%s/appRoleAssignedTo/%s", resourceId, appRoleAssignmentId),
 		},
 	})
 	if err != nil {
@@ -757,8 +737,7 @@ func (c *ServicePrincipalsClient) AssignAppRoleForResource(ctx context.Context, 
 		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
 		ValidStatusCodes:       []int{http.StatusCreated},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/servicePrincipals/%s/appRoleAssignedTo", resourceId),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/servicePrincipals/%s/appRoleAssignedTo", resourceId),
 		},
 	})
 	if err != nil {

--- a/msgraph/serviceprincipals.go
+++ b/msgraph/serviceprincipals.go
@@ -17,7 +17,7 @@ type ServicePrincipalsClient struct {
 }
 
 // NewServicePrincipalsClient returns a new ServicePrincipalsClient.
-func NewServicePrincipalsClient(tenantId string) *ServicePrincipalsClient {
+func NewServicePrincipalsClient() *ServicePrincipalsClient {
 	return &ServicePrincipalsClient{
 		BaseClient: NewClient(VersionBeta),
 	}

--- a/msgraph/sign_in_reports.go
+++ b/msgraph/sign_in_reports.go
@@ -16,7 +16,7 @@ type SignInReportsClient struct {
 }
 
 // NewSignInReportsClient returns a new SignInReportsClient.
-func NewSignInReportsClient(tenantId string) *SignInReportsClient {
+func NewSignInReportsClient() *SignInReportsClient {
 	return &SignInReportsClient{
 		BaseClient: NewClient(VersionBeta),
 	}

--- a/msgraph/sign_in_reports.go
+++ b/msgraph/sign_in_reports.go
@@ -18,7 +18,7 @@ type SignInReportsClient struct {
 // NewSignInReportsClient returns a new SignInReportsClient.
 func NewSignInReportsClient(tenantId string) *SignInReportsClient {
 	return &SignInReportsClient{
-		BaseClient: NewClient(VersionBeta, tenantId),
+		BaseClient: NewClient(VersionBeta),
 	}
 }
 
@@ -37,8 +37,7 @@ func (c *SignInReportsClient) List(ctx context.Context, query odata.Query) (*[]S
 		OData:                  query,
 		ValidStatusCodes:       []int{http.StatusOK},
 		Uri: Uri{
-			Entity:      "/auditLogs/signIns",
-			HasTenantId: true,
+			Entity: "/auditLogs/signIns",
 		},
 	})
 	if err != nil {
@@ -68,8 +67,7 @@ func (c *SignInReportsClient) Get(ctx context.Context, id string, query odata.Qu
 		OData:                  query,
 		ValidStatusCodes:       []int{http.StatusOK},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/auditLogs/signIns/%s", id),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/auditLogs/signIns/%s", id),
 		},
 	})
 	if err != nil {

--- a/msgraph/synchronization.go
+++ b/msgraph/synchronization.go
@@ -16,7 +16,7 @@ type SynchronizationJobClient struct {
 }
 
 // NewSynchronizationJobClient returns a new SynchronizationJobClient
-func NewSynchronizationJobClient(tenantId string) *SynchronizationJobClient {
+func NewSynchronizationJobClient() *SynchronizationJobClient {
 	return &SynchronizationJobClient{
 		BaseClient: NewClient(VersionBeta),
 	}

--- a/msgraph/synchronization.go
+++ b/msgraph/synchronization.go
@@ -18,7 +18,7 @@ type SynchronizationJobClient struct {
 // NewSynchronizationJobClient returns a new SynchronizationJobClient
 func NewSynchronizationJobClient(tenantId string) *SynchronizationJobClient {
 	return &SynchronizationJobClient{
-		BaseClient: NewClient(VersionBeta, tenantId),
+		BaseClient: NewClient(VersionBeta),
 	}
 }
 
@@ -37,8 +37,7 @@ func (c *SynchronizationJobClient) List(ctx context.Context, servicePrincipalId 
 	resp, status, _, err := c.BaseClient.Get(ctx, GetHttpRequestInput{
 		ValidStatusCodes: []int{http.StatusOK},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/servicePrincipals/%s/synchronization/jobs", servicePrincipalId),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/servicePrincipals/%s/synchronization/jobs", servicePrincipalId),
 		},
 	})
 	if err != nil {
@@ -67,8 +66,7 @@ func (c *SynchronizationJobClient) Get(ctx context.Context, id string, servicePr
 		ValidStatusCodes:       []int{http.StatusOK},
 		ConsistencyFailureFunc: ServicePrincipalDoesNotExistConsistency,
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/servicePrincipals/%s/synchronization/jobs/%s", servicePrincipalId, id),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/servicePrincipals/%s/synchronization/jobs/%s", servicePrincipalId, id),
 		},
 	})
 	if err != nil {
@@ -95,8 +93,7 @@ func (c *SynchronizationJobClient) GetSecrets(ctx context.Context, servicePrinci
 		ValidStatusCodes:       []int{http.StatusOK},
 		ConsistencyFailureFunc: ServicePrincipalDoesNotExistConsistency,
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/servicePrincipals/%s/synchronization/secrets", servicePrincipalId),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/servicePrincipals/%s/synchronization/secrets", servicePrincipalId),
 		},
 	})
 	if err != nil {
@@ -130,8 +127,7 @@ func (c *SynchronizationJobClient) SetSecrets(ctx context.Context, synchronizati
 		ConsistencyFailureFunc: ServicePrincipalDoesNotExistConsistency,
 		ValidStatusCodes:       []int{http.StatusNoContent},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/servicePrincipals/%s/synchronization/secrets", servicePrincipalId),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/servicePrincipals/%s/synchronization/secrets", servicePrincipalId),
 		},
 	})
 	if err != nil {
@@ -161,8 +157,7 @@ func (c *SynchronizationJobClient) Create(ctx context.Context, synchronizationJo
 		ConsistencyFailureFunc: ServicePrincipalDoesNotExistConsistency,
 		ValidStatusCodes:       []int{http.StatusCreated},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/servicePrincipals/%s/synchronization/jobs", servicePrincipalId),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/servicePrincipals/%s/synchronization/jobs", servicePrincipalId),
 		},
 	})
 	if err != nil {
@@ -190,8 +185,7 @@ func (c *SynchronizationJobClient) Start(ctx context.Context, id string, service
 		ConsistencyFailureFunc: ConflictConsistencyFailureFunc,
 		ValidStatusCodes:       []int{http.StatusNoContent},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/servicePrincipals/%s/synchronization/jobs/%s/start", servicePrincipalId, id),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/servicePrincipals/%s/synchronization/jobs/%s/start", servicePrincipalId, id),
 		},
 	})
 	if err != nil {
@@ -212,8 +206,7 @@ func (c *SynchronizationJobClient) Delete(ctx context.Context, id string, servic
 		ConsistencyFailureFunc: ConflictConsistencyFailureFunc,
 		ValidStatusCodes:       []int{http.StatusNoContent},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/servicePrincipals/%s/synchronization/jobs/%s/", servicePrincipalId, id),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/servicePrincipals/%s/synchronization/jobs/%s/", servicePrincipalId, id),
 		},
 	})
 	if err != nil {
@@ -230,8 +223,7 @@ func (c *SynchronizationJobClient) Pause(ctx context.Context, id string, service
 		ConsistencyFailureFunc: ConflictConsistencyFailureFunc,
 		ValidStatusCodes:       []int{http.StatusNoContent},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/servicePrincipals/%s/synchronization/jobs/%s/pause", servicePrincipalId, id),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/servicePrincipals/%s/synchronization/jobs/%s/pause", servicePrincipalId, id),
 		},
 	})
 	if err != nil {
@@ -260,8 +252,7 @@ func (c *SynchronizationJobClient) Restart(ctx context.Context, id string, synch
 		Body:                   body,
 		ValidStatusCodes:       []int{http.StatusNoContent},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/servicePrincipals/%s/synchronization/jobs/%s/restart", servicePrincipalId, id),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/servicePrincipals/%s/synchronization/jobs/%s/restart", servicePrincipalId, id),
 		},
 	})
 	if err != nil {
@@ -290,8 +281,7 @@ func (c *SynchronizationJobClient) ProvisionOnDemand(ctx context.Context, id str
 		Body:             body,
 		ValidStatusCodes: []int{http.StatusCreated},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/servicePrincipals/%s/synchronization/jobs/%s/provisionOnDemand", servicePrincipalId, id),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/servicePrincipals/%s/synchronization/jobs/%s/provisionOnDemand", servicePrincipalId, id),
 		},
 	})
 	if err != nil {
@@ -319,8 +309,7 @@ func (c *SynchronizationJobClient) ValidateCredentials(ctx context.Context, id s
 		Body:             body,
 		ValidStatusCodes: []int{http.StatusCreated},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/servicePrincipals/%s/synchronization/jobs/%s/validateCredentials", servicePrincipalId, id),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/servicePrincipals/%s/synchronization/jobs/%s/validateCredentials", servicePrincipalId, id),
 		},
 	})
 	if err != nil {

--- a/msgraph/termsofuse.go
+++ b/msgraph/termsofuse.go
@@ -16,7 +16,7 @@ type TermsOfUseAgreementClient struct {
 }
 
 // NewTermsOfUseAgreementClient returns a new TermsOfUseAgreementClient
-func NewTermsOfUseAgreementClient(tenantId string) *TermsOfUseAgreementClient {
+func NewTermsOfUseAgreementClient() *TermsOfUseAgreementClient {
 	return &TermsOfUseAgreementClient{
 		BaseClient: NewClient(VersionBeta),
 	}

--- a/msgraph/termsofuse.go
+++ b/msgraph/termsofuse.go
@@ -18,7 +18,7 @@ type TermsOfUseAgreementClient struct {
 // NewTermsOfUseAgreementClient returns a new TermsOfUseAgreementClient
 func NewTermsOfUseAgreementClient(tenantId string) *TermsOfUseAgreementClient {
 	return &TermsOfUseAgreementClient{
-		BaseClient: NewClient(VersionBeta, tenantId),
+		BaseClient: NewClient(VersionBeta),
 	}
 }
 
@@ -31,9 +31,8 @@ func (c *TermsOfUseAgreementClient) List(ctx context.Context, filter string) (*[
 	resp, status, _, err := c.BaseClient.Get(ctx, GetHttpRequestInput{
 		ValidStatusCodes: []int{http.StatusOK},
 		Uri: Uri{
-			Entity:      "/identityGovernance/termsOfUse/agreements",
-			Params:      params,
-			HasTenantId: true,
+			Entity: "/identityGovernance/termsOfUse/agreements",
+			Params: params,
 		},
 	})
 	if err != nil {
@@ -66,8 +65,7 @@ func (c *TermsOfUseAgreementClient) Create(ctx context.Context, termsOfUseAgreem
 		Body:             body,
 		ValidStatusCodes: []int{http.StatusCreated},
 		Uri: Uri{
-			Entity:      "/identityGovernance/termsOfUse/agreements",
-			HasTenantId: true,
+			Entity: "/identityGovernance/termsOfUse/agreements",
 		},
 	})
 	if err != nil {
@@ -90,8 +88,7 @@ func (c *TermsOfUseAgreementClient) Get(ctx context.Context, id string) (*TermsO
 	resp, status, _, err := c.BaseClient.Get(ctx, GetHttpRequestInput{
 		ValidStatusCodes: []int{http.StatusOK},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/identityGovernance/termsOfUse/agreements/%s", id),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/identityGovernance/termsOfUse/agreements/%s", id),
 		},
 	})
 	if err != nil {
@@ -124,8 +121,7 @@ func (c *TermsOfUseAgreementClient) Update(ctx context.Context, termsOfUseAgreem
 		Body:             body,
 		ValidStatusCodes: []int{http.StatusNoContent},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/identityGovernance/termsOfUse/agreements/%s", *termsOfUseAgreement.ID),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/identityGovernance/termsOfUse/agreements/%s", *termsOfUseAgreement.ID),
 		},
 	})
 	if err != nil {
@@ -139,8 +135,7 @@ func (c *TermsOfUseAgreementClient) Delete(ctx context.Context, id string) (int,
 	_, status, _, err := c.BaseClient.Delete(ctx, DeleteHttpRequestInput{
 		ValidStatusCodes: []int{http.StatusNoContent},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/identityGovernance/termsOfUse/agreements/%s", id),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/identityGovernance/termsOfUse/agreements/%s", id),
 		},
 	})
 	if err != nil {

--- a/msgraph/userflow_attributes.go
+++ b/msgraph/userflow_attributes.go
@@ -18,7 +18,7 @@ type UserFlowAttributesClient struct {
 // NewUserFlowAttributesClient returns a new UserFlowAttributesClient.
 func NewUserFlowAttributesClient(tenantId string) *UserFlowAttributesClient {
 	return &UserFlowAttributesClient{
-		BaseClient: NewClient(Version10, tenantId),
+		BaseClient: NewClient(Version10),
 	}
 }
 
@@ -28,8 +28,7 @@ func (c *UserFlowAttributesClient) List(ctx context.Context, query odata.Query) 
 		OData:            query,
 		ValidStatusCodes: []int{http.StatusOK},
 		Uri: Uri{
-			Entity:      "/identity/userFlowAttributes",
-			HasTenantId: true,
+			Entity: "/identity/userFlowAttributes",
 		},
 	})
 	if err != nil {
@@ -68,8 +67,7 @@ func (c *UserFlowAttributesClient) Create(ctx context.Context, userFlowAttribute
 		},
 		ValidStatusCodes: []int{http.StatusCreated},
 		Uri: Uri{
-			Entity:      "/identity/userFlowAttributes",
-			HasTenantId: true,
+			Entity: "/identity/userFlowAttributes",
 		},
 	})
 	if err != nil {
@@ -97,8 +95,7 @@ func (c *UserFlowAttributesClient) Get(ctx context.Context, id string, query oda
 		OData:                  query,
 		ValidStatusCodes:       []int{http.StatusOK},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/identity/userFlowAttributes/%s", id),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/identity/userFlowAttributes/%s", id),
 		},
 	})
 	if err != nil {
@@ -142,8 +139,7 @@ func (c *UserFlowAttributesClient) Update(ctx context.Context, userflowAttribute
 			http.StatusNoContent,
 		},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/identity/userFlowAttributes//%s", userflowID),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/identity/userFlowAttributes//%s", userflowID),
 		},
 	})
 	if err != nil {
@@ -159,8 +155,7 @@ func (c *UserFlowAttributesClient) Delete(ctx context.Context, id string) (int, 
 		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
 		ValidStatusCodes:       []int{http.StatusNoContent},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/identity/userFlowAttributes/%s", id),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/identity/userFlowAttributes/%s", id),
 		},
 	})
 	if err != nil {

--- a/msgraph/userflow_attributes.go
+++ b/msgraph/userflow_attributes.go
@@ -16,7 +16,7 @@ type UserFlowAttributesClient struct {
 }
 
 // NewUserFlowAttributesClient returns a new UserFlowAttributesClient.
-func NewUserFlowAttributesClient(tenantId string) *UserFlowAttributesClient {
+func NewUserFlowAttributesClient() *UserFlowAttributesClient {
 	return &UserFlowAttributesClient{
 		BaseClient: NewClient(Version10),
 	}

--- a/msgraph/users.go
+++ b/msgraph/users.go
@@ -16,7 +16,7 @@ type UsersClient struct {
 }
 
 // NewUsersClient returns a new UsersClient.
-func NewUsersClient(tenantId string) *UsersClient {
+func NewUsersClient() *UsersClient {
 	return &UsersClient{
 		BaseClient: NewClient(VersionBeta),
 	}

--- a/msgraph/users.go
+++ b/msgraph/users.go
@@ -18,7 +18,7 @@ type UsersClient struct {
 // NewUsersClient returns a new UsersClient.
 func NewUsersClient(tenantId string) *UsersClient {
 	return &UsersClient{
-		BaseClient: NewClient(VersionBeta, tenantId),
+		BaseClient: NewClient(VersionBeta),
 	}
 }
 
@@ -29,8 +29,7 @@ func (c *UsersClient) List(ctx context.Context, query odata.Query) (*[]User, int
 		OData:            query,
 		ValidStatusCodes: []int{http.StatusOK},
 		Uri: Uri{
-			Entity:      "/users",
-			HasTenantId: true,
+			Entity: "/users",
 		},
 	})
 	if err != nil {
@@ -77,8 +76,7 @@ func (c *UsersClient) Create(ctx context.Context, user User) (*User, int, error)
 		},
 		ValidStatusCodes: []int{http.StatusCreated},
 		Uri: Uri{
-			Entity:      "/users",
-			HasTenantId: true,
+			Entity: "/users",
 		},
 	})
 	if err != nil {
@@ -106,8 +104,7 @@ func (c *UsersClient) Get(ctx context.Context, id string, query odata.Query) (*U
 		OData:                  query,
 		ValidStatusCodes:       []int{http.StatusOK},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/users/%s", id),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/users/%s", id),
 		},
 	})
 	if err != nil {
@@ -151,8 +148,7 @@ func (c *UsersClient) GetWithSchemaExtensions(ctx context.Context, id string, qu
 		OData:                  query,
 		ValidStatusCodes:       []int{http.StatusOK},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/users/%s", id),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/users/%s", id),
 		},
 	})
 	if err != nil {
@@ -180,8 +176,7 @@ func (c *UsersClient) GetDeleted(ctx context.Context, id string, query odata.Que
 		OData:                  query,
 		ValidStatusCodes:       []int{http.StatusOK},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/directory/deletedItems/%s", id),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/directory/deletedItems/%s", id),
 		},
 	})
 	if err != nil {
@@ -216,8 +211,7 @@ func (c *UsersClient) Update(ctx context.Context, user User) (int, error) {
 		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
 		ValidStatusCodes:       []int{http.StatusNoContent},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/users/%s", *user.ID()),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/users/%s", *user.ID()),
 		},
 	})
 	if err != nil {
@@ -233,8 +227,7 @@ func (c *UsersClient) Delete(ctx context.Context, id string) (int, error) {
 		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
 		ValidStatusCodes:       []int{http.StatusNoContent},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/users/%s", id),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/users/%s", id),
 		},
 	})
 	if err != nil {
@@ -250,8 +243,7 @@ func (c *UsersClient) DeletePermanently(ctx context.Context, id string) (int, er
 		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
 		ValidStatusCodes:       []int{http.StatusNoContent},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/directory/deletedItems/%s", id),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/directory/deletedItems/%s", id),
 		},
 	})
 	if err != nil {
@@ -268,8 +260,7 @@ func (c *UsersClient) ListDeleted(ctx context.Context, query odata.Query) (*[]Us
 		OData:            query,
 		ValidStatusCodes: []int{http.StatusOK},
 		Uri: Uri{
-			Entity:      "/directory/deleteditems/microsoft.graph.user",
-			HasTenantId: true,
+			Entity: "/directory/deleteditems/microsoft.graph.user",
 		},
 	})
 	if err != nil {
@@ -294,8 +285,7 @@ func (c *UsersClient) RestoreDeleted(ctx context.Context, id string) (*User, int
 		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
 		ValidStatusCodes:       []int{http.StatusOK},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/directory/deletedItems/%s/restore", id),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/directory/deletedItems/%s/restore", id),
 		},
 	})
 	if err != nil {
@@ -324,8 +314,7 @@ func (c *UsersClient) ListGroupMemberships(ctx context.Context, id string, query
 		OData:                  query,
 		ValidStatusCodes:       []int{http.StatusOK},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/users/%s/transitiveMemberOf", id),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/users/%s/transitiveMemberOf", id),
 		},
 	})
 	if err != nil {
@@ -362,8 +351,7 @@ func (c *UsersClient) Sendmail(ctx context.Context, id string, message MailMessa
 		Body:             body,
 		ValidStatusCodes: []int{http.StatusOK, http.StatusAccepted},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/users/%s/sendMail", id),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/users/%s/sendMail", id),
 		},
 	})
 	if err != nil {
@@ -412,8 +400,7 @@ func (c *UsersClient) AssignManager(ctx context.Context, id string, manager User
 		Body:             body,
 		ValidStatusCodes: []int{http.StatusNoContent},
 		Uri: Uri{
-			Entity:      fmt.Sprintf("/users/%s/manager/$ref", id),
-			HasTenantId: true,
+			Entity: fmt.Sprintf("/users/%s/manager/$ref", id),
 		},
 	})
 	if err != nil {


### PR DESCRIPTION
Drop the tenant ID from Microsoft Graph endpoint URIs, as this is deprecated and no longer needed with MSAL.

Related: https://github.com/hashicorp/go-azure-sdk/pull/310