### PR TITLE
Add support for `AuthenticationStrengthPolicies`

### DIFF
--- a/internal/cmd/test-cleanup/authenticationstrengthpolicies.go
+++ b/internal/cmd/test-cleanup/authenticationstrengthpolicies.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+	"github.com/manicminer/hamilton/msgraph"
+)
+
+func cleanupAuthenticationStrengthPolicies() {
+	client := msgraph.NewAuthenticationStrengthPoliciesClient()
+	client.BaseClient.Authorizer = authorizer
+
+	authStrengthPolicies, _, err := client.List(ctx, odata.Query{Filter: fmt.Sprintf("startsWith(displayName, '%s')", displayNamePrefix)})
+	if err != nil {
+		log.Println(err)
+		return
+	}
+	if authStrengthPolicies == nil {
+		log.Println("bad API response, nil authStrengthPolicies result received")
+		return
+	}
+	for _, policy := range *authStrengthPolicies {
+		if policy.ID == nil || policy.DisplayName == nil {
+			log.Println("Authentication Strength Policy returned with nil ID or DisplayName")
+			continue
+		}
+
+		log.Printf("Deleting Authentication Strength Policy %q (DisplayName: %q)\n", *policy.ID, *policy.DisplayName)
+		_, err := client.Delete(ctx, *policy.ID)
+		if err != nil {
+			log.Printf("Error when deleting Authentication Strength Policy %q: %v\n", *policy.ID, err)
+		}
+	}
+}

--- a/internal/cmd/test-cleanup/main.go
+++ b/internal/cmd/test-cleanup/main.go
@@ -81,6 +81,7 @@ func main() {
 	cleanupConditionalAccessPolicies()
 	cleanupConnectedOrganizations()
 	cleanupNamedLocations()
+	cleanupAuthenticationStrengthPolicies()
 	cleanupServicePrincipals()
 	cleanupApplications()
 	cleanupGroups()

--- a/internal/test/testing.go
+++ b/internal/test/testing.go
@@ -247,6 +247,11 @@ func NewTest(t *testing.T) (c *Test) {
 	c.AuthenticationMethodsClient.BaseClient.Endpoint = *endpoint
 	c.AuthenticationMethodsClient.BaseClient.RetryableClient.RetryMax = retry
 
+	c.AuthenticationStrengthPoliciesClient = msgraph.NewAuthenticationStrengthPoliciesClient()
+	c.AuthenticationStrengthPoliciesClient.BaseClient.Authorizer = c.Connections["default"].Authorizer
+	c.AuthenticationStrengthPoliciesClient.BaseClient.Endpoint = *endpoint
+	c.AuthenticationStrengthPoliciesClient.BaseClient.RetryableClient.RetryMax = retry
+
 	c.B2CUserFlowClient = msgraph.NewB2CUserFlowClient()
 	c.B2CUserFlowClient.BaseClient.Authorizer = c.Connections["b2c"].Authorizer
 	c.B2CUserFlowClient.BaseClient.Endpoint = *endpoint

--- a/internal/test/testing.go
+++ b/internal/test/testing.go
@@ -102,6 +102,7 @@ type Test struct {
 	ApplicationsClient                        *msgraph.ApplicationsClient
 	AppRoleAssignedToClient                   *msgraph.AppRoleAssignedToClient
 	AuthenticationMethodsClient               *msgraph.AuthenticationMethodsClient
+	AuthenticationStrengthPoliciesClient      *msgraph.AuthenticationStrengthPoliciesClient
 	B2CUserFlowClient                         *msgraph.B2CUserFlowClient
 	ClaimsMappingPolicyClient                 *msgraph.ClaimsMappingPolicyClient
 	ConditionalAccessPoliciesClient           *msgraph.ConditionalAccessPoliciesClient

--- a/msgraph/authentication_strength_policy.go
+++ b/msgraph/authentication_strength_policy.go
@@ -26,7 +26,6 @@ func NewAuthenticationStrengthPoliciesClient() *AuthenticationStrengthPoliciesCl
 // List returns a list of AuthenticationStrengthPolicy, optionally queried using OData.
 func (c *AuthenticationStrengthPoliciesClient) List(ctx context.Context, query odata.Query) (*[]AuthenticationStrengthPolicy, int, error) {
 	resp, status, _, err := c.BaseClient.Get(ctx, GetHttpRequestInput{
-		DisablePaging:    query.Top > 0,
 		OData:            query,
 		ValidStatusCodes: []int{http.StatusOK},
 		Uri: Uri{

--- a/msgraph/authentication_strength_policy.go
+++ b/msgraph/authentication_strength_policy.go
@@ -147,7 +147,7 @@ func (c *AuthenticationStrengthPoliciesClient) Delete(ctx context.Context, id st
 		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
 		ValidStatusCodes:       []int{http.StatusNoContent},
 		Uri: Uri{
-			Entity: fmt.Sprintf("/policies/authenticationStrengthPolicies/%s/#ref", id),
+			Entity: fmt.Sprintf("/policies/authenticationStrengthPolicies/%s/$ref", id),
 		},
 	})
 	if err != nil {

--- a/msgraph/authentication_strength_policy.go
+++ b/msgraph/authentication_strength_policy.go
@@ -1,0 +1,159 @@
+package msgraph
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// AuthenticationStrengthPoliciesClient performs operations on AuthenticationStrengthPolicy.
+type AuthenticationStrengthPoliciesClient struct {
+	BaseClient Client
+}
+
+// NewAuthenticationStrengthPoliciesClient returns a new AuthenticationStrengthPoliciesClient
+func NewAuthenticationStrengthPoliciesClient() *AuthenticationStrengthPoliciesClient {
+	return &AuthenticationStrengthPoliciesClient{
+		BaseClient: NewClient(VersionBeta),
+	}
+}
+
+// List returns a list of AuthenticationStrengthPolicy, optionally queried using OData.
+func (c *AuthenticationStrengthPoliciesClient) List(ctx context.Context, query odata.Query) (*[]AuthenticationStrengthPolicy, int, error) {
+	resp, status, _, err := c.BaseClient.Get(ctx, GetHttpRequestInput{
+		DisablePaging:    query.Top > 0,
+		OData:            query,
+		ValidStatusCodes: []int{http.StatusOK},
+		Uri: Uri{
+			Entity: "/policies/authenticationStrengthPolicies",
+		},
+	})
+	if err != nil {
+		return nil, status, fmt.Errorf("AuthenticationStrengthPoliciesClient.BaseClient.Get(): %v", err)
+	}
+
+	defer resp.Body.Close()
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, status, fmt.Errorf("io.ReadAll(): %v", err)
+	}
+
+	var data struct {
+		AuthenticationStrengthPolicys []AuthenticationStrengthPolicy `json:"value"`
+	}
+	if err := json.Unmarshal(respBody, &data); err != nil {
+		return nil, status, fmt.Errorf("json.Unmarshal(): %v", err)
+	}
+
+	return &data.AuthenticationStrengthPolicys, status, nil
+}
+
+// Create creates a new AuthenticationStrengthPolicy.
+func (c *AuthenticationStrengthPoliciesClient) Create(ctx context.Context, authenticationStrengthPolicy AuthenticationStrengthPolicy) (*AuthenticationStrengthPolicy, int, error) {
+	var status int
+	body, err := json.Marshal(authenticationStrengthPolicy)
+	if err != nil {
+		return nil, status, fmt.Errorf("json.Marshal(): %v", err)
+	}
+
+	resp, status, _, err := c.BaseClient.Post(ctx, PostHttpRequestInput{
+		Body:             body,
+		ValidStatusCodes: []int{http.StatusCreated},
+		Uri: Uri{
+			Entity: "/policies/authenticationStrengthPolicies",
+		},
+	})
+	if err != nil {
+		return nil, status, fmt.Errorf("AuthenticationStrengthPoliciesClient.BaseClient.Post(): %v", err)
+	}
+
+	defer resp.Body.Close()
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, status, fmt.Errorf("io.ReadAll(): %v", err)
+	}
+
+	var newAuthenticationStrengthPolicy AuthenticationStrengthPolicy
+	if err := json.Unmarshal(respBody, &newAuthenticationStrengthPolicy); err != nil {
+		return nil, status, fmt.Errorf("json.Unmarshal(): %v", err)
+	}
+
+	return &newAuthenticationStrengthPolicy, status, nil
+}
+
+// Get retrieves a AuthenticationStrengthPolicy.
+func (c *AuthenticationStrengthPoliciesClient) Get(ctx context.Context, id string, query odata.Query) (*AuthenticationStrengthPolicy, int, error) {
+	resp, status, _, err := c.BaseClient.Get(ctx, GetHttpRequestInput{
+		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
+		OData:                  query,
+		ValidStatusCodes:       []int{http.StatusOK},
+		Uri: Uri{
+			Entity: fmt.Sprintf("/policies/authenticationStrengthPolicies/%s", id),
+		},
+	})
+	if err != nil {
+		return nil, status, fmt.Errorf("AuthenticationStrengthPoliciesClient.BaseClient.Get(): %v", err)
+	}
+
+	defer resp.Body.Close()
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, status, fmt.Errorf("io.ReadAll(): %v", err)
+	}
+
+	var AuthenticationStrengthPolicy AuthenticationStrengthPolicy
+	if err := json.Unmarshal(respBody, &AuthenticationStrengthPolicy); err != nil {
+		return nil, status, fmt.Errorf("json.Unmarshal(): %v", err)
+	}
+
+	return &AuthenticationStrengthPolicy, status, nil
+}
+
+// Update amends an existing AuthenticationStrengthPolicy.
+func (c *AuthenticationStrengthPoliciesClient) Update(ctx context.Context, AuthenticationStrengthPolicy AuthenticationStrengthPolicy) (int, error) {
+	var status int
+
+	if AuthenticationStrengthPolicy.ID == nil {
+		return status, errors.New("cannot update AuthenticationStrengthPolicy with nil ID")
+	}
+
+	body, err := json.Marshal(AuthenticationStrengthPolicy)
+	if err != nil {
+		return status, fmt.Errorf("json.Marshal(): %v", err)
+	}
+
+	_, status, _, err = c.BaseClient.Patch(ctx, PatchHttpRequestInput{
+		Body:                   body,
+		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
+		ValidStatusCodes:       []int{http.StatusNoContent},
+		Uri: Uri{
+			Entity: fmt.Sprintf("/policies/authenticationStrengthPolicies/%s", *AuthenticationStrengthPolicy.ID),
+		},
+	})
+	if err != nil {
+		return status, fmt.Errorf("AuthenticationStrengthPoliciesClient.BaseClient.Patch(): %v", err)
+	}
+
+	return status, nil
+}
+
+// Delete removes a AuthenticationStrengthPolicy.
+func (c *AuthenticationStrengthPoliciesClient) Delete(ctx context.Context, id string) (int, error) {
+	_, status, _, err := c.BaseClient.Delete(ctx, DeleteHttpRequestInput{
+		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
+		ValidStatusCodes:       []int{http.StatusNoContent},
+		Uri: Uri{
+			Entity: fmt.Sprintf("/policies/authenticationStrengthPolicies/%s/#ref", id),
+		},
+	})
+	if err != nil {
+		return status, fmt.Errorf("AuthenticationStrengthPoliciesClient.BaseClient.Delete(): %v", err)
+	}
+
+	return status, nil
+}

--- a/msgraph/authentication_strength_policy_test.go
+++ b/msgraph/authentication_strength_policy_test.go
@@ -16,7 +16,7 @@ func TestAuthenticationStrengthPolicyClient(t *testing.T) {
 
 	policy := testAuthenticationStrengthPoliciesClient_Create(t, c, msgraph.AuthenticationStrengthPolicy{
 		DisplayName:         utils.StringPtr(fmt.Sprintf("test-policy-%s", c.RandomString)),
-		Description:         utils.StringPtr("FIDO2"),
+		Description:         utils.StringPtr("Password and Hardware OATH"),
 		AllowedCombinations: &[]string{"password, hardwareOath"},
 	},
 	)

--- a/msgraph/authentication_strength_policy_test.go
+++ b/msgraph/authentication_strength_policy_test.go
@@ -25,11 +25,11 @@ func TestAuthenticationStrengthPolicyClient(t *testing.T) {
 		ID:          policy.ID,
 		DisplayName: utils.StringPtr(fmt.Sprintf("test-policy-updated-%s", c.RandomString)),
 	}
-	testAuthenticationStrengthPolicysClient_Update(t, c, updatePolicy)
+	testAuthenticationStrengthPoliciesClient_Update(t, c, updatePolicy)
 
-	testAuthenticationStrengthPolicysClient_List(t, c)
-	testAuthenticationStrengthPolicysClient_Get(t, c, *policy.ID)
-	testAuthenticationStrengthPolicysClient_Delete(t, c, *policy.ID)
+	testAuthenticationStrengthPoliciesClient_List(t, c)
+	testAuthenticationStrengthPoliciesClient_Get(t, c, *policy.ID)
+	testAuthenticationStrengthPoliciesClient_Delete(t, c, *policy.ID)
 
 }
 
@@ -50,7 +50,7 @@ func testAuthenticationStrengthPoliciesClient_Create(t *testing.T, c *test.Test,
 	return
 }
 
-func testAuthenticationStrengthPolicysClient_Get(t *testing.T, c *test.Test, id string) (policy *msgraph.AuthenticationStrengthPolicy) {
+func testAuthenticationStrengthPoliciesClient_Get(t *testing.T, c *test.Test, id string) (policy *msgraph.AuthenticationStrengthPolicy) {
 	policy, status, err := c.AuthenticationStrengthPoliciesClient.Get(c.Context, id, odata.Query{})
 	if err != nil {
 		t.Fatalf("AuthenticationStrengthPolicyClient.Get(): %v", err)
@@ -64,7 +64,7 @@ func testAuthenticationStrengthPolicysClient_Get(t *testing.T, c *test.Test, id 
 	return
 }
 
-func testAuthenticationStrengthPolicysClient_Update(t *testing.T, c *test.Test, policy msgraph.AuthenticationStrengthPolicy) {
+func testAuthenticationStrengthPoliciesClient_Update(t *testing.T, c *test.Test, policy msgraph.AuthenticationStrengthPolicy) {
 	status, err := c.AuthenticationStrengthPoliciesClient.Update(c.Context, policy)
 	if err != nil {
 		t.Fatalf("AuthenticationStrengthPolicyClient.Update(): %v", err)
@@ -74,7 +74,7 @@ func testAuthenticationStrengthPolicysClient_Update(t *testing.T, c *test.Test, 
 	}
 }
 
-func testAuthenticationStrengthPolicysClient_List(t *testing.T, c *test.Test) (policies *[]msgraph.AuthenticationStrengthPolicy) {
+func testAuthenticationStrengthPoliciesClient_List(t *testing.T, c *test.Test) (policies *[]msgraph.AuthenticationStrengthPolicy) {
 	policies, _, err := c.AuthenticationStrengthPoliciesClient.List(c.Context, odata.Query{Top: 10})
 	if err != nil {
 		t.Fatalf("AuthenticationStrengthPolicyClient.List(): %v", err)
@@ -85,7 +85,7 @@ func testAuthenticationStrengthPolicysClient_List(t *testing.T, c *test.Test) (p
 	return
 }
 
-func testAuthenticationStrengthPolicysClient_Delete(t *testing.T, c *test.Test, id string) {
+func testAuthenticationStrengthPoliciesClient_Delete(t *testing.T, c *test.Test, id string) {
 	status, err := c.AuthenticationStrengthPoliciesClient.Delete(c.Context, id)
 	if err != nil {
 		t.Fatalf("AuthenticationStrengthPolicyClient.Delete(): %v", err)

--- a/msgraph/authentication_strength_policy_test.go
+++ b/msgraph/authentication_strength_policy_test.go
@@ -1,0 +1,96 @@
+package msgraph_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+	"github.com/manicminer/hamilton/internal/test"
+	"github.com/manicminer/hamilton/internal/utils"
+	"github.com/manicminer/hamilton/msgraph"
+)
+
+func TestAuthenticationStrengthPolicyClient(t *testing.T) {
+	c := test.NewTest(t)
+	defer c.CancelFunc()
+
+	policy := testAuthenticationStrengthPolicysClient_Create(t, c, msgraph.AuthenticationStrengthPolicy{
+		DisplayName:         utils.StringPtr(fmt.Sprintf("test-policy-%s", c.RandomString)),
+		Description:         utils.StringPtr("FIDO2"),
+		AllowedCombinations: &[]string{"password", "hardwareOath"},
+	},
+	)
+
+	updatePolicy := msgraph.AuthenticationStrengthPolicy{
+		ID:          policy.ID,
+		DisplayName: utils.StringPtr(fmt.Sprintf("test-policy-updated-%s", c.RandomString)),
+	}
+	testAuthenticationStrengthPolicysClient_Update(t, c, updatePolicy)
+
+	testAuthenticationStrengthPolicysClient_List(t, c)
+	testAuthenticationStrengthPolicysClient_Get(t, c, *policy.ID)
+	testAuthenticationStrengthPolicysClient_Delete(t, c, *policy.ID)
+
+}
+
+func testAuthenticationStrengthPolicysClient_Create(t *testing.T, c *test.Test, a msgraph.AuthenticationStrengthPolicy) (authenticationStrengthPolicy *msgraph.AuthenticationStrengthPolicy) {
+	authenticationStrengthPolicy, status, err := c.AuthenticationStrengthPoliciesClient.Create(c.Context, a)
+	if err != nil {
+		t.Fatalf("AuthenticationStrengthPolicyClient.Create(): %v", err)
+	}
+	if status < 200 || status >= 300 {
+		t.Fatalf("AuthenticationStrengthPolicyClient.Create(): invalid status: %d", status)
+	}
+	if authenticationStrengthPolicy == nil {
+		t.Fatal("AuthenticationStrengthPolicyClient.Create(): authenticationStrengthPolicy was nil")
+	}
+	if authenticationStrengthPolicy.ID == nil {
+		t.Fatal("AuthenticationStrengthPolicyClient.Create(): authenticationStrengthPolicy.ID was nil")
+	}
+	return
+}
+
+func testAuthenticationStrengthPolicysClient_Get(t *testing.T, c *test.Test, id string) (policy *msgraph.AuthenticationStrengthPolicy) {
+	policy, status, err := c.AuthenticationStrengthPoliciesClient.Get(c.Context, id, odata.Query{})
+	if err != nil {
+		t.Fatalf("AuthenticationStrengthPolicyClient.Get(): %v", err)
+	}
+	if status < 200 || status >= 300 {
+		t.Fatalf("AuthenticationStrengthPolicyClient.Get(): invalid status: %d", status)
+	}
+	if policy == nil {
+		t.Fatal("AuthenticationStrengthPolicyClient.Get(): policy was nil")
+	}
+	return
+}
+
+func testAuthenticationStrengthPolicysClient_Update(t *testing.T, c *test.Test, policy msgraph.AuthenticationStrengthPolicy) {
+	status, err := c.AuthenticationStrengthPoliciesClient.Update(c.Context, policy)
+	if err != nil {
+		t.Fatalf("AuthenticationStrengthPolicyClient.Update(): %v", err)
+	}
+	if status < 200 || status >= 300 {
+		t.Fatalf("AuthenticationStrengthPolicyClient.Update(): invalid status: %d", status)
+	}
+}
+
+func testAuthenticationStrengthPolicysClient_List(t *testing.T, c *test.Test) (policies *[]msgraph.AuthenticationStrengthPolicy) {
+	policies, _, err := c.AuthenticationStrengthPoliciesClient.List(c.Context, odata.Query{Top: 10})
+	if err != nil {
+		t.Fatalf("AuthenticationStrengthPolicyClient.List(): %v", err)
+	}
+	if policies == nil {
+		t.Fatal("AuthenticationStrengthPolicyClient.List(): policies was nil")
+	}
+	return
+}
+
+func testAuthenticationStrengthPolicysClient_Delete(t *testing.T, c *test.Test, id string) {
+	status, err := c.AuthenticationStrengthPoliciesClient.Delete(c.Context, id)
+	if err != nil {
+		t.Fatalf("AuthenticationStrengthPolicyClient.Delete(): %v", err)
+	}
+	if status < 200 || status >= 300 {
+		t.Fatalf("AuthenticationStrengthPolicyClient.Delete(): invalid status: %d", status)
+	}
+}

--- a/msgraph/authentication_strength_policy_test.go
+++ b/msgraph/authentication_strength_policy_test.go
@@ -17,7 +17,7 @@ func TestAuthenticationStrengthPolicyClient(t *testing.T) {
 	policy := testAuthenticationStrengthPoliciesClient_Create(t, c, msgraph.AuthenticationStrengthPolicy{
 		DisplayName:         utils.StringPtr(fmt.Sprintf("test-policy-%s", c.RandomString)),
 		Description:         utils.StringPtr("FIDO2"),
-		AllowedCombinations: &[]string{"password", "hardwareOath"},
+		AllowedCombinations: &[]string{"password, hardwareOath"},
 	},
 	)
 

--- a/msgraph/authentication_strength_policy_test.go
+++ b/msgraph/authentication_strength_policy_test.go
@@ -14,7 +14,7 @@ func TestAuthenticationStrengthPolicyClient(t *testing.T) {
 	c := test.NewTest(t)
 	defer c.CancelFunc()
 
-	policy := testAuthenticationStrengthPolicysClient_Create(t, c, msgraph.AuthenticationStrengthPolicy{
+	policy := testAuthenticationStrengthPoliciesClient_Create(t, c, msgraph.AuthenticationStrengthPolicy{
 		DisplayName:         utils.StringPtr(fmt.Sprintf("test-policy-%s", c.RandomString)),
 		Description:         utils.StringPtr("FIDO2"),
 		AllowedCombinations: &[]string{"password", "hardwareOath"},
@@ -33,7 +33,7 @@ func TestAuthenticationStrengthPolicyClient(t *testing.T) {
 
 }
 
-func testAuthenticationStrengthPolicysClient_Create(t *testing.T, c *test.Test, a msgraph.AuthenticationStrengthPolicy) (authenticationStrengthPolicy *msgraph.AuthenticationStrengthPolicy) {
+func testAuthenticationStrengthPoliciesClient_Create(t *testing.T, c *test.Test, a msgraph.AuthenticationStrengthPolicy) (authenticationStrengthPolicy *msgraph.AuthenticationStrengthPolicy) {
 	authenticationStrengthPolicy, status, err := c.AuthenticationStrengthPoliciesClient.Create(c.Context, a)
 	if err != nil {
 		t.Fatalf("AuthenticationStrengthPolicyClient.Create(): %v", err)

--- a/msgraph/authentication_strength_policy_test.go
+++ b/msgraph/authentication_strength_policy_test.go
@@ -75,7 +75,7 @@ func testAuthenticationStrengthPoliciesClient_Update(t *testing.T, c *test.Test,
 }
 
 func testAuthenticationStrengthPoliciesClient_List(t *testing.T, c *test.Test) (policies *[]msgraph.AuthenticationStrengthPolicy) {
-	policies, _, err := c.AuthenticationStrengthPoliciesClient.List(c.Context, odata.Query{Top: 10})
+	policies, _, err := c.AuthenticationStrengthPoliciesClient.List(c.Context, odata.Query{})
 	if err != nil {
 		t.Fatalf("AuthenticationStrengthPolicyClient.List(): %v", err)
 	}

--- a/msgraph/conditionalaccesspolicy_test.go
+++ b/msgraph/conditionalaccesspolicy_test.go
@@ -68,7 +68,7 @@ func TestConditionalAccessPolicyClient(t *testing.T) {
 	testGroup_Delete(t, c, testIncGroup)
 	testGroup_Delete(t, c, testExcGroup)
 	testUser_Delete(t, c, testUser)
-	testAuthenticationStrengthPoliciesClient_Delete(t, c, *policy.ID)
+	testAuthenticationStrengthPoliciesClient_Delete(t, c, *authStrengthPolicy.ID)
 
 }
 

--- a/msgraph/conditionalaccesspolicy_test.go
+++ b/msgraph/conditionalaccesspolicy_test.go
@@ -22,7 +22,7 @@ func TestConditionalAccessPolicyClient(t *testing.T) {
 
 	authStrengthPolicy := testAuthenticationStrengthPoliciesClient_Create(t, c, msgraph.AuthenticationStrengthPolicy{
 		DisplayName:         utils.StringPtr(fmt.Sprintf("test-policy-%s", c.RandomString)),
-		Description:         utils.StringPtr("Password and Hardware OATH"),
+		Description:         utils.StringPtr("Password and Hardware OATH token"),
 		AllowedCombinations: &[]string{"password, hardwareOath"},
 	},
 	)

--- a/msgraph/conditionalaccesspolicy_test.go
+++ b/msgraph/conditionalaccesspolicy_test.go
@@ -20,6 +20,13 @@ func TestConditionalAccessPolicyClient(t *testing.T) {
 	testExcGroup := testGroup_Create(t, c, "test-conditionalAccessPolicy-exc")
 	testUser := testUser_Create(t, c)
 
+	authStrengthPolicy := testAuthenticationStrengthPoliciesClient_Create(t, c, msgraph.AuthenticationStrengthPolicy{
+		DisplayName:         utils.StringPtr(fmt.Sprintf("test-policy-%s", c.RandomString)),
+		Description:         utils.StringPtr("Password and Hardware OATH"),
+		AllowedCombinations: &[]string{"password, hardwareOath"},
+	},
+	)
+
 	policy := testConditionalAccessPolicysClient_Create(t, c, msgraph.ConditionalAccessPolicy{
 		DisplayName: utils.StringPtr(fmt.Sprintf("test-policy-%s", c.RandomString)),
 		State:       utils.StringPtr("enabled"),
@@ -42,6 +49,9 @@ func TestConditionalAccessPolicyClient(t *testing.T) {
 		GrantControls: &msgraph.ConditionalAccessGrantControls{
 			Operator:        utils.StringPtr("OR"),
 			BuiltInControls: &[]string{"block"},
+			AuthenticationStrength: &msgraph.AuthenticationStrengthPolicy{
+				ID: authStrengthPolicy.ID,
+			},
 		},
 	})
 

--- a/msgraph/conditionalaccesspolicy_test.go
+++ b/msgraph/conditionalaccesspolicy_test.go
@@ -68,6 +68,8 @@ func TestConditionalAccessPolicyClient(t *testing.T) {
 	testGroup_Delete(t, c, testIncGroup)
 	testGroup_Delete(t, c, testExcGroup)
 	testUser_Delete(t, c, testUser)
+	testAuthenticationStrengthPoliciesClient_Delete(t, c, *policy.ID)
+
 }
 
 func testConditionalAccessPolicysClient_Create(t *testing.T, c *test.Test, a msgraph.ConditionalAccessPolicy) (conditionalAccessPolicy *msgraph.ConditionalAccessPolicy) {

--- a/msgraph/conditionalaccesspolicy_test.go
+++ b/msgraph/conditionalaccesspolicy_test.go
@@ -22,7 +22,7 @@ func TestConditionalAccessPolicyClient(t *testing.T) {
 
 	authStrengthPolicy := testAuthenticationStrengthPoliciesClient_Create(t, c, msgraph.AuthenticationStrengthPolicy{
 		DisplayName:         utils.StringPtr(fmt.Sprintf("test-policy-%s", c.RandomString)),
-		Description:         utils.StringPtr("Password and Hardware OATH methods"),
+		Description:         utils.StringPtr("Password and Hardware OATH"),
 		AllowedCombinations: &[]string{"password, hardwareOath"},
 	},
 	)

--- a/msgraph/conditionalaccesspolicy_test.go
+++ b/msgraph/conditionalaccesspolicy_test.go
@@ -22,7 +22,7 @@ func TestConditionalAccessPolicyClient(t *testing.T) {
 
 	authStrengthPolicy := testAuthenticationStrengthPoliciesClient_Create(t, c, msgraph.AuthenticationStrengthPolicy{
 		DisplayName:         utils.StringPtr(fmt.Sprintf("test-policy-%s", c.RandomString)),
-		Description:         utils.StringPtr("Password and Hardware OATH"),
+		Description:         utils.StringPtr("Password and Hardware OATH methods"),
 		AllowedCombinations: &[]string{"password, hardwareOath"},
 	},
 	)

--- a/msgraph/models.go
+++ b/msgraph/models.go
@@ -656,6 +656,7 @@ type ConditionalAccessFilter struct {
 
 type ConditionalAccessGrantControls struct {
 	Operator                    *string                          `json:"operator,omitempty"`
+	AuthenticationStrength      *[]AuthenticationStrengthPolicy  `json:"authenticationStrength,omitempty"`
 	BuiltInControls             *[]ConditionalAccessGrantControl `json:"builtInControls,omitempty"`
 	CustomAuthenticationFactors *[]string                        `json:"customAuthenticationFactors,omitempty"`
 	TermsOfUse                  *[]string                        `json:"termsOfUse,omitempty"`

--- a/msgraph/models.go
+++ b/msgraph/models.go
@@ -656,7 +656,7 @@ type ConditionalAccessFilter struct {
 
 type ConditionalAccessGrantControls struct {
 	Operator                    *string                          `json:"operator,omitempty"`
-	AuthenticationStrength      *[]AuthenticationStrengthPolicy  `json:"authenticationStrength,omitempty"`
+	AuthenticationStrength      *AuthenticationStrengthPolicy  `json:"authenticationStrength,omitempty"`
 	BuiltInControls             *[]ConditionalAccessGrantControl `json:"builtInControls,omitempty"`
 	CustomAuthenticationFactors *[]string                        `json:"customAuthenticationFactors,omitempty"`
 	TermsOfUse                  *[]string                        `json:"termsOfUse,omitempty"`

--- a/msgraph/models.go
+++ b/msgraph/models.go
@@ -656,7 +656,7 @@ type ConditionalAccessFilter struct {
 
 type ConditionalAccessGrantControls struct {
 	Operator                    *string                          `json:"operator,omitempty"`
-	AuthenticationStrength      *AuthenticationStrengthPolicy  `json:"authenticationStrength,omitempty"`
+	AuthenticationStrength      *AuthenticationStrengthPolicy    `json:"authenticationStrength,omitempty"`
 	BuiltInControls             *[]ConditionalAccessGrantControl `json:"builtInControls,omitempty"`
 	CustomAuthenticationFactors *[]string                        `json:"customAuthenticationFactors,omitempty"`
 	TermsOfUse                  *[]string                        `json:"termsOfUse,omitempty"`

--- a/msgraph/models.go
+++ b/msgraph/models.go
@@ -582,6 +582,16 @@ type AuditActivityInitiator struct {
 
 type AuthenticationMethod interface{}
 
+type AuthenticationStrengthPolicy struct {
+	AllowedCombinations *[]AuthenticationMethodModes      `json:"allowedCombinations,omitempty"`
+	CreatedDateTime     *time.Time                        `json:"createdDateTime,omitempty"`
+	ID                  *string                           `json:"id,omitempty"`
+	ModifiedDateTime    *time.Time                        `json:"modifiedDateTime,omitempty"`
+	PolicyType          *AuthenticationStrengthPolicyType `json:"policyType,omitempty"`
+	Description         *string                           `json:"description,omitempty"`
+	DisplayName         *string                           `json:"displayName,omitempty"`
+}
+
 type BaseNamedLocation struct {
 	ODataType        *odata.Type `json:"@odata.type,omitempty"`
 	ID               *string     `json:"id,omitempty"`

--- a/msgraph/valuetypes.go
+++ b/msgraph/valuetypes.go
@@ -251,12 +251,42 @@ const (
 	AuthenticationMethodKeyStrengthUnknown AuthenticationMethodKeyStrength = "unknown"
 )
 
+type AuthenticationMethodModes = string
+
+const (
+	AuthenticationMethodModesEmail                       AuthenticationMethodModes = "email"
+	AuthenticationMethodModesFederatedMultiFactor        AuthenticationMethodModes = "federatedMultiFactor"
+	AuthenticationMethodModesFederatedSingleFactor       AuthenticationMethodModes = "federatedSingleFactor"
+	AuthenticationMethodModesFido2                       AuthenticationMethodModes = "fido2"
+	AuthenticationMethodModesHardwareOath                AuthenticationMethodModes = "hardwareOath"
+	AuthenticationMethodModesMicrosoftAuthenticatorPush  AuthenticationMethodModes = "microsoftAuthenticatorPush"
+	AuthenticationMethodModesMicrosoftDeviceBasedPush    AuthenticationMethodModes = "deviceBasedPush"
+	AuthenticationMethodModesPassword                    AuthenticationMethodModes = "password"
+	AuthenticationMethodModesSms                         AuthenticationMethodModes = "sms"
+	AuthenticationMethodModesSoftwareOath                AuthenticationMethodModes = "softwareOath"
+	AuthenticationMethodModesTemporaryAccessPassMultiUse AuthenticationMethodModes = "temporaryAccessPassMultiUse"
+	AuthenticationMethodModesTemporaryAccessPassOneTime  AuthenticationMethodModes = "temporaryAccessPassOneTime"
+	AuthenticationMethodModesUnknownFutureValue          AuthenticationMethodModes = "unknownFutureValue"
+	AuthenticationMethodModesVoice                       AuthenticationMethodModes = "voice"
+	AuthenticationMethodModesWindowsHelloForBusiness     AuthenticationMethodModes = "windowsHelloForBusiness"
+	AuthenticationMethodModesX509CertificateMultiFactor  AuthenticationMethodModes = "x509CertificateMultiFactor"
+	AuthenticationMethodModesX509CertificateSingleFactor AuthenticationMethodModes = "x509CertificateSingleFactor"
+)
+
 type AuthenticationPhoneType = string
 
 const (
 	AuthenticationPhoneTypeMobile          AuthenticationPhoneType = "mobile"
 	AuthenticationPhoneTypeAlternateMobile AuthenticationPhoneType = "alternateMobile"
 	AuthenticationPhoneTypeOffice          AuthenticationPhoneType = "office"
+)
+
+type AuthenticationStrengthPolicyType = string
+
+const (
+	authenticationStrengthPolicyTypeBuiltIn            AuthenticationStrengthPolicyType = "builtIn"
+	authenticationStrengthPolicyTypeCustom             AuthenticationStrengthPolicyType = "custom"
+	authenticationStrengthPolicyTypeUnknownFutureValue AuthenticationStrengthPolicyType = "unknownFutureValue"
 )
 
 type BodyType = string

--- a/msgraph/valuetypes.go
+++ b/msgraph/valuetypes.go
@@ -284,9 +284,9 @@ const (
 type AuthenticationStrengthPolicyType = string
 
 const (
-	authenticationStrengthPolicyTypeBuiltIn            AuthenticationStrengthPolicyType = "builtIn"
-	authenticationStrengthPolicyTypeCustom             AuthenticationStrengthPolicyType = "custom"
-	authenticationStrengthPolicyTypeUnknownFutureValue AuthenticationStrengthPolicyType = "unknownFutureValue"
+	AuthenticationStrengthPolicyTypeBuiltIn            AuthenticationStrengthPolicyType = "builtIn"
+	AuthenticationStrengthPolicyTypeCustom             AuthenticationStrengthPolicyType = "custom"
+	AuthenticationStrengthPolicyTypeUnknownFutureValue AuthenticationStrengthPolicyType = "unknownFutureValue"
 )
 
 type BodyType = string


### PR DESCRIPTION
Adding support for `AuthenticationStrengthPolicies`.

Microsoft GraphAPI doco - https://learn.microsoft.com/en-us/graph/api/resources/authenticationstrengthpolicy?view=graph-rest-1.0