### PR TITLE
Add RoleEligibilityScheduleRequest

### DIFF
--- a/internal/test/testing.go
+++ b/internal/test/testing.go
@@ -123,6 +123,7 @@ type Test struct {
 	ReportsClient                             *msgraph.ReportsClient
 	RoleAssignmentsClient                     *msgraph.RoleAssignmentsClient
 	RoleDefinitionsClient                     *msgraph.RoleDefinitionsClient
+	RoleEligibilityScheduleRequestsClient     *msgraph.RoleEligibilityScheduleRequestsClient
 	SchemaExtensionsClient                    *msgraph.SchemaExtensionsClient
 	ServicePrincipalsAppRoleAssignmentsClient *msgraph.AppRoleAssignmentsClient
 	ServicePrincipalsClient                   *msgraph.ServicePrincipalsClient
@@ -349,6 +350,11 @@ func NewTest(t *testing.T) (c *Test) {
 	c.RoleDefinitionsClient.BaseClient.Authorizer = c.Connections["default"].Authorizer
 	c.RoleDefinitionsClient.BaseClient.Endpoint = *endpoint
 	c.RoleDefinitionsClient.BaseClient.RetryableClient.RetryMax = retry
+
+	c.RoleEligibilityScheduleRequestsClient = msgraph.NewRoleEligibilityScheduleRequestsClient()
+	c.RoleEligibilityScheduleRequestsClient.BaseClient.Authorizer = c.Connections["default"].Authorizer
+	c.RoleEligibilityScheduleRequestsClient.BaseClient.Endpoint = *endpoint
+	c.RoleEligibilityScheduleRequestsClient.BaseClient.RetryableClient.RetryMax = retry
 
 	c.SchemaExtensionsClient = msgraph.NewSchemaExtensionsClient()
 	c.SchemaExtensionsClient.BaseClient.Authorizer = c.Connections["default"].Authorizer

--- a/msgraph/models.go
+++ b/msgraph/models.go
@@ -1113,6 +1113,15 @@ type IdentityProvider struct {
 	Name         *string     `json:"displayName,omitempty"`
 }
 
+type IdentitySet struct {
+	Application              *Identity `json:"application,omitempty"`
+	Conversation             *Identity `json:"conversation,omitempty"`
+	ConversationIdentityType *Identity `json:"conversationIdentityType,omitempty"`
+	Device                   *Identity `json:"device,omitempty"`
+	Phone                    *Identity `json:"phone,omitempty"`
+	User                     *Identity `json:"user,omitempty"`
+}
+
 // Used in the identity sources of a ConnectedOrganization.
 type IdentitySource struct {
 	ODataType   *odata.Type `json:"@odata.type,omitempty"`
@@ -1299,6 +1308,11 @@ type ParentalControlSettings struct {
 	LegalAgeGroupRule         *string   `json:"legalAgeGroupRule,omitempty"`
 }
 
+type PatternedRecurrence struct {
+	Pattern *RecurrencePattern `json:"pattern,omitempty"`
+	Range   *RecurrenceRange   `json:"range,omitempty"`
+}
+
 // PasswordCredential describes a password credential for an object.
 type PasswordCredential struct {
 	CustomKeyIdentifier *string    `json:"customKeyIdentifier,omitempty"`
@@ -1359,8 +1373,22 @@ type RecurrencePattern struct {
 	Index          *IndexType             `json:"index,omitempty"`
 }
 
+type RecurrenceRange struct {
+	EndDate             *time.Time           `json:"endDate,omitempty"`
+	NumberOfOccurrences *int32               `json:"numberOfOccurrences,omitempty"`
+	RecurrenceTimeZone  *string              `json:"recurrenceTimeZone,omitempty"`
+	StartDate           *time.Time           `json:"startDate,omitempty"`
+	Type                *RecurrenceRangeType `json:"type,omitempty"`
+}
+
 type Ref struct {
 	ObjectUri *string `json:"@odata.id,omitempty"`
+}
+
+type RequestSchedule struct {
+	Expiration    *ExpirationPattern   `json:"expiration,omitempty"`
+	Recurrence    *PatternedRecurrence `json:"recurrence,omitempty"`
+	StartDateTime *time.Time           `json:"startDateTime,omitempty"`
 }
 
 type RequestorSettings struct {
@@ -1658,6 +1686,11 @@ type TemporaryAccessPassAuthenticationMethod struct {
 	MethodUsabilityReason *MethodUsabilityReason `json:"methodUsabilityReason,omitempty"`
 }
 
+type TicketInfo struct {
+	TicketNumber *string `json:"ticketNumber,omitempty"`
+	TicketSystem *string `json:"ticketSystem,omitempty"`
+}
+
 type TokenIssuancePolicy struct {
 	DirectoryObject
 	Definition            *[]string `json:"definition,omitempty"`
@@ -1686,6 +1719,26 @@ type UnifiedRoleDefinition struct {
 	RolePermissions *[]UnifiedRolePermission `json:"rolePermissions,omitempty"`
 	TemplateId      *string                  `json:"templateId,omitempty"`
 	Version         *string                  `json:"version,omitempty"`
+}
+
+type UnifiedRoleEligibilityScheduleRequest struct {
+	ID                *string                            `json:"id,omitempty"`
+	Action            *UnifiedRoleScheduleRequestActions `json:"action,omitempty"`
+	ApprovalId        *string                            `json:"approvalId,omitempty"`
+	AppScopeId        *string                            `json:"appScopeId,omitempty"`
+	CompletedDateTime *time.Time                         `json:"completedDateTime,omitempty"`
+	CreatedBy         *IdentitySet                       `json:"createdBy,omitempty"`
+	CreatedDateTime   *time.Time                         `json:"createdDateTime,omitempty"`
+	CustomData        *string                            `json:"customData,omitempty"`
+	DirectoryScopeId  *string                            `json:"directoryScopeId,omitempty"`
+	IsValidationOnly  *bool                              `json:"isValidationOnly,omitempty"`
+	Justification     *string                            `json:"justification,omitempty"`
+	PrincipalId       *string                            `json:"principalId,omitempty"`
+	RoleDefinitionId  *string                            `json:"roleDefinitionId,omitempty"`
+	ScheduleInfo      *RequestSchedule                   `json:"scheduleInfo,omitempty"`
+	Status            *RequestStatus                     `json:"status,omitempty"`
+	TargetScheduleId  *string                            `json:"targetScheduleId,omitempty"`
+	TicketInfo        *TicketInfo                        `json:"ticketInfo,omitempty"`
 }
 
 type UnifiedRolePermission struct {

--- a/msgraph/role_eligibility_schedule_requests.go
+++ b/msgraph/role_eligibility_schedule_requests.go
@@ -1,0 +1,114 @@
+package msgraph
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// RoleEligibilityScheduleRequestsClient performs operations on RoleEligibilityScheduleRequests.
+type RoleEligibilityScheduleRequestsClient struct {
+	BaseClient Client
+}
+
+// NewRoleEligibilityScheduleRequestsClient returns a new RoleEligibilityScheduleRequestsClient
+func NewRoleEligibilityScheduleRequestsClient() *RoleEligibilityScheduleRequestsClient {
+	return &RoleEligibilityScheduleRequestsClient{
+		BaseClient: NewClient(Version10),
+	}
+}
+
+// List returns a list of RoleEligibilityScheduleRequestsClient
+func (c *RoleEligibilityScheduleRequestsClient) List(ctx context.Context, query odata.Query) (*[]UnifiedRoleEligibilityScheduleRequest, int, error) {
+	resp, status, _, err := c.BaseClient.Get(ctx, GetHttpRequestInput{
+		OData:            query,
+		ValidStatusCodes: []int{http.StatusOK},
+		Uri: Uri{
+			Entity: "/roleManagement/directory/roleEligibilityScheduleRequests",
+		},
+	})
+	if err != nil {
+		return nil, status, fmt.Errorf("RoleEligibilityScheduleRequestsClient.BaseClient.Get(): %v", err)
+	}
+
+	defer resp.Body.Close()
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, status, fmt.Errorf("io.ReadAll(): %v", err)
+	}
+
+	var data struct {
+		RoleEligibilityScheduleRequest []UnifiedRoleEligibilityScheduleRequest `json:"value"`
+	}
+	if err := json.Unmarshal(respBody, &data); err != nil {
+		return nil, status, fmt.Errorf("json.Unmarshal(): %v", err)
+	}
+
+	return &data.RoleEligibilityScheduleRequest, status, nil
+}
+
+// Get retrieves a UnifiedRoleEligibilityScheduleRequest
+func (c *RoleEligibilityScheduleRequestsClient) Get(ctx context.Context, id string, query odata.Query) (*UnifiedRoleEligibilityScheduleRequest, int, error) {
+	resp, status, _, err := c.BaseClient.Get(ctx, GetHttpRequestInput{
+		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
+		OData:                  query,
+		ValidStatusCodes:       []int{http.StatusOK},
+		Uri: Uri{
+			Entity: fmt.Sprintf("/roleManagement/directory/roleEligibilityScheduleRequests/%s", id),
+		},
+	})
+	if err != nil {
+		return nil, status, fmt.Errorf("RoleEligibilityScheduleRequestsClient.BaseClient.Get(): %v", err)
+	}
+
+	defer resp.Body.Close()
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, status, fmt.Errorf("io.ReadAll(): %v", err)
+	}
+
+	var roleEligibilityScheduleRequest UnifiedRoleEligibilityScheduleRequest
+	if err := json.Unmarshal(respBody, &roleEligibilityScheduleRequest); err != nil {
+		return nil, status, fmt.Errorf("json.Unmarshal(): %v", err)
+	}
+
+	return &roleEligibilityScheduleRequest, status, nil
+}
+
+// Create creates a new UnifiedRoleEligibilityScheduleRequest.
+func (c *RoleEligibilityScheduleRequestsClient) Create(ctx context.Context, roleEligibilityScheduleRequest UnifiedRoleEligibilityScheduleRequest) (*UnifiedRoleEligibilityScheduleRequest, int, error) {
+	var status int
+
+	body, err := json.Marshal(roleEligibilityScheduleRequest)
+	if err != nil {
+		return nil, status, fmt.Errorf("json.Marshal(): %v", err)
+	}
+
+	resp, status, _, err := c.BaseClient.Post(ctx, PostHttpRequestInput{
+		Body:             body,
+		ValidStatusCodes: []int{http.StatusCreated},
+		Uri: Uri{
+			Entity: "/roleManagement/directory/roleEligibilityScheduleRequests",
+		},
+	})
+	if err != nil {
+		return nil, status, fmt.Errorf("RoleEligibilityScheduleRequestsClient.BaseClient.Post(): %v", err)
+	}
+
+	defer resp.Body.Close()
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, status, fmt.Errorf("io.ReadAll(): %v", err)
+	}
+
+	var newRoleEligibilityScheduleRequest UnifiedRoleEligibilityScheduleRequest
+	if err := json.Unmarshal(respBody, &newRoleEligibilityScheduleRequest); err != nil {
+		return nil, status, fmt.Errorf("json.Unmarshal(): %v", err)
+	}
+
+	return &newRoleEligibilityScheduleRequest, status, nil
+}

--- a/msgraph/role_eligibility_schedule_requests_test.go
+++ b/msgraph/role_eligibility_schedule_requests_test.go
@@ -1,0 +1,92 @@
+package msgraph_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+	"github.com/manicminer/hamilton/internal/test"
+	"github.com/manicminer/hamilton/internal/utils"
+	"github.com/manicminer/hamilton/msgraph"
+)
+
+func TestRoleEligibilityScheduleRequestsClient(t *testing.T) {
+	c := test.NewTest(t)
+	defer c.CancelFunc()
+
+	testUser := testUser_Create(t, c)
+
+	roleEligibilityScheduleRequest := testRoleEligibilityScheduleRequestsClient_Create(t, c, msgraph.UnifiedRoleEligibilityScheduleRequest{
+		Action:           utils.StringPtr(msgraph.UnifiedRoleScheduleRequestActionsAdminAssign),
+		DirectoryScopeId: utils.StringPtr("/"),
+		PrincipalId:      testUser.ID(),
+		// ffd52fa5-98dc-465c-991d-fc073eb59f8f is the template id of the "Attribute Assignment Reader" built-in role
+		RoleDefinitionId: utils.StringPtr("ffd52fa5-98dc-465c-991d-fc073eb59f8f"),
+		ScheduleInfo: &msgraph.RequestSchedule{
+			Expiration: &msgraph.ExpirationPattern{
+				Type: utils.StringPtr(msgraph.ExpirationPatternTypeNoExpiration),
+			},
+		},
+	})
+	testRoleEligibilityScheduleRequestsClient_List(t, c)
+	testRoleEligibilityScheduleRequestsClient_Get(t, c, *roleEligibilityScheduleRequest.ID)
+
+	// Processing of the request action takes a little time internally, so it is necessary to sleep for another action
+	time.Sleep(20 * time.Second)
+
+	// Remove the role assignment from UI
+	testRoleEligibilityScheduleRequestsClient_Create(t, c, msgraph.UnifiedRoleEligibilityScheduleRequest{
+		Action:           utils.StringPtr(msgraph.UnifiedRoleScheduleRequestActionsAdminRemove),
+		DirectoryScopeId: utils.StringPtr("/"),
+		PrincipalId:      testUser.ID(),
+		// ffd52fa5-98dc-465c-991d-fc073eb59f8f is the template id of the "Attribute Assignment Reader" built-in role
+		RoleDefinitionId: utils.StringPtr("ffd52fa5-98dc-465c-991d-fc073eb59f8f"),
+	})
+
+	testUser_Delete(t, c, testUser)
+}
+
+func testRoleEligibilityScheduleRequestsClient_List(t *testing.T, c *test.Test) (roleEligibilityScheduleRequests *[]msgraph.UnifiedRoleEligibilityScheduleRequest) {
+	roleEligibilityScheduleRequests, _, err := c.RoleEligibilityScheduleRequestsClient.List(c.Context, odata.Query{Top: 10})
+	if err != nil {
+		t.Fatalf("RoleEligibilityScheduleRequestsClient.List(): %v", err)
+	}
+	if roleEligibilityScheduleRequests == nil {
+		t.Fatal("RoleEligibilityScheduleRequestsClient.List(): roleEligibilityScheduleRequests was nil")
+	}
+	return
+}
+
+func testRoleEligibilityScheduleRequestsClient_Get(t *testing.T, c *test.Test, id string) (roleEligibilityScheduleRequest *msgraph.UnifiedRoleEligibilityScheduleRequest) {
+	roleEligibilityScheduleRequest, status, err := c.RoleEligibilityScheduleRequestsClient.Get(c.Context, id, odata.Query{})
+	if err != nil {
+		t.Fatalf("RoleEligibilityScheduleRequestsClient.Get(): %v", err)
+	}
+	if status < 200 || status >= 300 {
+		t.Fatalf("RoleEligibilityScheduleRequestsClient.Get(): invalid status: %d", status)
+	}
+	if roleEligibilityScheduleRequest == nil {
+		t.Fatal("RoleEligibilityScheduleRequestsClient.Get(): roleEligibilityScheduleRequest was nil")
+	}
+	if *roleEligibilityScheduleRequest.ID != id {
+		t.Fatal("RoleEligibilityScheduleRequestsClient.Get(): roleEligibilityScheduleRequest.ID was different")
+	}
+	return
+}
+
+func testRoleEligibilityScheduleRequestsClient_Create(t *testing.T, c *test.Test, r msgraph.UnifiedRoleEligibilityScheduleRequest) (roleEligibilityScheduleRequest *msgraph.UnifiedRoleEligibilityScheduleRequest) {
+	roleEligibilityScheduleRequest, status, err := c.RoleEligibilityScheduleRequestsClient.Create(c.Context, r)
+	if err != nil {
+		t.Fatalf("RoleEligibilityScheduleRequestsClient.Create(): %v", err)
+	}
+	if status < 200 || status >= 300 {
+		t.Fatalf("RoleEligibilityScheduleRequestsClient.Create(): invalid status: %d", status)
+	}
+	if roleEligibilityScheduleRequest == nil {
+		t.Fatal("RoleEligibilityScheduleRequestsClient.Create(): roleEligibilityScheduleRequest was nil")
+	}
+	if roleEligibilityScheduleRequest.ID == nil {
+		t.Fatal("RoleEligibilityScheduleRequestsClient.Create(): roleEligibilityScheduleRequest.ID was nil")
+	}
+	return
+}

--- a/msgraph/valuetypes.go
+++ b/msgraph/valuetypes.go
@@ -676,6 +676,14 @@ const (
 	RecurrencePatternTypeRelativeYearly  RecurrencePatternType = "relativeYearly"
 )
 
+type RecurrenceRangeType = string
+
+const (
+	RecurrenceRangeTypeEndDate  RecurrenceRangeType = "endDate"
+	RecurrenceRangeTypeNoEnd    RecurrenceRangeType = "noEnd"
+	RecurrenceRangeTypeNumbered RecurrenceRangeType = "numbered"
+)
+
 type RegistrationAuthMethod = string
 
 const (
@@ -713,6 +721,22 @@ const (
 	RequestorSettingsScopeTypeSpecificDirectorySubjects                  RequestorSettingsScopeType = "SpecificDirectorySubjects"
 )
 
+type RequestStatus = string
+
+const (
+	RequestStatusCanceled                RequestStatus = "Canceled"
+	RequestStatusDenied                  RequestStatus = "Denied"
+	RequestStatusFailed                  RequestStatus = "Failed"
+	RequestStatusGranted                 RequestStatus = "Granted"
+	RequestStatusPendingAdminDecision    RequestStatus = "PendingAdminDecision"
+	RequestStatusPendingApproval         RequestStatus = "PendingApproval"
+	RequestStatusPendingProvisioning     RequestStatus = "PendingProvisioning"
+	RequestStatusPendingScheduleCreation RequestStatus = "PendingScheduleCreation"
+	RequestStatusProvisioned             RequestStatus = "Provisioned"
+	RequestStatusRevoked                 RequestStatus = "Revoked"
+	RequestStatusScheduleCreated         RequestStatus = "ScheduleCreated"
+)
+
 type ResourceAccessType = string
 
 const (
@@ -747,6 +771,21 @@ const (
 	SignInAudienceAzureADMultipleOrgs                SignInAudience = "AzureADMultipleOrgs"
 	SignInAudienceAzureADandPersonalMicrosoftAccount SignInAudience = "AzureADandPersonalMicrosoftAccount"
 	SignInAudiencePersonalMicrosoftAccount           SignInAudience = "PersonalMicrosoftAccount"
+)
+
+type UnifiedRoleScheduleRequestActions = string
+
+const (
+	UnifiedRoleScheduleRequestActionsAdminAssign        UnifiedRoleScheduleRequestActions = "adminAssign"
+	UnifiedRoleScheduleRequestActionsAdminUpdate        UnifiedRoleScheduleRequestActions = "adminUpdate"
+	UnifiedRoleScheduleRequestActionsAdminRemove        UnifiedRoleScheduleRequestActions = "adminRemove"
+	UnifiedRoleScheduleRequestActionsSelfActivate       UnifiedRoleScheduleRequestActions = "selfActivate"
+	UnifiedRoleScheduleRequestActionsSelfDeactivate     UnifiedRoleScheduleRequestActions = "selfDeactivate"
+	UnifiedRoleScheduleRequestActionsAdminExtend        UnifiedRoleScheduleRequestActions = "adminExtend"
+	UnifiedRoleScheduleRequestActionsAdminRenew         UnifiedRoleScheduleRequestActions = "adminRenew"
+	UnifiedRoleScheduleRequestActionsSelfExtend         UnifiedRoleScheduleRequestActions = "selfExtend"
+	UnifiedRoleScheduleRequestActionsSelfRenew          UnifiedRoleScheduleRequestActions = "selfRenew"
+	UnifiedRoleScheduleRequestActionsUnknownFutureValue UnifiedRoleScheduleRequestActions = "unknownFutureValue"
 )
 
 type UsageAuthMethod = string


### PR DESCRIPTION
This adds initial support for the RoleEligibilityScheduleRequest resource.

This client requires `RoleManagement.ReadWrite.Directory` permissions.

In https://github.com/manicminer/hamilton/pull/204, someone else has submitted a Pull Request, but it doesn't seem to be active. Therefore, I decided to create a new Pull Request.

Graph API Reference:

* https://learn.microsoft.com/en-us/graph/api/rbacapplication-list-roleeligibilityschedulerequests
* https://learn.microsoft.com/en-us/graph/api/rbacapplication-post-roleeligibilityschedulerequests
* https://learn.microsoft.com/en-us/graph/api/unifiedroleeligibilityschedulerequest-get