### PR TITLE
Add delete function for `AccessPackageResourceRoleScope`

### DIFF
--- a/msgraph/accesspackageresource.go
+++ b/msgraph/accesspackageresource.go
@@ -83,7 +83,7 @@ func (c *AccessPackageResourceClient) Get(ctx context.Context, catalogId string,
 	accessPackageResources := data.AccessPackageResources
 
 	if len(accessPackageResources) == 0 {
-		return nil, status, fmt.Errorf("No accessPackageResource found with catalogId %v and originId %v", catalogId, originId)
+		return nil, http.StatusNotFound, fmt.Errorf("No accessPackageResource found with catalogId %v and originId %v", catalogId, originId)
 	}
 
 	return &accessPackageResources[0], status, nil

--- a/msgraph/accesspackageresourcerolescope.go
+++ b/msgraph/accesspackageresourcerolescope.go
@@ -148,7 +148,7 @@ func (c *AccessPackageResourceRoleScopeClient) Get(ctx context.Context, accessPa
 	}
 
 	if accessPackageResourceRoleScope.ID == nil {
-		return nil, status, fmt.Errorf("AccessPackageResourceRoleScopeClient.BaseClient.Get(): Could not find accessPackageResourceRoleScope ID")
+		return nil, http.StatusNotFound, fmt.Errorf("AccessPackageResourceRoleScopeClient.BaseClient.Get(): Could not find accessPackageResourceRoleScope ID %s", id)
 	}
 
 	return &accessPackageResourceRoleScope, status, nil

--- a/msgraph/accesspackageresourcerolescope.go
+++ b/msgraph/accesspackageresourcerolescope.go
@@ -153,3 +153,19 @@ func (c *AccessPackageResourceRoleScopeClient) Get(ctx context.Context, accessPa
 
 	return &accessPackageResourceRoleScope, status, nil
 }
+
+// Delete removes a AccessPackageResourceRoleScope.
+func (c *AccessPackageResourceRoleScopeClient) Delete(ctx context.Context, accessPackageId string, id string) (int, error) {
+	_, status, _, err := c.BaseClient.Delete(ctx, DeleteHttpRequestInput{
+		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
+		ValidStatusCodes:       []int{http.StatusOK},
+		Uri: Uri{
+			Entity: fmt.Sprintf("/identityGovernance/entitlementManagement/accessPackages/%s/accessPackageResourceRoleScopes/%s", accessPackageId, id),
+		},
+	})
+	if err != nil {
+		return status, fmt.Errorf("AccessPackageResourceRoleScopeClient.BaseClient.Delete(): %v", err)
+	}
+
+	return status, nil
+}

--- a/msgraph/accesspackageresourcerolescope_test.go
+++ b/msgraph/accesspackageresourcerolescope_test.go
@@ -67,6 +67,7 @@ func TestAccessPackageResourceRoleScopeClient(t *testing.T) {
 	testAccessPackageResourceRoleScopeClient_Get(t, c, *accessPackageResourceRoleScope.AccessPackageId, *accessPackageResourceRoleScope.ID)
 	testAccessPackageResourceRoleScopeResource_Get(t, c, *accessPackageResourceRequest.CatalogId, *accessPackageResourceRequest.AccessPackageResource.OriginId)
 	testAccessPackageResourceRoleScopeClient_List(t, c, *accessPackageResourceRoleScope.AccessPackageId)
+	testAccessPackageResourceRoleScopeClient_Delete(t, c, *accessPackageResourceRoleScope.AccessPackageId, *accessPackageResourceRoleScope.ID)
 
 	// Force-replacement scenario
 	testAccessPackageResourceRoleScopeAP_Delete(t, c, *accessPackage.ID)
@@ -93,7 +94,6 @@ func TestAccessPackageResourceRoleScopeClient(t *testing.T) {
 		},
 	})
 
-	//testAccessPackageResourceRoleScopeClient_Delete(t, c, *accessPackageResourceRoleScope)
 	//testAccessPackageResourceRequestClient_Delete(t, c, accessPackageResourceRequest)
 
 	// Cleanup
@@ -145,6 +145,16 @@ func testAccessPackageResourceRoleScopeClient_List(t *testing.T, c *test.Test, a
 		t.Fatal("AccessPackageResourceRequestClient.List(): accessPackageResourceRequests was nil")
 	}
 	return
+}
+
+func testAccessPackageResourceRoleScopeClient_Delete(t *testing.T, c *test.Test, accessPackageId string, id string) {
+	status, err := c.AccessPackageResourceRoleScopeClient.Delete(c.Context, accessPackageId, id)
+	if err != nil {
+		t.Fatalf("AccessPackageResourceRequestClient.Delete(): %v", err)
+	}
+	if status < 200 || status >= 300 {
+		t.Fatalf("AccessPackageResourceRequestClient.Delete(): invalid status: %d", status)
+	}
 }
 
 // AccessPackageResourceRequest


### PR DESCRIPTION
Hey @manicminer 

Hoping this can help towards resolving https://github.com/hashicorp/terraform-provider-azuread/issues/1091
Once the delete function is merged it can be referenced in this function:
https://github.com/hashicorp/terraform-provider-azuread/blob/main/internal/services/identitygovernance/access_package_resource_package_association_resource.go#L146-L150

Errors should still be expected if a user has been assigned a given resource but this will at least allow things to delete when no assignments are in place

Let me know if any tweaks are needed!