### PR TITLE
Added `ServicePrincipalRiskLevels` to `ConditionalAccessConditionSet`

### DIFF
--- a/msgraph/models.go
+++ b/msgraph/models.go
@@ -615,17 +615,17 @@ type ConditionalAccessClientApplications struct {
 }
 
 type ConditionalAccessConditionSet struct {
-	Applications               *ConditionalAccessApplications                `json:"applications,omitempty"`
-	ClientApplications         *ConditionalAccessClientApplications          `json:"clientApplications,omitempty"`
-	ClientAppTypes             *[]ConditionalAccessClientAppType             `json:"clientAppTypes,omitempty"`
-	Devices                    *ConditionalAccessDevices                     `json:"devices,omitempty"`
-	DeviceStates               *ConditionalAccessDeviceStates                `json:"deviceStates,omitempty"`
-	Locations                  *ConditionalAccessLocations                   `json:"locations"`
-	Platforms                  *ConditionalAccessPlatforms                   `json:"platforms"`
-	ServicePrincipalRiskLevels *[]ConditionalAccessServicePrincipalRiskLevel `json:"servicePrincipalRiskLevels,omitempty"`
-	SignInRiskLevels           *[]ConditionalAccessRiskLevel                 `json:"signInRiskLevels,omitempty"`
-	UserRiskLevels             *[]ConditionalAccessRiskLevel                 `json:"userRiskLevels,omitempty"`
-	Users                      *ConditionalAccessUsers                       `json:"users,omitempty"`
+	Applications               *ConditionalAccessApplications       `json:"applications,omitempty"`
+	ClientApplications         *ConditionalAccessClientApplications `json:"clientApplications,omitempty"`
+	ClientAppTypes             *[]ConditionalAccessClientAppType    `json:"clientAppTypes,omitempty"`
+	Devices                    *ConditionalAccessDevices            `json:"devices,omitempty"`
+	DeviceStates               *ConditionalAccessDeviceStates       `json:"deviceStates,omitempty"`
+	Locations                  *ConditionalAccessLocations          `json:"locations"`
+	Platforms                  *ConditionalAccessPlatforms          `json:"platforms"`
+	ServicePrincipalRiskLevels *[]ConditionalAccessRiskLevel        `json:"servicePrincipalRiskLevels,omitempty"`
+	SignInRiskLevels           *[]ConditionalAccessRiskLevel        `json:"signInRiskLevels,omitempty"`
+	UserRiskLevels             *[]ConditionalAccessRiskLevel        `json:"userRiskLevels,omitempty"`
+	Users                      *ConditionalAccessUsers              `json:"users,omitempty"`
 }
 
 type ConditionalAccessDevices struct {

--- a/msgraph/models.go
+++ b/msgraph/models.go
@@ -615,16 +615,17 @@ type ConditionalAccessClientApplications struct {
 }
 
 type ConditionalAccessConditionSet struct {
-	Applications       *ConditionalAccessApplications       `json:"applications,omitempty"`
-	ClientApplications *ConditionalAccessClientApplications `json:"clientApplications,omitempty"`
-	ClientAppTypes     *[]ConditionalAccessClientAppType    `json:"clientAppTypes,omitempty"`
-	Devices            *ConditionalAccessDevices            `json:"devices,omitempty"`
-	DeviceStates       *ConditionalAccessDeviceStates       `json:"deviceStates,omitempty"`
-	Locations          *ConditionalAccessLocations          `json:"locations"`
-	Platforms          *ConditionalAccessPlatforms          `json:"platforms"`
-	SignInRiskLevels   *[]ConditionalAccessRiskLevel        `json:"signInRiskLevels,omitempty"`
-	UserRiskLevels     *[]ConditionalAccessRiskLevel        `json:"userRiskLevels,omitempty"`
-	Users              *ConditionalAccessUsers              `json:"users,omitempty"`
+	Applications               *ConditionalAccessApplications                `json:"applications,omitempty"`
+	ClientApplications         *ConditionalAccessClientApplications          `json:"clientApplications,omitempty"`
+	ClientAppTypes             *[]ConditionalAccessClientAppType             `json:"clientAppTypes,omitempty"`
+	Devices                    *ConditionalAccessDevices                     `json:"devices,omitempty"`
+	DeviceStates               *ConditionalAccessDeviceStates                `json:"deviceStates,omitempty"`
+	Locations                  *ConditionalAccessLocations                   `json:"locations"`
+	Platforms                  *ConditionalAccessPlatforms                   `json:"platforms"`
+	ServicePrincipalRiskLevels *[]ConditionalAccessServicePrincipalRiskLevel `json:"servicePrincipalRiskLevels,omitempty"`
+	SignInRiskLevels           *[]ConditionalAccessRiskLevel                 `json:"signInRiskLevels,omitempty"`
+	UserRiskLevels             *[]ConditionalAccessRiskLevel                 `json:"userRiskLevels,omitempty"`
+	Users                      *ConditionalAccessUsers                       `json:"users,omitempty"`
 }
 
 type ConditionalAccessDevices struct {

--- a/msgraph/valuetypes.go
+++ b/msgraph/valuetypes.go
@@ -368,6 +368,16 @@ const (
 	ConditionalAccessRiskLevelUnknownFutureValue ConditionalAccessRiskLevel = "unknownFutureValue"
 )
 
+type ConditionalAccessServicePrincipalRiskLevel = string
+
+const (
+	ConditionalAccessServicePrincipalRiskLevelHigh               ConditionalAccessServicePrincipalRiskLevel = "high"
+	ConditionalAccessServicePrincipalRiskLevelLow                ConditionalAccessServicePrincipalRiskLevel = "low"
+	ConditionalAccessServicePrincipalRiskLevelMedium             ConditionalAccessServicePrincipalRiskLevel = "medium"
+	CConditionalAccessServicePrincipalRiskLevelNone              ConditionalAccessServicePrincipalRiskLevel = "none"
+	ConditionalAccessServicePrincipalRiskLevelUnknownFutureValue ConditionalAccessServicePrincipalRiskLevel = "unknownFutureValue"
+)
+
 type ConnectedOrganizationState = string
 
 const (

--- a/msgraph/valuetypes.go
+++ b/msgraph/valuetypes.go
@@ -368,16 +368,6 @@ const (
 	ConditionalAccessRiskLevelUnknownFutureValue ConditionalAccessRiskLevel = "unknownFutureValue"
 )
 
-type ConditionalAccessServicePrincipalRiskLevel = string
-
-const (
-	ConditionalAccessServicePrincipalRiskLevelHigh               ConditionalAccessServicePrincipalRiskLevel = "high"
-	ConditionalAccessServicePrincipalRiskLevelLow                ConditionalAccessServicePrincipalRiskLevel = "low"
-	ConditionalAccessServicePrincipalRiskLevelMedium             ConditionalAccessServicePrincipalRiskLevel = "medium"
-	ConditionalAccessServicePrincipalRiskLevelNone               ConditionalAccessServicePrincipalRiskLevel = "none"
-	ConditionalAccessServicePrincipalRiskLevelUnknownFutureValue ConditionalAccessServicePrincipalRiskLevel = "unknownFutureValue"
-)
-
 type ConnectedOrganizationState = string
 
 const (

--- a/msgraph/valuetypes.go
+++ b/msgraph/valuetypes.go
@@ -374,7 +374,7 @@ const (
 	ConditionalAccessServicePrincipalRiskLevelHigh               ConditionalAccessServicePrincipalRiskLevel = "high"
 	ConditionalAccessServicePrincipalRiskLevelLow                ConditionalAccessServicePrincipalRiskLevel = "low"
 	ConditionalAccessServicePrincipalRiskLevelMedium             ConditionalAccessServicePrincipalRiskLevel = "medium"
-	CConditionalAccessServicePrincipalRiskLevelNone              ConditionalAccessServicePrincipalRiskLevel = "none"
+	ConditionalAccessServicePrincipalRiskLevelNone               ConditionalAccessServicePrincipalRiskLevel = "none"
 	ConditionalAccessServicePrincipalRiskLevelUnknownFutureValue ConditionalAccessServicePrincipalRiskLevel = "unknownFutureValue"
 )
 


### PR DESCRIPTION
Added `ServicePrincipalRiskLevels` to `ConditionalAccessConditionSet`

Created a new value type for `ConditionalAccessServicePrincipalRiskLevel` as Service Principles don't have the `hidden` value which is currently in `ConditionalAccessRiskLevel` - see [Graph API v1.0 documentation](https://learn.microsoft.com/en-us/graph/api/resources/conditionalaccessconditionset?view=graph-rest-1.0)

