### PR TITLE
Bugfix: enable `grantControls` or `sessionControls`

### DIFF
--- a/msgraph/conditionalaccesspolicy_test.go
+++ b/msgraph/conditionalaccesspolicy_test.go
@@ -58,6 +58,26 @@ func TestConditionalAccessPolicyClient(t *testing.T) {
 	updatePolicy := msgraph.ConditionalAccessPolicy{
 		ID:          policy.ID,
 		DisplayName: utils.StringPtr(fmt.Sprintf("test-policy-updated-%s", c.RandomString)),
+		Conditions: &msgraph.ConditionalAccessConditionSet{
+			ClientAppTypes: &[]string{"all"},
+			Applications: &msgraph.ConditionalAccessApplications{
+				IncludeApplications: &[]string{testAppId},
+			},
+			Users: &msgraph.ConditionalAccessUsers{
+				IncludeUsers:  &[]string{"All"},
+				ExcludeUsers:  &[]string{*testUser.ID(), "GuestsOrExternalUsers"},
+				IncludeGroups: &[]string{*testIncGroup.ID()},
+				ExcludeGroups: &[]string{*testExcGroup.ID()},
+			},
+			Locations: &msgraph.ConditionalAccessLocations{
+				IncludeLocations: &[]string{"All"},
+				ExcludeLocations: &[]string{"AllTrusted"},
+			},
+		},
+		GrantControls: &msgraph.ConditionalAccessGrantControls{
+			Operator:        utils.StringPtr("OR"),
+			BuiltInControls: &[]string{"block"},
+		},
 	}
 	testConditionalAccessPolicysClient_Update(t, c, updatePolicy)
 

--- a/msgraph/models.go
+++ b/msgraph/models.go
@@ -677,10 +677,10 @@ type ConditionalAccessPolicy struct {
 	Conditions       *ConditionalAccessConditionSet    `json:"conditions,omitempty"`
 	CreatedDateTime  *time.Time                        `json:"createdDateTime,omitempty"`
 	DisplayName      *string                           `json:"displayName,omitempty"`
-	GrantControls    *ConditionalAccessGrantControls   `json:"grantControls,omitempty"`
+	GrantControls    *ConditionalAccessGrantControls   `json:"grantControls"`
 	ID               *string                           `json:"id,omitempty"`
 	ModifiedDateTime *time.Time                        `json:"modifiedDateTime,omitempty"`
-	SessionControls  *ConditionalAccessSessionControls `json:"sessionControls,omitempty"`
+	SessionControls  *ConditionalAccessSessionControls `json:"sessionControls"`
 	State            *ConditionalAccessPolicyState     `json:"state,omitempty"`
 }
 


### PR DESCRIPTION
Conditional Access Policies can have `grantControls` or `sessionControls`, or both, but must be explicitly null in the `or` case