### PR TITLE
Add support for PIM AAD Group assignments

### DIFF
--- a/internal/test/testing.go
+++ b/internal/test/testing.go
@@ -91,52 +91,53 @@ type Test struct {
 	Claims *claims.Claims
 	Token  *oauth2.Token
 
-	AccessPackageAssignmentPolicyClient       *msgraph.AccessPackageAssignmentPolicyClient
-	AccessPackageAssignmentRequestClient      *msgraph.AccessPackageAssignmentRequestClient
-	AccessPackageCatalogClient                *msgraph.AccessPackageCatalogClient
-	AccessPackageClient                       *msgraph.AccessPackageClient
-	AccessPackageResourceClient               *msgraph.AccessPackageResourceClient
-	AccessPackageResourceRequestClient        *msgraph.AccessPackageResourceRequestClient
-	AccessPackageResourceRoleScopeClient      *msgraph.AccessPackageResourceRoleScopeClient
-	AdministrativeUnitsClient                 *msgraph.AdministrativeUnitsClient
-	ApplicationTemplatesClient                *msgraph.ApplicationTemplatesClient
-	ApplicationsClient                        *msgraph.ApplicationsClient
-	AppRoleAssignedToClient                   *msgraph.AppRoleAssignedToClient
-	AuthenticationMethodsClient               *msgraph.AuthenticationMethodsClient
-	AuthenticationStrengthPoliciesClient      *msgraph.AuthenticationStrengthPoliciesClient
-	B2CUserFlowClient                         *msgraph.B2CUserFlowClient
-	ClaimsMappingPolicyClient                 *msgraph.ClaimsMappingPolicyClient
-	ConditionalAccessPoliciesClient           *msgraph.ConditionalAccessPoliciesClient
-	ConnectedOrganizationClient               *msgraph.ConnectedOrganizationClient
-	DelegatedPermissionGrantsClient           *msgraph.DelegatedPermissionGrantsClient
-	DirectoryAuditReportsClient               *msgraph.DirectoryAuditReportsClient
-	DirectoryObjectsClient                    *msgraph.DirectoryObjectsClient
-	DirectoryRoleTemplatesClient              *msgraph.DirectoryRoleTemplatesClient
-	DirectoryRolesClient                      *msgraph.DirectoryRolesClient
-	DomainsClient                             *msgraph.DomainsClient
-	EntitlementRoleAssignmentsClient          *msgraph.EntitlementRoleAssignmentsClient
-	EntitlementRoleDefinitionsClient          *msgraph.EntitlementRoleDefinitionsClient
-	GroupsAppRoleAssignmentsClient            *msgraph.AppRoleAssignmentsClient
-	GroupsClient                              *msgraph.GroupsClient
-	IdentityProvidersClient                   *msgraph.IdentityProvidersClient
-	InvitationsClient                         *msgraph.InvitationsClient
-	MeClient                                  *msgraph.MeClient
-	NamedLocationsClient                      *msgraph.NamedLocationsClient
-	ReportsClient                             *msgraph.ReportsClient
-	RoleAssignmentsClient                     *msgraph.RoleAssignmentsClient
-	RoleDefinitionsClient                     *msgraph.RoleDefinitionsClient
-	RoleEligibilityScheduleRequestClient      *msgraph.RoleEligibilityScheduleRequestClient
-	SchemaExtensionsClient                    *msgraph.SchemaExtensionsClient
-	ServicePrincipalsAppRoleAssignmentsClient *msgraph.AppRoleAssignmentsClient
-	ServicePrincipalsClient                   *msgraph.ServicePrincipalsClient
-	SignInReportsClient                       *msgraph.SignInReportsClient
-	SynchronizationJobClient                  *msgraph.SynchronizationJobClient
-	TermsOfUseAgreementClient                 *msgraph.TermsOfUseAgreementClient
-	TokenIssuancePolicyClient                 *msgraph.TokenIssuancePolicyClient
-	UserFlowAttributesClient                  *msgraph.UserFlowAttributesClient
-	UsersAppRoleAssignmentsClient             *msgraph.AppRoleAssignmentsClient
-	UsersClient                               *msgraph.UsersClient
-	WindowsAutopilotDeploymentProfilesClient  *msgraph.WindowsAutopilotDeploymentProfilesClient
+	AccessPackageAssignmentPolicyClient           *msgraph.AccessPackageAssignmentPolicyClient
+	AccessPackageAssignmentRequestClient          *msgraph.AccessPackageAssignmentRequestClient
+	AccessPackageCatalogClient                    *msgraph.AccessPackageCatalogClient
+	AccessPackageClient                           *msgraph.AccessPackageClient
+	AccessPackageResourceClient                   *msgraph.AccessPackageResourceClient
+	AccessPackageResourceRequestClient            *msgraph.AccessPackageResourceRequestClient
+	AccessPackageResourceRoleScopeClient          *msgraph.AccessPackageResourceRoleScopeClient
+	AdministrativeUnitsClient                     *msgraph.AdministrativeUnitsClient
+	ApplicationTemplatesClient                    *msgraph.ApplicationTemplatesClient
+	ApplicationsClient                            *msgraph.ApplicationsClient
+	AppRoleAssignedToClient                       *msgraph.AppRoleAssignedToClient
+	AuthenticationMethodsClient                   *msgraph.AuthenticationMethodsClient
+	AuthenticationStrengthPoliciesClient          *msgraph.AuthenticationStrengthPoliciesClient
+	B2CUserFlowClient                             *msgraph.B2CUserFlowClient
+	ClaimsMappingPolicyClient                     *msgraph.ClaimsMappingPolicyClient
+	ConditionalAccessPoliciesClient               *msgraph.ConditionalAccessPoliciesClient
+	ConnectedOrganizationClient                   *msgraph.ConnectedOrganizationClient
+	DelegatedPermissionGrantsClient               *msgraph.DelegatedPermissionGrantsClient
+	DirectoryAuditReportsClient                   *msgraph.DirectoryAuditReportsClient
+	DirectoryObjectsClient                        *msgraph.DirectoryObjectsClient
+	DirectoryRoleTemplatesClient                  *msgraph.DirectoryRoleTemplatesClient
+	DirectoryRolesClient                          *msgraph.DirectoryRolesClient
+	DomainsClient                                 *msgraph.DomainsClient
+	EntitlementRoleAssignmentsClient              *msgraph.EntitlementRoleAssignmentsClient
+	EntitlementRoleDefinitionsClient              *msgraph.EntitlementRoleDefinitionsClient
+	GroupsAppRoleAssignmentsClient                *msgraph.AppRoleAssignmentsClient
+	GroupsClient                                  *msgraph.GroupsClient
+	IdentityProvidersClient                       *msgraph.IdentityProvidersClient
+	InvitationsClient                             *msgraph.InvitationsClient
+	MeClient                                      *msgraph.MeClient
+	NamedLocationsClient                          *msgraph.NamedLocationsClient
+	PrivilegedAccessGroupAssignmentScheduleClient *msgraph.PrivilegedAccessGroupAssignmentScheduleClient
+	ReportsClient                                 *msgraph.ReportsClient
+	RoleAssignmentsClient                         *msgraph.RoleAssignmentsClient
+	RoleDefinitionsClient                         *msgraph.RoleDefinitionsClient
+	RoleEligibilityScheduleRequestClient          *msgraph.RoleEligibilityScheduleRequestClient
+	SchemaExtensionsClient                        *msgraph.SchemaExtensionsClient
+	ServicePrincipalsAppRoleAssignmentsClient     *msgraph.AppRoleAssignmentsClient
+	ServicePrincipalsClient                       *msgraph.ServicePrincipalsClient
+	SignInReportsClient                           *msgraph.SignInReportsClient
+	SynchronizationJobClient                      *msgraph.SynchronizationJobClient
+	TermsOfUseAgreementClient                     *msgraph.TermsOfUseAgreementClient
+	TokenIssuancePolicyClient                     *msgraph.TokenIssuancePolicyClient
+	UserFlowAttributesClient                      *msgraph.UserFlowAttributesClient
+	UsersAppRoleAssignmentsClient                 *msgraph.AppRoleAssignmentsClient
+	UsersClient                                   *msgraph.UsersClient
+	WindowsAutopilotDeploymentProfilesClient      *msgraph.WindowsAutopilotDeploymentProfilesClient
 }
 
 func NewTest(t *testing.T) (c *Test) {
@@ -344,6 +345,11 @@ func NewTest(t *testing.T) (c *Test) {
 	c.NamedLocationsClient.BaseClient.Authorizer = c.Connections["default"].Authorizer
 	c.NamedLocationsClient.BaseClient.Endpoint = *endpoint
 	c.NamedLocationsClient.BaseClient.RetryableClient.RetryMax = retry
+
+	c.PrivilegedAccessGroupAssignmentScheduleClient = msgraph.NewPrivilegedAccessGroupAssignmentScheduleClient()
+	c.PrivilegedAccessGroupAssignmentScheduleClient.BaseClient.Authorizer = c.Connections["default"].Authorizer
+	c.PrivilegedAccessGroupAssignmentScheduleClient.BaseClient.Endpoint = *endpoint
+	c.PrivilegedAccessGroupAssignmentScheduleClient.BaseClient.RetryableClient.RetryMax = retry
 
 	c.ReportsClient = msgraph.NewReportsClient()
 	c.ReportsClient.BaseClient.Authorizer = c.Connections["default"].Authorizer

--- a/internal/test/testing.go
+++ b/internal/test/testing.go
@@ -91,53 +91,55 @@ type Test struct {
 	Claims *claims.Claims
 	Token  *oauth2.Token
 
-	AccessPackageAssignmentPolicyClient           *msgraph.AccessPackageAssignmentPolicyClient
-	AccessPackageAssignmentRequestClient          *msgraph.AccessPackageAssignmentRequestClient
-	AccessPackageCatalogClient                    *msgraph.AccessPackageCatalogClient
-	AccessPackageClient                           *msgraph.AccessPackageClient
-	AccessPackageResourceClient                   *msgraph.AccessPackageResourceClient
-	AccessPackageResourceRequestClient            *msgraph.AccessPackageResourceRequestClient
-	AccessPackageResourceRoleScopeClient          *msgraph.AccessPackageResourceRoleScopeClient
-	AdministrativeUnitsClient                     *msgraph.AdministrativeUnitsClient
-	ApplicationTemplatesClient                    *msgraph.ApplicationTemplatesClient
-	ApplicationsClient                            *msgraph.ApplicationsClient
-	AppRoleAssignedToClient                       *msgraph.AppRoleAssignedToClient
-	AuthenticationMethodsClient                   *msgraph.AuthenticationMethodsClient
-	AuthenticationStrengthPoliciesClient          *msgraph.AuthenticationStrengthPoliciesClient
-	B2CUserFlowClient                             *msgraph.B2CUserFlowClient
-	ClaimsMappingPolicyClient                     *msgraph.ClaimsMappingPolicyClient
-	ConditionalAccessPoliciesClient               *msgraph.ConditionalAccessPoliciesClient
-	ConnectedOrganizationClient                   *msgraph.ConnectedOrganizationClient
-	DelegatedPermissionGrantsClient               *msgraph.DelegatedPermissionGrantsClient
-	DirectoryAuditReportsClient                   *msgraph.DirectoryAuditReportsClient
-	DirectoryObjectsClient                        *msgraph.DirectoryObjectsClient
-	DirectoryRoleTemplatesClient                  *msgraph.DirectoryRoleTemplatesClient
-	DirectoryRolesClient                          *msgraph.DirectoryRolesClient
-	DomainsClient                                 *msgraph.DomainsClient
-	EntitlementRoleAssignmentsClient              *msgraph.EntitlementRoleAssignmentsClient
-	EntitlementRoleDefinitionsClient              *msgraph.EntitlementRoleDefinitionsClient
-	GroupsAppRoleAssignmentsClient                *msgraph.AppRoleAssignmentsClient
-	GroupsClient                                  *msgraph.GroupsClient
-	IdentityProvidersClient                       *msgraph.IdentityProvidersClient
-	InvitationsClient                             *msgraph.InvitationsClient
-	MeClient                                      *msgraph.MeClient
-	NamedLocationsClient                          *msgraph.NamedLocationsClient
-	PrivilegedAccessGroupAssignmentScheduleClient *msgraph.PrivilegedAccessGroupAssignmentScheduleClient
-	ReportsClient                                 *msgraph.ReportsClient
-	RoleAssignmentsClient                         *msgraph.RoleAssignmentsClient
-	RoleDefinitionsClient                         *msgraph.RoleDefinitionsClient
-	RoleEligibilityScheduleRequestClient          *msgraph.RoleEligibilityScheduleRequestClient
-	SchemaExtensionsClient                        *msgraph.SchemaExtensionsClient
-	ServicePrincipalsAppRoleAssignmentsClient     *msgraph.AppRoleAssignmentsClient
-	ServicePrincipalsClient                       *msgraph.ServicePrincipalsClient
-	SignInReportsClient                           *msgraph.SignInReportsClient
-	SynchronizationJobClient                      *msgraph.SynchronizationJobClient
-	TermsOfUseAgreementClient                     *msgraph.TermsOfUseAgreementClient
-	TokenIssuancePolicyClient                     *msgraph.TokenIssuancePolicyClient
-	UserFlowAttributesClient                      *msgraph.UserFlowAttributesClient
-	UsersAppRoleAssignmentsClient                 *msgraph.AppRoleAssignmentsClient
-	UsersClient                                   *msgraph.UsersClient
-	WindowsAutopilotDeploymentProfilesClient      *msgraph.WindowsAutopilotDeploymentProfilesClient
+	AccessPackageAssignmentPolicyClient                    *msgraph.AccessPackageAssignmentPolicyClient
+	AccessPackageAssignmentRequestClient                   *msgraph.AccessPackageAssignmentRequestClient
+	AccessPackageCatalogClient                             *msgraph.AccessPackageCatalogClient
+	AccessPackageClient                                    *msgraph.AccessPackageClient
+	AccessPackageResourceClient                            *msgraph.AccessPackageResourceClient
+	AccessPackageResourceRequestClient                     *msgraph.AccessPackageResourceRequestClient
+	AccessPackageResourceRoleScopeClient                   *msgraph.AccessPackageResourceRoleScopeClient
+	AdministrativeUnitsClient                              *msgraph.AdministrativeUnitsClient
+	ApplicationTemplatesClient                             *msgraph.ApplicationTemplatesClient
+	ApplicationsClient                                     *msgraph.ApplicationsClient
+	AppRoleAssignedToClient                                *msgraph.AppRoleAssignedToClient
+	AuthenticationMethodsClient                            *msgraph.AuthenticationMethodsClient
+	AuthenticationStrengthPoliciesClient                   *msgraph.AuthenticationStrengthPoliciesClient
+	B2CUserFlowClient                                      *msgraph.B2CUserFlowClient
+	ClaimsMappingPolicyClient                              *msgraph.ClaimsMappingPolicyClient
+	ConditionalAccessPoliciesClient                        *msgraph.ConditionalAccessPoliciesClient
+	ConnectedOrganizationClient                            *msgraph.ConnectedOrganizationClient
+	DelegatedPermissionGrantsClient                        *msgraph.DelegatedPermissionGrantsClient
+	DirectoryAuditReportsClient                            *msgraph.DirectoryAuditReportsClient
+	DirectoryObjectsClient                                 *msgraph.DirectoryObjectsClient
+	DirectoryRoleTemplatesClient                           *msgraph.DirectoryRoleTemplatesClient
+	DirectoryRolesClient                                   *msgraph.DirectoryRolesClient
+	DomainsClient                                          *msgraph.DomainsClient
+	EntitlementRoleAssignmentsClient                       *msgraph.EntitlementRoleAssignmentsClient
+	EntitlementRoleDefinitionsClient                       *msgraph.EntitlementRoleDefinitionsClient
+	GroupsAppRoleAssignmentsClient                         *msgraph.AppRoleAssignmentsClient
+	GroupsClient                                           *msgraph.GroupsClient
+	IdentityProvidersClient                                *msgraph.IdentityProvidersClient
+	InvitationsClient                                      *msgraph.InvitationsClient
+	MeClient                                               *msgraph.MeClient
+	NamedLocationsClient                                   *msgraph.NamedLocationsClient
+	PrivilegedAccessGroupAssignmentScheduleClient          *msgraph.PrivilegedAccessGroupAssignmentScheduleClient
+	PrivilegedAccessGroupAssignmentScheduleInstancesClient *msgraph.PrivilegedAccessGroupAssignmentScheduleInstancesClient
+	PrivilegedAccessGroupAssignmentScheduleRequestsClient  *msgraph.PrivilegedAccessGroupAssignmentScheduleRequestsClient
+	ReportsClient                                          *msgraph.ReportsClient
+	RoleAssignmentsClient                                  *msgraph.RoleAssignmentsClient
+	RoleDefinitionsClient                                  *msgraph.RoleDefinitionsClient
+	RoleEligibilityScheduleRequestClient                   *msgraph.RoleEligibilityScheduleRequestClient
+	SchemaExtensionsClient                                 *msgraph.SchemaExtensionsClient
+	ServicePrincipalsAppRoleAssignmentsClient              *msgraph.AppRoleAssignmentsClient
+	ServicePrincipalsClient                                *msgraph.ServicePrincipalsClient
+	SignInReportsClient                                    *msgraph.SignInReportsClient
+	SynchronizationJobClient                               *msgraph.SynchronizationJobClient
+	TermsOfUseAgreementClient                              *msgraph.TermsOfUseAgreementClient
+	TokenIssuancePolicyClient                              *msgraph.TokenIssuancePolicyClient
+	UserFlowAttributesClient                               *msgraph.UserFlowAttributesClient
+	UsersAppRoleAssignmentsClient                          *msgraph.AppRoleAssignmentsClient
+	UsersClient                                            *msgraph.UsersClient
+	WindowsAutopilotDeploymentProfilesClient               *msgraph.WindowsAutopilotDeploymentProfilesClient
 }
 
 func NewTest(t *testing.T) (c *Test) {
@@ -350,6 +352,16 @@ func NewTest(t *testing.T) (c *Test) {
 	c.PrivilegedAccessGroupAssignmentScheduleClient.BaseClient.Authorizer = c.Connections["default"].Authorizer
 	c.PrivilegedAccessGroupAssignmentScheduleClient.BaseClient.Endpoint = *endpoint
 	c.PrivilegedAccessGroupAssignmentScheduleClient.BaseClient.RetryableClient.RetryMax = retry
+
+	c.PrivilegedAccessGroupAssignmentScheduleInstancesClient = msgraph.NewPrivilegedAccessGroupAssignmentScheduleInstancesClient()
+	c.PrivilegedAccessGroupAssignmentScheduleInstancesClient.BaseClient.Authorizer = c.Connections["default"].Authorizer
+	c.PrivilegedAccessGroupAssignmentScheduleInstancesClient.BaseClient.Endpoint = *endpoint
+	c.PrivilegedAccessGroupAssignmentScheduleInstancesClient.BaseClient.RetryableClient.RetryMax = retry
+
+	c.PrivilegedAccessGroupAssignmentScheduleRequestsClient = msgraph.NewPrivilegedAccessGroupAssignmentScheduleRequestsClient()
+	c.PrivilegedAccessGroupAssignmentScheduleRequestsClient.BaseClient.Authorizer = c.Connections["default"].Authorizer
+	c.PrivilegedAccessGroupAssignmentScheduleRequestsClient.BaseClient.Endpoint = *endpoint
+	c.PrivilegedAccessGroupAssignmentScheduleRequestsClient.BaseClient.RetryableClient.RetryMax = retry
 
 	c.ReportsClient = msgraph.NewReportsClient()
 	c.ReportsClient.BaseClient.Authorizer = c.Connections["default"].Authorizer

--- a/msgraph/models.go
+++ b/msgraph/models.go
@@ -1353,6 +1353,51 @@ type PhoneAuthenticationMethod struct {
 	PhoneNumber *string                  `json:"phoneNumber,omitempty"`
 	PhoneType   *AuthenticationPhoneType `json:"phoneType,omitempty"`
 }
+
+type PrivilegedAccessGroupAssignmentSchedule struct {
+	ID               *string                              `json:"id,omitempty"`
+	AccessId         *PrivilegedAccessGroupRelationship   `json:"accessId,omitempty"`
+	AssignmentType   *PrivilegedAccessGroupAssignmentType `json:"assignmentType,omitempty"`
+	CreatedDateTime  *time.Time                           `json:"createdDateTime,omitempty"`
+	CreatedUsing     *string                              `json:"createdUsing,omitempty"`
+	GroupId          *string                              `json:"groupId,omitempty"`
+	MemberType       *PrivilegedAccessGroupMemberType     `json:"memberType,omitempty"`
+	ModifiedDateTime *time.Time                           `json:"modifiedDateTime,omitempty"`
+	PrincipalId      *string                              `json:"principalId,omitempty"`
+	ScheduleInfo     *RequestSchedule                     `json:"scheduleInfo,omitempty"`
+	Status           *string                              `json:"status,omitempty"`
+}
+
+type PrivilegedAccessGroupAssignmentScheduleInstance struct {
+	ID                   *string                              `json:"id,omitempty"`
+	AccessId             *PrivilegedAccessGroupRelationship   `json:"accessId,omitempty"`
+	AssignmentScheduleId *string                              `json:"assignmentScheduleId,omitempty"`
+	AssignmentType       *PrivilegedAccessGroupAssignmentType `json:"assignmentType,omitempty"`
+	EndDateTime          *time.Time                           `json:"createdDateTime,omitempty"`
+	GroupId              *string                              `json:"groupId,omitempty"`
+	MemberType           *PrivilegedAccessGroupMemberType     `json:"memberType,omitempty"`
+	PrincipalId          *string                              `json:"principalId,omitempty"`
+	StartDateTime        *time.Time                           `json:"startDateTime,omitempty"`
+}
+
+type PrivilegedAccessGroupAssignmentScheduleRequest struct {
+	ID                *string                                `json:"id,omitempty"`
+	AccessId          *PrivilegedAccessGroupRelationship     `json:"accessId,omitempty"`
+	Action            *PrivilegedAccessGroupAssignmentAction `json:"action,omitempty"`
+	ApprovalId        *string                                `json:"approvalId,omitempty"`
+	CompletedDateTime *time.Time                             `json:"completedDateTime,omitempty"`
+	CreatedDateTime   *time.Time                             `json:"createdDateTime,omitempty"`
+	CustomData        *string                                `json:"customData,omitempty"`
+	GroupId           *string                                `json:"groupId,omitempty"`
+	IsValidationOnly  *bool                                  `json:"isValidationOnly,omitempty"`
+	Justification     *string                                `json:"justification,omitempty"`
+	PrincipalId       *string                                `json:"principalId,omitempty"`
+	ScheduleInfo      *RequestSchedule                       `json:"scheduleInfo,omitempty"`
+	Status            *string                                `json:"status,omitempty"`
+	TargetScheduleId  *string                                `json:"targetScheduleId,omitempty"`
+	TicketInfo        *TicketInfo                            `json:"ticketInfo,omitempty"`
+}
+
 type PublicClient struct {
 	RedirectUris *[]string `json:"redirectUris,omitempty"`
 }

--- a/msgraph/models.go
+++ b/msgraph/models.go
@@ -1381,21 +1381,21 @@ type PrivilegedAccessGroupAssignmentScheduleInstance struct {
 }
 
 type PrivilegedAccessGroupAssignmentScheduleRequest struct {
-	ID                *string                                `json:"id,omitempty"`
-	AccessId          *PrivilegedAccessGroupRelationship     `json:"accessId,omitempty"`
-	Action            *PrivilegedAccessGroupAssignmentAction `json:"action,omitempty"`
-	ApprovalId        *string                                `json:"approvalId,omitempty"`
-	CompletedDateTime *time.Time                             `json:"completedDateTime,omitempty"`
-	CreatedDateTime   *time.Time                             `json:"createdDateTime,omitempty"`
-	CustomData        *string                                `json:"customData,omitempty"`
-	GroupId           *string                                `json:"groupId,omitempty"`
-	IsValidationOnly  *bool                                  `json:"isValidationOnly,omitempty"`
-	Justification     *string                                `json:"justification,omitempty"`
-	PrincipalId       *string                                `json:"principalId,omitempty"`
-	ScheduleInfo      *RequestSchedule                       `json:"scheduleInfo,omitempty"`
-	Status            *string                                `json:"status,omitempty"`
-	TargetScheduleId  *string                                `json:"targetScheduleId,omitempty"`
-	TicketInfo        *TicketInfo                            `json:"ticketInfo,omitempty"`
+	ID                *string                            `json:"id,omitempty"`
+	AccessId          *PrivilegedAccessGroupRelationship `json:"accessId,omitempty"`
+	Action            *PrivilegedAccessGroupAction       `json:"action,omitempty"`
+	ApprovalId        *string                            `json:"approvalId,omitempty"`
+	CompletedDateTime *time.Time                         `json:"completedDateTime,omitempty"`
+	CreatedDateTime   *time.Time                         `json:"createdDateTime,omitempty"`
+	CustomData        *string                            `json:"customData,omitempty"`
+	GroupId           *string                            `json:"groupId,omitempty"`
+	IsValidationOnly  *bool                              `json:"isValidationOnly,omitempty"`
+	Justification     *string                            `json:"justification,omitempty"`
+	PrincipalId       *string                            `json:"principalId,omitempty"`
+	ScheduleInfo      *RequestSchedule                   `json:"scheduleInfo,omitempty"`
+	Status            *string                            `json:"status,omitempty"`
+	TargetScheduleId  *string                            `json:"targetScheduleId,omitempty"`
+	TicketInfo        *TicketInfo                        `json:"ticketInfo,omitempty"`
 }
 
 type PublicClient struct {

--- a/msgraph/models.go
+++ b/msgraph/models.go
@@ -947,9 +947,9 @@ type ExtensionSchemaProperty struct {
 }
 
 type ExpirationPattern struct {
-	Duration    *time.Duration         `json:"duration,omitempty"`
-	EndDateTime *time.Time             `json:"endDateTime,omitempty"`
-	Type        *ExpirationPatternType `json:"type,omitempty"`
+	Duration    *time.Duration        `json:"duration,omitempty"`
+	EndDateTime *time.Time            `json:"endDateTime,omitempty"`
+	Type        ExpirationPatternType `json:"type,omitempty"`
 }
 
 type FederatedIdentityCredential struct {
@@ -1355,47 +1355,47 @@ type PhoneAuthenticationMethod struct {
 }
 
 type PrivilegedAccessGroupAssignmentSchedule struct {
-	ID               *string                              `json:"id,omitempty"`
-	AccessId         *PrivilegedAccessGroupRelationship   `json:"accessId,omitempty"`
-	AssignmentType   *PrivilegedAccessGroupAssignmentType `json:"assignmentType,omitempty"`
-	CreatedDateTime  *time.Time                           `json:"createdDateTime,omitempty"`
-	CreatedUsing     *string                              `json:"createdUsing,omitempty"`
-	GroupId          *string                              `json:"groupId,omitempty"`
-	MemberType       *PrivilegedAccessGroupMemberType     `json:"memberType,omitempty"`
-	ModifiedDateTime *time.Time                           `json:"modifiedDateTime,omitempty"`
-	PrincipalId      *string                              `json:"principalId,omitempty"`
-	ScheduleInfo     *RequestSchedule                     `json:"scheduleInfo,omitempty"`
-	Status           *string                              `json:"status,omitempty"`
+	ID               *string                               `json:"id,omitempty"`
+	AccessId         PrivilegedAccessGroupRelationship     `json:"accessId,omitempty"`
+	AssignmentType   PrivilegedAccessGroupAssignmentType   `json:"assignmentType,omitempty"`
+	CreatedDateTime  *time.Time                            `json:"createdDateTime,omitempty"`
+	CreatedUsing     *string                               `json:"createdUsing,omitempty"`
+	GroupId          *string                               `json:"groupId,omitempty"`
+	MemberType       PrivilegedAccessGroupMemberType       `json:"memberType,omitempty"`
+	ModifiedDateTime *time.Time                            `json:"modifiedDateTime,omitempty"`
+	PrincipalId      *string                               `json:"principalId,omitempty"`
+	ScheduleInfo     *RequestSchedule                      `json:"scheduleInfo,omitempty"`
+	Status           PrivilegedAccessGroupAssignmentStatus `json:"status,omitempty"`
 }
 
 type PrivilegedAccessGroupAssignmentScheduleInstance struct {
-	ID                   *string                              `json:"id,omitempty"`
-	AccessId             *PrivilegedAccessGroupRelationship   `json:"accessId,omitempty"`
-	AssignmentScheduleId *string                              `json:"assignmentScheduleId,omitempty"`
-	AssignmentType       *PrivilegedAccessGroupAssignmentType `json:"assignmentType,omitempty"`
-	EndDateTime          *time.Time                           `json:"createdDateTime,omitempty"`
-	GroupId              *string                              `json:"groupId,omitempty"`
-	MemberType           *PrivilegedAccessGroupMemberType     `json:"memberType,omitempty"`
-	PrincipalId          *string                              `json:"principalId,omitempty"`
-	StartDateTime        *time.Time                           `json:"startDateTime,omitempty"`
+	ID                   *string                             `json:"id,omitempty"`
+	AccessId             PrivilegedAccessGroupRelationship   `json:"accessId,omitempty"`
+	AssignmentScheduleId *string                             `json:"assignmentScheduleId,omitempty"`
+	AssignmentType       PrivilegedAccessGroupAssignmentType `json:"assignmentType,omitempty"`
+	EndDateTime          *time.Time                          `json:"createdDateTime,omitempty"`
+	GroupId              *string                             `json:"groupId,omitempty"`
+	MemberType           PrivilegedAccessGroupMemberType     `json:"memberType,omitempty"`
+	PrincipalId          *string                             `json:"principalId,omitempty"`
+	StartDateTime        *time.Time                          `json:"startDateTime,omitempty"`
 }
 
 type PrivilegedAccessGroupAssignmentScheduleRequest struct {
-	ID                *string                            `json:"id,omitempty"`
-	AccessId          *PrivilegedAccessGroupRelationship `json:"accessId,omitempty"`
-	Action            *PrivilegedAccessGroupAction       `json:"action,omitempty"`
-	ApprovalId        *string                            `json:"approvalId,omitempty"`
-	CompletedDateTime *time.Time                         `json:"completedDateTime,omitempty"`
-	CreatedDateTime   *time.Time                         `json:"createdDateTime,omitempty"`
-	CustomData        *string                            `json:"customData,omitempty"`
-	GroupId           *string                            `json:"groupId,omitempty"`
-	IsValidationOnly  *bool                              `json:"isValidationOnly,omitempty"`
-	Justification     *string                            `json:"justification,omitempty"`
-	PrincipalId       *string                            `json:"principalId,omitempty"`
-	ScheduleInfo      *RequestSchedule                   `json:"scheduleInfo,omitempty"`
-	Status            *string                            `json:"status,omitempty"`
-	TargetScheduleId  *string                            `json:"targetScheduleId,omitempty"`
-	TicketInfo        *TicketInfo                        `json:"ticketInfo,omitempty"`
+	ID                *string                               `json:"id,omitempty"`
+	AccessId          PrivilegedAccessGroupRelationship     `json:"accessId,omitempty"`
+	Action            PrivilegedAccessGroupAction           `json:"action,omitempty"`
+	ApprovalId        *string                               `json:"approvalId,omitempty"`
+	CompletedDateTime *time.Time                            `json:"completedDateTime,omitempty"`
+	CreatedDateTime   *time.Time                            `json:"createdDateTime,omitempty"`
+	CustomData        *string                               `json:"customData,omitempty"`
+	GroupId           *string                               `json:"groupId,omitempty"`
+	IsValidationOnly  *bool                                 `json:"isValidationOnly,omitempty"`
+	Justification     *string                               `json:"justification,omitempty"`
+	PrincipalId       *string                               `json:"principalId,omitempty"`
+	ScheduleInfo      *RequestSchedule                      `json:"scheduleInfo,omitempty"`
+	Status            PrivilegedAccessGroupAssignmentStatus `json:"status,omitempty"`
+	TargetScheduleId  *string                               `json:"targetScheduleId,omitempty"`
+	TicketInfo        *TicketInfo                           `json:"ticketInfo,omitempty"`
 }
 
 type PublicClient struct {

--- a/msgraph/privilegedaccess_groups_assignmentschedule.go
+++ b/msgraph/privilegedaccess_groups_assignmentschedule.go
@@ -1,0 +1,240 @@
+package msgraph
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+type PrivilegedAccessGroupAssignmentScheduleClient struct {
+	BaseClient Client
+}
+
+func NewPrivilegedAccessGroupAssignmentScheduleClient() *PrivilegedAccessGroupAssignmentScheduleClient {
+	return &PrivilegedAccessGroupAssignmentScheduleClient{
+		BaseClient: NewClient(VersionBeta),
+	}
+}
+
+// List retrieves a list of PrivilegedAccessGroupAssignments
+func (c *PrivilegedAccessGroupAssignmentScheduleClient) List(ctx context.Context, query odata.Query) (*[]PrivilegedAccessGroupAssignmentSchedule, int, error) {
+	resp, status, _, err := c.BaseClient.Get(ctx, GetHttpRequestInput{
+		DisablePaging:    query.Top > 0,
+		OData:            query,
+		ValidStatusCodes: []int{http.StatusOK},
+		Uri: Uri{
+			Entity: "/identityGovernance/privilegedAccess/group/assignmentSchedules",
+		},
+	})
+	if err != nil {
+		return nil, status, fmt.Errorf("PrivilegedAccessGroupAssignmentScheduleClient.BaseClient.Get(): %v", err)
+	}
+
+	defer resp.Body.Close()
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, status, fmt.Errorf("io.ReadAll(): %v", err)
+	}
+
+	var data struct {
+		Schedules []PrivilegedAccessGroupAssignmentSchedule `json:"value"`
+	}
+	if err := json.Unmarshal(respBody, &data); err != nil {
+		return nil, status, fmt.Errorf("json.Unmarshal(): %v", err)
+	}
+
+	return &data.Schedules, status, nil
+}
+
+// Get retrieves a PrivilegedAccessGroupAssignment
+func (c *PrivilegedAccessGroupAssignmentScheduleClient) Get(ctx context.Context, scheduleId string) (*PrivilegedAccessGroupAssignmentSchedule, int, error) {
+	resp, status, _, err := c.BaseClient.Get(ctx, GetHttpRequestInput{
+		ValidStatusCodes: []int{http.StatusOK},
+		Uri: Uri{
+			Entity: fmt.Sprintf("/identityGovernance/privilegedAccess/group/assignmentSchedules/%s", scheduleId),
+		},
+	})
+	if err != nil {
+		return nil, status, fmt.Errorf("PrivilegedAccessGroupAssignmentScheduleClient.BaseClient.Get(): %v", err)
+	}
+
+	defer resp.Body.Close()
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, status, fmt.Errorf("io.ReadAll(): %v", err)
+	}
+
+	var schedule PrivilegedAccessGroupAssignmentSchedule
+	if err := json.Unmarshal(respBody, &schedule); err != nil {
+		return nil, status, fmt.Errorf("json.Unmarshal(): %v", err)
+	}
+
+	return &schedule, status, nil
+}
+
+// List retrieves a list of PrivilegedAccessGroupAssignmentScheduleInstances
+func (c *PrivilegedAccessGroupAssignmentScheduleClient) InstancesList(ctx context.Context, query odata.Query) (*[]PrivilegedAccessGroupAssignmentScheduleInstance, int, error) {
+	resp, status, _, err := c.BaseClient.Get(ctx, GetHttpRequestInput{
+		DisablePaging:    query.Top > 0,
+		OData:            query,
+		ValidStatusCodes: []int{http.StatusOK},
+		Uri: Uri{
+			Entity: "/identityGovernance/privilegedAccess/group/assignmentScheduleInstances",
+		},
+	})
+	if err != nil {
+		return nil, status, fmt.Errorf("PrivilegedAccessGroupClient.BaseClient.Get(): %v", err)
+	}
+
+	defer resp.Body.Close()
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, status, fmt.Errorf("io.ReadAll(): %v", err)
+	}
+
+	var data struct {
+		Instances []PrivilegedAccessGroupAssignmentScheduleInstance `json:"value"`
+	}
+	if err := json.Unmarshal(respBody, &data); err != nil {
+		return nil, status, fmt.Errorf("json.Unmarshal(): %v", err)
+	}
+
+	return &data.Instances, status, nil
+}
+
+// Get retrieves a PrivilegedAccessGroupAssignmentScheduleInstance
+func (c *PrivilegedAccessGroupAssignmentScheduleClient) InstancesGet(ctx context.Context, instanceId string) (*PrivilegedAccessGroupAssignmentScheduleInstance, int, error) {
+	resp, status, _, err := c.BaseClient.Get(ctx, GetHttpRequestInput{
+		ValidStatusCodes: []int{http.StatusOK},
+		Uri: Uri{
+			Entity: fmt.Sprintf("/identityGovernance/privilegedAccess/group/assignmentScheduleInstances/%s", instanceId),
+		},
+	})
+	if err != nil {
+		return nil, status, fmt.Errorf("PrivilegedAccessGroupClient.BaseClient.Get(): %v", err)
+	}
+
+	defer resp.Body.Close()
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, status, fmt.Errorf("io.ReadAll(): %v", err)
+	}
+
+	var instance PrivilegedAccessGroupAssignmentScheduleInstance
+	if err := json.Unmarshal(respBody, &instance); err != nil {
+		return nil, status, fmt.Errorf("json.Unmarshal(): %v", err)
+	}
+
+	return &instance, status, nil
+}
+
+// List retrieves a list of PrivilegedAccessGroupAssignmentScheduleRequests
+func (c *PrivilegedAccessGroupAssignmentScheduleClient) RequestsList(ctx context.Context, query odata.Query) (*[]PrivilegedAccessGroupAssignmentScheduleRequest, int, error) {
+	resp, status, _, err := c.BaseClient.Get(ctx, GetHttpRequestInput{
+		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
+		DisablePaging:          query.Top > 0,
+		OData:                  query,
+		ValidStatusCodes:       []int{http.StatusOK},
+		Uri: Uri{
+			Entity: "/identityGovernance/privilegedAccess/group/assignmentScheduleRequests",
+		},
+	})
+	if err != nil {
+		return nil, status, fmt.Errorf("PrivilegedAccessGroupClient.BaseClient.Get(): %v", err)
+	}
+
+	defer resp.Body.Close()
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, status, fmt.Errorf("io.ReadAll(): %v", err)
+	}
+
+	var data struct {
+		Requests []PrivilegedAccessGroupAssignmentScheduleRequest `json:"value"`
+	}
+	if err := json.Unmarshal(respBody, &data); err != nil {
+		return nil, status, fmt.Errorf("json.Unmarshal(): %v", err)
+	}
+
+	return &data.Requests, status, nil
+}
+
+// Create creates a new PrivilegedAccessGroupAssignmentScheduleRequest.
+func (c *PrivilegedAccessGroupAssignmentScheduleClient) RequestsCreate(ctx context.Context, request PrivilegedAccessGroupAssignmentScheduleRequest) (*PrivilegedAccessGroupAssignmentScheduleRequest, int, error) {
+	var status int
+
+	body, err := json.Marshal(request)
+	if err != nil {
+		return nil, status, fmt.Errorf("json.Marshal(): %v", err)
+	}
+
+	resp, status, _, err := c.BaseClient.Post(ctx, PostHttpRequestInput{
+		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
+		Body:                   body,
+		ValidStatusCodes:       []int{http.StatusCreated},
+		Uri: Uri{
+			Entity: "/identityGovernance/privilegedAccess/group/assignmentScheduleRequests",
+		},
+	})
+	if err != nil && status != http.StatusNotFound {
+		return nil, status, fmt.Errorf("PrivilegedAccessGroupAssignmentScheduleRequestClient.BaseClient.Post(): %v", err)
+	}
+
+	defer resp.Body.Close()
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, status, fmt.Errorf("io.ReadAll(): %v", err)
+	}
+
+	var newRequest PrivilegedAccessGroupAssignmentScheduleRequest
+	if err := json.Unmarshal(respBody, &newRequest); err != nil {
+		return nil, status, fmt.Errorf("json.Unmarshal(): %v", err)
+	}
+
+	return &newRequest, status, nil
+}
+
+// Get retrieves a PrivilegedAccessGroupAssignmentScheduleRequest
+func (c *PrivilegedAccessGroupAssignmentScheduleClient) RequestsGet(ctx context.Context, requestId string) (*PrivilegedAccessGroupAssignmentScheduleRequest, int, error) {
+	resp, status, _, err := c.BaseClient.Get(ctx, GetHttpRequestInput{
+		ValidStatusCodes: []int{http.StatusOK},
+		Uri: Uri{
+			Entity: fmt.Sprintf("/identityGovernance/privilegedAccess/group/assignmentScheduleRequests/%s", requestId),
+		},
+	})
+	if err != nil {
+		return nil, status, fmt.Errorf("PrivilegedAccessGroupClient.BaseClient.Get(): %v", err)
+	}
+
+	defer resp.Body.Close()
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, status, fmt.Errorf("io.ReadAll(): %v", err)
+	}
+
+	var request PrivilegedAccessGroupAssignmentScheduleRequest
+	if err := json.Unmarshal(respBody, &request); err != nil {
+		return nil, status, fmt.Errorf("json.Unmarshal(): %v", err)
+	}
+
+	return &request, status, nil
+}
+
+// Cancel cancels a PrivilegedAccessGroupAssignmentScheduleRequest
+func (c *PrivilegedAccessGroupAssignmentScheduleClient) RequestsCancel(ctx context.Context, requestId string) (int, error) {
+	_, status, _, err := c.BaseClient.Post(ctx, PostHttpRequestInput{
+		ValidStatusCodes: []int{http.StatusNoContent},
+		Uri: Uri{
+			Entity: fmt.Sprintf("/identityGovernance/privilegedAccess/group/assignmentScheduleRequests/%s/cancel", requestId),
+		},
+	})
+	if err != nil {
+		return status, fmt.Errorf("PrivilegedAccessGroupClient.BaseClient.Post(): %v", err)
+	}
+
+	return status, nil
+}

--- a/msgraph/privilegedaccess_groups_assignmentschedule_instance.go
+++ b/msgraph/privilegedaccess_groups_assignmentschedule_instance.go
@@ -1,0 +1,77 @@
+package msgraph
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+type PrivilegedAccessGroupAssignmentScheduleInstancesClient struct {
+	BaseClient Client
+}
+
+func NewPrivilegedAccessGroupAssignmentScheduleInstancesClient() *PrivilegedAccessGroupAssignmentScheduleInstancesClient {
+	return &PrivilegedAccessGroupAssignmentScheduleInstancesClient{
+		BaseClient: NewClient(VersionBeta),
+	}
+}
+
+// List retrieves a list of PrivilegedAccessGroupAssignmentScheduleInstances
+func (c *PrivilegedAccessGroupAssignmentScheduleInstancesClient) List(ctx context.Context, query odata.Query) (*[]PrivilegedAccessGroupAssignmentScheduleInstance, int, error) {
+	resp, status, _, err := c.BaseClient.Get(ctx, GetHttpRequestInput{
+		DisablePaging:    query.Top > 0,
+		OData:            query,
+		ValidStatusCodes: []int{http.StatusOK},
+		Uri: Uri{
+			Entity: "/identityGovernance/privilegedAccess/group/assignmentScheduleInstances",
+		},
+	})
+	if err != nil {
+		return nil, status, fmt.Errorf("PrivilegedAccessGroupClient.BaseClient.Get(): %v", err)
+	}
+
+	defer resp.Body.Close()
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, status, fmt.Errorf("io.ReadAll(): %v", err)
+	}
+
+	var data struct {
+		Instances []PrivilegedAccessGroupAssignmentScheduleInstance `json:"value"`
+	}
+	if err := json.Unmarshal(respBody, &data); err != nil {
+		return nil, status, fmt.Errorf("json.Unmarshal(): %v", err)
+	}
+
+	return &data.Instances, status, nil
+}
+
+// Get retrieves a PrivilegedAccessGroupAssignmentScheduleInstance
+func (c *PrivilegedAccessGroupAssignmentScheduleInstancesClient) Get(ctx context.Context, instanceId string) (*PrivilegedAccessGroupAssignmentScheduleInstance, int, error) {
+	resp, status, _, err := c.BaseClient.Get(ctx, GetHttpRequestInput{
+		ValidStatusCodes: []int{http.StatusOK},
+		Uri: Uri{
+			Entity: fmt.Sprintf("/identityGovernance/privilegedAccess/group/assignmentScheduleInstances/%s", instanceId),
+		},
+	})
+	if err != nil {
+		return nil, status, fmt.Errorf("PrivilegedAccessGroupClient.BaseClient.Get(): %v", err)
+	}
+
+	defer resp.Body.Close()
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, status, fmt.Errorf("io.ReadAll(): %v", err)
+	}
+
+	var instance PrivilegedAccessGroupAssignmentScheduleInstance
+	if err := json.Unmarshal(respBody, &instance); err != nil {
+		return nil, status, fmt.Errorf("json.Unmarshal(): %v", err)
+	}
+
+	return &instance, status, nil
+}

--- a/msgraph/privilegedaccess_groups_assignmentschedule_instance_test.go
+++ b/msgraph/privilegedaccess_groups_assignmentschedule_instance_test.go
@@ -1,0 +1,40 @@
+package msgraph_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+	"github.com/manicminer/hamilton/internal/test"
+	"github.com/manicminer/hamilton/msgraph"
+)
+
+func testPrivilegedAccessGroupAssignmentScheduleInstancesClient_List(t *testing.T, c *test.Test, query odata.Query) (instances *[]msgraph.PrivilegedAccessGroupAssignmentScheduleInstance) {
+	instances, status, err := c.PrivilegedAccessGroupAssignmentScheduleInstancesClient.List(c.Context, query)
+	if err != nil {
+		t.Fatalf("PrivilegedAccessGroupAssignmentScheduleInstancesClient.List(): %v", err)
+	}
+	if status < 200 || status >= 300 {
+		t.Fatalf("PrivilegedAccessGroupAssignmentScheduleInstancesClient.List(): invalid status: %d", status)
+	}
+	if instances == nil {
+		t.Fatal("PrivilegedAccessGroupAssignmentScheduleInstancesClient.List(): PrivilegedAccessGroupAssignmentSchedule was nil")
+	}
+	if len(*instances) == 0 {
+		t.Fatal("PrivilegedAccessGroupAssignmentScheduleInstancesClient.List(): Returned zero results")
+	}
+	return
+}
+
+func testPrivilegedAccessGroupAssignmentScheduleInstancesClient_Get(t *testing.T, c *test.Test, id string) (request *msgraph.PrivilegedAccessGroupAssignmentScheduleInstance) {
+	request, status, err := c.PrivilegedAccessGroupAssignmentScheduleInstancesClient.Get(c.Context, id)
+	if err != nil {
+		t.Fatalf("PrivilegedAccessGroupAssignmentScheduleInstancesClient.Get(): %v", err)
+	}
+	if status < 200 || status >= 300 {
+		t.Fatalf("PrivilegedAccessGroupAssignmentScheduleInstancesClient.Get(): invalid status: %d", status)
+	}
+	if request == nil {
+		t.Fatal("PrivilegedAccessGroupAssignmentScheduleInstancesClient.Get(): PrivilegedAccessGroupAssignmentSchedule was nil")
+	}
+	return
+}

--- a/msgraph/privilegedaccess_groups_assignmentschedule_requests.go
+++ b/msgraph/privilegedaccess_groups_assignmentschedule_requests.go
@@ -1,0 +1,128 @@
+package msgraph
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+type PrivilegedAccessGroupAssignmentScheduleRequestsClient struct {
+	BaseClient Client
+}
+
+func NewPrivilegedAccessGroupAssignmentScheduleRequestsClient() *PrivilegedAccessGroupAssignmentScheduleRequestsClient {
+	return &PrivilegedAccessGroupAssignmentScheduleRequestsClient{
+		BaseClient: NewClient(VersionBeta),
+	}
+}
+
+// List retrieves a list of PrivilegedAccessGroupAssignmentScheduleRequests
+func (c *PrivilegedAccessGroupAssignmentScheduleRequestsClient) List(ctx context.Context, query odata.Query) (*[]PrivilegedAccessGroupAssignmentScheduleRequest, int, error) {
+	resp, status, _, err := c.BaseClient.Get(ctx, GetHttpRequestInput{
+		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
+		DisablePaging:          query.Top > 0,
+		OData:                  query,
+		ValidStatusCodes:       []int{http.StatusOK},
+		Uri: Uri{
+			Entity: "/identityGovernance/privilegedAccess/group/assignmentScheduleRequests",
+		},
+	})
+	if err != nil {
+		return nil, status, fmt.Errorf("PrivilegedAccessGroupAssignmentScheduleRequestsClient.BaseClient.Get(): %v", err)
+	}
+
+	defer resp.Body.Close()
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, status, fmt.Errorf("io.ReadAll(): %v", err)
+	}
+
+	var data struct {
+		Requests []PrivilegedAccessGroupAssignmentScheduleRequest `json:"value"`
+	}
+	if err := json.Unmarshal(respBody, &data); err != nil {
+		return nil, status, fmt.Errorf("json.Unmarshal(): %v", err)
+	}
+
+	return &data.Requests, status, nil
+}
+
+// Create creates a new PrivilegedAccessGroupAssignmentScheduleRequest.
+func (c *PrivilegedAccessGroupAssignmentScheduleRequestsClient) Create(ctx context.Context, request PrivilegedAccessGroupAssignmentScheduleRequest) (*PrivilegedAccessGroupAssignmentScheduleRequest, int, error) {
+	var status int
+
+	body, err := json.Marshal(request)
+	if err != nil {
+		return nil, status, fmt.Errorf("json.Marshal(): %v", err)
+	}
+
+	resp, status, _, err := c.BaseClient.Post(ctx, PostHttpRequestInput{
+		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
+		Body:                   body,
+		ValidStatusCodes:       []int{http.StatusCreated},
+		Uri: Uri{
+			Entity: "/identityGovernance/privilegedAccess/group/assignmentScheduleRequests",
+		},
+	})
+	if err != nil && status != http.StatusNotFound {
+		return nil, status, fmt.Errorf("PrivilegedAccessGroupAssignmentScheduleRequestsClient.BaseClient.Post(): %v", err)
+	}
+
+	defer resp.Body.Close()
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, status, fmt.Errorf("io.ReadAll(): %v", err)
+	}
+
+	var newRequest PrivilegedAccessGroupAssignmentScheduleRequest
+	if err := json.Unmarshal(respBody, &newRequest); err != nil {
+		return nil, status, fmt.Errorf("json.Unmarshal(): %v", err)
+	}
+
+	return &newRequest, status, nil
+}
+
+// Get retrieves a PrivilegedAccessGroupAssignmentScheduleRequest
+func (c *PrivilegedAccessGroupAssignmentScheduleRequestsClient) Get(ctx context.Context, requestId string) (*PrivilegedAccessGroupAssignmentScheduleRequest, int, error) {
+	resp, status, _, err := c.BaseClient.Get(ctx, GetHttpRequestInput{
+		ValidStatusCodes: []int{http.StatusOK},
+		Uri: Uri{
+			Entity: fmt.Sprintf("/identityGovernance/privilegedAccess/group/assignmentScheduleRequests/%s", requestId),
+		},
+	})
+	if err != nil {
+		return nil, status, fmt.Errorf("PrivilegedAccessGroupAssignmentScheduleRequestsClient.BaseClient.Get(): %v", err)
+	}
+
+	defer resp.Body.Close()
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, status, fmt.Errorf("io.ReadAll(): %v", err)
+	}
+
+	var request PrivilegedAccessGroupAssignmentScheduleRequest
+	if err := json.Unmarshal(respBody, &request); err != nil {
+		return nil, status, fmt.Errorf("json.Unmarshal(): %v", err)
+	}
+
+	return &request, status, nil
+}
+
+// Cancel cancels a PrivilegedAccessGroupAssignmentScheduleRequest
+func (c *PrivilegedAccessGroupAssignmentScheduleRequestsClient) Cancel(ctx context.Context, requestId string) (int, error) {
+	_, status, _, err := c.BaseClient.Post(ctx, PostHttpRequestInput{
+		ValidStatusCodes: []int{http.StatusNoContent},
+		Uri: Uri{
+			Entity: fmt.Sprintf("/identityGovernance/privilegedAccess/group/assignmentScheduleRequests/%s/cancel", requestId),
+		},
+	})
+	if err != nil {
+		return status, fmt.Errorf("PrivilegedAccessGroupAssignmentScheduleRequestsClient.BaseClient.Post(): %v", err)
+	}
+
+	return status, nil
+}

--- a/msgraph/privilegedaccess_groups_assignmentschedule_requests_test.go
+++ b/msgraph/privilegedaccess_groups_assignmentschedule_requests_test.go
@@ -1,0 +1,64 @@
+package msgraph_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+	"github.com/manicminer/hamilton/internal/test"
+	"github.com/manicminer/hamilton/msgraph"
+)
+
+func testPrivilegedAccessGroupAssignmentScheduleRequestsClient_Create(t *testing.T, c *test.Test, r msgraph.PrivilegedAccessGroupAssignmentScheduleRequest) (request *msgraph.PrivilegedAccessGroupAssignmentScheduleRequest) {
+	request, status, err := c.PrivilegedAccessGroupAssignmentScheduleRequestsClient.Create(c.Context, r)
+	if err != nil {
+		t.Fatalf("PrivilegedAccessGroupAssignmentScheduleRequestsClient.Create(): %v", err)
+	}
+	if status < 200 || status >= 300 {
+		t.Fatalf("PrivilegedAccessGroupAssignmentScheduleRequestsClient.Create(): invalid status: %d", status)
+	}
+	if request == nil {
+		t.Fatal("PrivilegedAccessGroupAssignmentScheduleRequestsClient.Create(): PrivilegedAccessGroupAssignmentScheduleRequest was nil")
+	}
+	if request.ID == nil {
+		t.Fatal("PrivilegedAccessGroupAssignmentScheduleRequestsClient.Create(): PrivilegedAccessGroupAssignmentScheduleRequest.ID was nil")
+	}
+	return
+}
+
+func testPrivilegedAccessGroupAssignmentScheduleRequestsClient_List(t *testing.T, c *test.Test) (requests *[]msgraph.PrivilegedAccessGroupAssignmentScheduleRequest) {
+	requests, status, err := c.PrivilegedAccessGroupAssignmentScheduleRequestsClient.List(c.Context, odata.Query{})
+	if err != nil {
+		t.Fatalf("PrivilegedAccessGroupAssignmentScheduleRequestsClient.List(): %v", err)
+	}
+	if status < 200 || status >= 300 {
+		t.Fatalf("PrivilegedAccessGroupAssignmentScheduleRequestsClient.List(): invalid status: %d", status)
+	}
+	if requests == nil {
+		t.Fatal("PrivilegedAccessGroupAssignmentScheduleRequestsClient.List(): PrivilegedAccessGroupAssignmentScheduleRequest was nil")
+	}
+	return
+}
+
+func testPrivilegedAccessGroupAssignmentScheduleRequestsClient_Get(t *testing.T, c *test.Test, id string) (request *msgraph.PrivilegedAccessGroupAssignmentScheduleRequest) {
+	request, status, err := c.PrivilegedAccessGroupAssignmentScheduleRequestsClient.Get(c.Context, id)
+	if err != nil {
+		t.Fatalf("PrivilegedAccessGroupAssignmentScheduleRequestsClient.Get(): %v", err)
+	}
+	if status < 200 || status >= 300 {
+		t.Fatalf("PrivilegedAccessGroupAssignmentScheduleRequestsClient.Get(): invalid status: %d", status)
+	}
+	if request == nil {
+		t.Fatal("PrivilegedAccessGroupAssignmentScheduleRequestsClient.Get(): PrivilegedAccessGroupAssignmentScheduleRequest was nil")
+	}
+	return
+}
+
+func testPrivilegedAccessGroupAssignmentScheduleRequestsClient_Cancel(t *testing.T, c *test.Test, id string) {
+	status, err := c.PrivilegedAccessGroupAssignmentScheduleRequestsClient.Cancel(c.Context, id)
+	if err != nil {
+		t.Fatalf("PrivilegedAccessGroupAssignmentScheduleRequestsClient.Cancel(): %v", err)
+	}
+	if status < 200 || status >= 300 {
+		t.Fatalf("PrivilegedAccessGroupAssignmentScheduleRequestsClient.Cancel(): invalid status: %d", status)
+	}
+}

--- a/msgraph/privilegedaccess_groups_assignmentschedule_test.go
+++ b/msgraph/privilegedaccess_groups_assignmentschedule_test.go
@@ -35,16 +35,27 @@ func TestPrivilegedAccessGroupAssignmentScheduleClient(t *testing.T) {
 	})
 	defer testGroupsClient_Delete(t, c, *groupMember.ID())
 
-	userMember := testUsersClient_Create(t, c, msgraph.User{
+	userMemberDuration := testUsersClient_Create(t, c, msgraph.User{
 		AccountEnabled:    utils.BoolPtr(true),
-		DisplayName:       utils.StringPtr("test-user-groupmember"),
-		MailNickname:      utils.StringPtr(fmt.Sprintf("test-user-groupmember-%s", c.RandomString)),
-		UserPrincipalName: utils.StringPtr(fmt.Sprintf("test-user-groupmember-%s@%s", c.RandomString, c.Connections["default"].DomainName)),
+		DisplayName:       utils.StringPtr("test-user-groupmember-duration"),
+		MailNickname:      utils.StringPtr(fmt.Sprintf("test-user-groupmember-duration-%s", c.RandomString)),
+		UserPrincipalName: utils.StringPtr(fmt.Sprintf("test-user-groupmember-duration-%s@%s", c.RandomString, c.Connections["default"].DomainName)),
 		PasswordProfile: &msgraph.UserPasswordProfile{
 			Password: utils.StringPtr(fmt.Sprintf("IrPa55w0rd%s", c.RandomString)),
 		},
 	})
-	defer testUsersClient_Delete(t, c, *userMember.ID())
+	defer testUsersClient_Delete(t, c, *userMemberDuration.ID())
+
+	userMemberFixed := testUsersClient_Create(t, c, msgraph.User{
+		AccountEnabled:    utils.BoolPtr(true),
+		DisplayName:       utils.StringPtr("test-user-groupmember-fixed"),
+		MailNickname:      utils.StringPtr(fmt.Sprintf("test-user-groupmember-fixed-%s", c.RandomString)),
+		UserPrincipalName: utils.StringPtr(fmt.Sprintf("test-user-groupmember-fixed-%s@%s", c.RandomString, c.Connections["default"].DomainName)),
+		PasswordProfile: &msgraph.UserPasswordProfile{
+			Password: utils.StringPtr(fmt.Sprintf("IrPa55w0rd%s", c.RandomString)),
+		},
+	})
+	defer testUsersClient_Delete(t, c, *userMemberFixed.ID())
 
 	userOwner := testUsersClient_Create(t, c, msgraph.User{
 		AccountEnabled:    utils.BoolPtr(true),
@@ -74,11 +85,26 @@ func TestPrivilegedAccessGroupAssignmentScheduleClient(t *testing.T) {
 		},
 	})
 
-	reqMemberUser := testPrivilegedAccessGroupAssignmentScheduleRequestsClient_Create(t, c, msgraph.PrivilegedAccessGroupAssignmentScheduleRequest{
+	reqMemberUserDuration := testPrivilegedAccessGroupAssignmentScheduleRequestsClient_Create(t, c, msgraph.PrivilegedAccessGroupAssignmentScheduleRequest{
 		AccessId:      msgraph.PrivilegedAccessGroupRelationshipMember,
 		Action:        msgraph.PrivilegedAccessGroupActionAdminAssign,
 		GroupId:       pimGroup.ID(),
-		PrincipalId:   userMember.ID(),
+		PrincipalId:   userMemberDuration.ID(),
+		Justification: utils.StringPtr("Hamilton Testing"),
+		ScheduleInfo: &msgraph.RequestSchedule{
+			StartDateTime: &future,
+			Expiration: &msgraph.ExpirationPattern{
+				Duration: utils.StringPtr("P30D"),
+				Type:     msgraph.ExpirationPatternTypeAfterDuration,
+			},
+		},
+	})
+
+	reqMemberUserFixed := testPrivilegedAccessGroupAssignmentScheduleRequestsClient_Create(t, c, msgraph.PrivilegedAccessGroupAssignmentScheduleRequest{
+		AccessId:      msgraph.PrivilegedAccessGroupRelationshipMember,
+		Action:        msgraph.PrivilegedAccessGroupActionAdminAssign,
+		GroupId:       pimGroup.ID(),
+		PrincipalId:   userMemberFixed.ID(),
 		Justification: utils.StringPtr("Hamilton Testing"),
 		ScheduleInfo: &msgraph.RequestSchedule{
 			StartDateTime: &future,
@@ -105,7 +131,8 @@ func TestPrivilegedAccessGroupAssignmentScheduleClient(t *testing.T) {
 	})
 
 	testPrivilegedAccessGroupAssignmentScheduleRequestsClient_Get(t, c, *reqOwner.ID)
-	testPrivilegedAccessGroupAssignmentScheduleRequestsClient_Get(t, c, *reqMemberUser.ID)
+	testPrivilegedAccessGroupAssignmentScheduleRequestsClient_Get(t, c, *reqMemberUserDuration.ID)
+	testPrivilegedAccessGroupAssignmentScheduleRequestsClient_Get(t, c, *reqMemberUserFixed.ID)
 	testPrivilegedAccessGroupAssignmentScheduleRequestsClient_Get(t, c, *reqMemberGroup.ID)
 
 	schedules := testPrivilegedAccessGroupAssignmentScheduleClient_List(t, c, odata.Query{
@@ -122,7 +149,8 @@ func TestPrivilegedAccessGroupAssignmentScheduleClient(t *testing.T) {
 		testPrivilegedAccessGroupAssignmentScheduleInstancesClient_Get(t, c, *inst.ID)
 	}
 
-	testPrivilegedAccessGroupAssignmentScheduleRequestsClient_Cancel(t, c, *reqMemberUser.ID)
+	testPrivilegedAccessGroupAssignmentScheduleRequestsClient_Cancel(t, c, *reqMemberUserDuration.ID)
+	testPrivilegedAccessGroupAssignmentScheduleRequestsClient_Cancel(t, c, *reqMemberUserFixed.ID)
 	testPrivilegedAccessGroupAssignmentScheduleRequestsClient_Cancel(t, c, *reqMemberGroup.ID)
 }
 

--- a/msgraph/privilegedaccess_groups_assignmentschedule_test.go
+++ b/msgraph/privilegedaccess_groups_assignmentschedule_test.go
@@ -1,0 +1,225 @@
+package msgraph_test
+
+import (
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+	"github.com/manicminer/hamilton/internal/test"
+	"github.com/manicminer/hamilton/internal/utils"
+	"github.com/manicminer/hamilton/msgraph"
+)
+
+func TestPrivilegedAccessGroupAssignmentScheduleClient(t *testing.T) {
+	c := test.NewTest(t)
+	defer c.CancelFunc()
+
+	var pimGroupId string
+	if v := os.Getenv("PIM_GROUP_ID"); v != "" {
+		pimGroupId = v
+	} else {
+		pimGroupId = "8647a803-6803-46d6-bad4-bec15c5989d6"
+	}
+
+	now := time.Now()
+	future := now.AddDate(0, 0, 7)
+	end := now.AddDate(0, 2, 0)
+
+	groupMember := testGroupsClient_Create(t, c, msgraph.Group{
+		DisplayName:     utils.StringPtr("test-group-member"),
+		MailEnabled:     utils.BoolPtr(false),
+		MailNickname:    utils.StringPtr(fmt.Sprintf("test-group-member-%s", c.RandomString)),
+		SecurityEnabled: utils.BoolPtr(true),
+	})
+	defer testGroupsClient_Delete(t, c, *groupMember.ID())
+
+	userMember := testUsersClient_Create(t, c, msgraph.User{
+		AccountEnabled:    utils.BoolPtr(true),
+		DisplayName:       utils.StringPtr("test-user-groupmember"),
+		MailNickname:      utils.StringPtr(fmt.Sprintf("test-user-groupmember-%s", c.RandomString)),
+		UserPrincipalName: utils.StringPtr(fmt.Sprintf("test-user-groupmember-%s@%s", c.RandomString, c.Connections["default"].DomainName)),
+		PasswordProfile: &msgraph.UserPasswordProfile{
+			Password: utils.StringPtr(fmt.Sprintf("IrPa55w0rd%s", c.RandomString)),
+		},
+	})
+	defer testUsersClient_Delete(t, c, *userMember.ID())
+
+	userOwner := testUsersClient_Create(t, c, msgraph.User{
+		AccountEnabled:    utils.BoolPtr(true),
+		DisplayName:       utils.StringPtr("test-user-groupowner"),
+		MailNickname:      utils.StringPtr(fmt.Sprintf("test-user-groupowner-%s", c.RandomString)),
+		UserPrincipalName: utils.StringPtr(fmt.Sprintf("test-user-groupowner-%s@%s", c.RandomString, c.Connections["default"].DomainName)),
+		PasswordProfile: &msgraph.UserPasswordProfile{
+			Password: utils.StringPtr(fmt.Sprintf("IrPa55w0rd%s", c.RandomString)),
+		},
+	})
+	defer testUsersClient_Delete(t, c, *userOwner.ID())
+
+	testPrivilegedAccessGroupAssignmentScheduleClient_RequestsList(t, c)
+
+	reqOwner := testPrivilegedAccessGroupAssignmentScheduleClient_RequestsCreate(t, c, msgraph.PrivilegedAccessGroupAssignmentScheduleRequest{
+		AccessId:      utils.StringPtr(msgraph.PrivilegedAccessGroupRelationshipOwner),
+		Action:        utils.StringPtr(msgraph.PrivilegedAccessGroupAssignmentActionAdminAssign),
+		GroupId:       utils.StringPtr(pimGroupId),
+		PrincipalId:   userOwner.ID(),
+		Justification: utils.StringPtr("Hamilton Testing"),
+		ScheduleInfo: &msgraph.RequestSchedule{
+			StartDateTime: &now,
+			Expiration: &msgraph.ExpirationPattern{
+				EndDateTime: &end,
+				Type:        utils.StringPtr(msgraph.ExpirationPatternTypeAfterDateTime),
+			},
+		},
+	})
+
+	reqMemberUser := testPrivilegedAccessGroupAssignmentScheduleClient_RequestsCreate(t, c, msgraph.PrivilegedAccessGroupAssignmentScheduleRequest{
+		AccessId:      utils.StringPtr(msgraph.PrivilegedAccessGroupRelationshipMember),
+		Action:        utils.StringPtr(msgraph.PrivilegedAccessGroupAssignmentActionAdminAssign),
+		GroupId:       utils.StringPtr(pimGroupId),
+		PrincipalId:   userMember.ID(),
+		Justification: utils.StringPtr("Hamilton Testing"),
+		ScheduleInfo: &msgraph.RequestSchedule{
+			StartDateTime: &future,
+			Expiration: &msgraph.ExpirationPattern{
+				EndDateTime: &end,
+				Type:        utils.StringPtr(msgraph.ExpirationPatternTypeAfterDateTime),
+			},
+		},
+	})
+
+	reqMemberGroup := testPrivilegedAccessGroupAssignmentScheduleClient_RequestsCreate(t, c, msgraph.PrivilegedAccessGroupAssignmentScheduleRequest{
+		AccessId:      utils.StringPtr(msgraph.PrivilegedAccessGroupRelationshipMember),
+		Action:        utils.StringPtr(msgraph.PrivilegedAccessGroupAssignmentActionAdminAssign),
+		GroupId:       utils.StringPtr(pimGroupId),
+		PrincipalId:   groupMember.ID(),
+		Justification: utils.StringPtr("Hamilton Testing"),
+		ScheduleInfo: &msgraph.RequestSchedule{
+			StartDateTime: &future,
+			Expiration: &msgraph.ExpirationPattern{
+				EndDateTime: &end,
+				Type:        utils.StringPtr(msgraph.ExpirationPatternTypeAfterDateTime),
+			},
+		},
+	})
+
+	testPrivilegedAccessGroupAssignmentScheduleClient_RequestsGet(t, c, *reqOwner.ID)
+	testPrivilegedAccessGroupAssignmentScheduleClient_RequestsGet(t, c, *reqMemberUser.ID)
+	testPrivilegedAccessGroupAssignmentScheduleClient_RequestsGet(t, c, *reqMemberGroup.ID)
+
+	testPrivilegedAccessGroupAssignmentScheduleClient_RequestsCancel(t, c, *reqMemberUser.ID)
+	testPrivilegedAccessGroupAssignmentScheduleClient_RequestsCancel(t, c, *reqMemberGroup.ID)
+
+}
+
+func testPrivilegedAccessGroupAssignmentScheduleClient_List(t *testing.T, c *test.Test, query odata.Query) (requests *[]msgraph.PrivilegedAccessGroupAssignmentSchedule) {
+	requests, status, err := c.PrivilegedAccessGroupAssignmentScheduleClient.List(c.Context, query)
+	if err != nil {
+		t.Fatalf("PrivilegedAccessGroupAssignmentScheduleClient.List(): %v", err)
+	}
+	if status < 200 || status >= 300 {
+		t.Fatalf("PrivilegedAccessGroupAssignmentScheduleClient.List(): invalid status: %d", status)
+	}
+	if requests == nil {
+		t.Fatal("PrivilegedAccessGroupAssignmentScheduleClient.List(): PrivilegedAccessGroupAssignmentSchedule was nil")
+	}
+	return
+}
+
+func testPrivilegedAccessGroupAssignmentScheduleClient_Get(t *testing.T, c *test.Test, id string) (request *msgraph.PrivilegedAccessGroupAssignmentSchedule) {
+	request, status, err := c.PrivilegedAccessGroupAssignmentScheduleClient.Get(c.Context, id)
+	if err != nil {
+		t.Fatalf("PrivilegedAccessGroupAssignmentScheduleClient.Get(): %v", err)
+	}
+	if status < 200 || status >= 300 {
+		t.Fatalf("PrivilegedAccessGroupAssignmentScheduleClient.Get(): invalid status: %d", status)
+	}
+	if request == nil {
+		t.Fatal("PrivilegedAccessGroupAssignmentScheduleClient.Get(): PrivilegedAccessGroupAssignmentSchedule was nil")
+	}
+	return
+}
+
+func testPrivilegedAccessGroupAssignmentScheduleClient_InstancesList(t *testing.T, c *test.Test, query odata.Query) (requests *[]msgraph.PrivilegedAccessGroupAssignmentScheduleInstance) {
+	requests, status, err := c.PrivilegedAccessGroupAssignmentScheduleClient.InstancesList(c.Context, query)
+	if err != nil {
+		t.Fatalf("PrivilegedAccessGroupAssignmentScheduleClient.InstancesList(): %v", err)
+	}
+	if status < 200 || status >= 300 {
+		t.Fatalf("PrivilegedAccessGroupAssignmentScheduleClient.InstancesList(): invalid status: %d", status)
+	}
+	if requests == nil {
+		t.Fatal("PrivilegedAccessGroupAssignmentScheduleClient.InstancesList(): PrivilegedAccessGroupAssignmentSchedule was nil")
+	}
+	return
+}
+
+func testPrivilegedAccessGroupAssignmentScheduleClient_InstancesGet(t *testing.T, c *test.Test, id string) (request *msgraph.PrivilegedAccessGroupAssignmentScheduleInstance) {
+	request, status, err := c.PrivilegedAccessGroupAssignmentScheduleClient.InstancesGet(c.Context, id)
+	if err != nil {
+		t.Fatalf("PrivilegedAccessGroupAssignmentScheduleClient.InstancesGet(): %v", err)
+	}
+	if status < 200 || status >= 300 {
+		t.Fatalf("PrivilegedAccessGroupAssignmentScheduleClient.InstancesGet(): invalid status: %d", status)
+	}
+	if request == nil {
+		t.Fatal("PrivilegedAccessGroupAssignmentScheduleClient.InstancesGet(): PrivilegedAccessGroupAssignmentSchedule was nil")
+	}
+	return
+}
+
+func testPrivilegedAccessGroupAssignmentScheduleClient_RequestsCreate(t *testing.T, c *test.Test, r msgraph.PrivilegedAccessGroupAssignmentScheduleRequest) (request *msgraph.PrivilegedAccessGroupAssignmentScheduleRequest) {
+	request, status, err := c.PrivilegedAccessGroupAssignmentScheduleClient.RequestsCreate(c.Context, r)
+	if err != nil {
+		t.Fatalf("PrivilegedAccessGroupAssignmentScheduleClient.Create(): %v", err)
+	}
+	if status < 200 || status >= 300 {
+		t.Fatalf("PrivilegedAccessGroupAssignmentScheduleClient.Create(): invalid status: %d", status)
+	}
+	if request == nil {
+		t.Fatal("PrivilegedAccessGroupAssignmentScheduleClient.Create(): PrivilegedAccessGroupAssignmentScheduleRequest was nil")
+	}
+	if request.ID == nil {
+		t.Fatal("PrivilegedAccessGroupAssignmentScheduleClient.Create(): PrivilegedAccessGroupAssignmentScheduleRequest.ID was nil")
+	}
+	return
+}
+
+func testPrivilegedAccessGroupAssignmentScheduleClient_RequestsList(t *testing.T, c *test.Test) (requests *[]msgraph.PrivilegedAccessGroupAssignmentScheduleRequest) {
+	requests, status, err := c.PrivilegedAccessGroupAssignmentScheduleClient.RequestsList(c.Context, odata.Query{})
+	if err != nil {
+		t.Fatalf("PrivilegedAccessGroupAssignmentScheduleClient.List(): %v", err)
+	}
+	if status < 200 || status >= 300 {
+		t.Fatalf("PrivilegedAccessGroupAssignmentScheduleClient.List(): invalid status: %d", status)
+	}
+	if requests == nil {
+		t.Fatal("PrivilegedAccessGroupAssignmentScheduleClient.List(): PrivilegedAccessGroupAssignmentScheduleRequest was nil")
+	}
+	return
+}
+
+func testPrivilegedAccessGroupAssignmentScheduleClient_RequestsGet(t *testing.T, c *test.Test, id string) (request *msgraph.PrivilegedAccessGroupAssignmentScheduleRequest) {
+	request, status, err := c.PrivilegedAccessGroupAssignmentScheduleClient.RequestsGet(c.Context, id)
+	if err != nil {
+		t.Fatalf("PrivilegedAccessGroupAssignmentScheduleClient.Get(): %v", err)
+	}
+	if status < 200 || status >= 300 {
+		t.Fatalf("PrivilegedAccessGroupAssignmentScheduleClient.Get(): invalid status: %d", status)
+	}
+	if request == nil {
+		t.Fatal("PrivilegedAccessGroupAssignmentScheduleClient.Get(): PrivilegedAccessGroupAssignmentScheduleRequest was nil")
+	}
+	return
+}
+
+func testPrivilegedAccessGroupAssignmentScheduleClient_RequestsCancel(t *testing.T, c *test.Test, id string) {
+	status, err := c.PrivilegedAccessGroupAssignmentScheduleClient.RequestsCancel(c.Context, id)
+	if err != nil {
+		t.Fatalf("PrivilegedAccessGroupAssignmentScheduleClient.Cancel(): %v", err)
+	}
+	if status < 200 || status >= 300 {
+		t.Fatalf("PrivilegedAccessGroupAssignmentScheduleClient.Cancel(): invalid status: %d", status)
+	}
+}

--- a/msgraph/privilegedaccess_groups_assignmentschedule_test.go
+++ b/msgraph/privilegedaccess_groups_assignmentschedule_test.go
@@ -20,7 +20,7 @@ func TestPrivilegedAccessGroupAssignmentScheduleClient(t *testing.T) {
 	if v := os.Getenv("PIM_GROUP_ID"); v != "" {
 		pimGroupId = v
 	} else {
-		pimGroupId = "8647a803-6803-46d6-bad4-bec15c5989d6"
+		pimGroupId = ""
 	}
 
 	now := time.Now()

--- a/msgraph/privilegedaccess_groups_assignmentschedule_test.go
+++ b/msgraph/privilegedaccess_groups_assignmentschedule_test.go
@@ -60,8 +60,8 @@ func TestPrivilegedAccessGroupAssignmentScheduleClient(t *testing.T) {
 	testPrivilegedAccessGroupAssignmentScheduleRequestsClient_List(t, c)
 
 	reqOwner := testPrivilegedAccessGroupAssignmentScheduleRequestsClient_Create(t, c, msgraph.PrivilegedAccessGroupAssignmentScheduleRequest{
-		AccessId:      utils.StringPtr(msgraph.PrivilegedAccessGroupRelationshipOwner),
-		Action:        utils.StringPtr(msgraph.PrivilegedAccessGroupActionAdminAssign),
+		AccessId:      msgraph.PrivilegedAccessGroupRelationshipOwner,
+		Action:        msgraph.PrivilegedAccessGroupActionAdminAssign,
 		GroupId:       pimGroup.ID(),
 		PrincipalId:   userOwner.ID(),
 		Justification: utils.StringPtr("Hamilton Testing"),
@@ -69,14 +69,14 @@ func TestPrivilegedAccessGroupAssignmentScheduleClient(t *testing.T) {
 			StartDateTime: &now,
 			Expiration: &msgraph.ExpirationPattern{
 				EndDateTime: &end,
-				Type:        utils.StringPtr(msgraph.ExpirationPatternTypeAfterDateTime),
+				Type:        msgraph.ExpirationPatternTypeAfterDateTime,
 			},
 		},
 	})
 
 	reqMemberUser := testPrivilegedAccessGroupAssignmentScheduleRequestsClient_Create(t, c, msgraph.PrivilegedAccessGroupAssignmentScheduleRequest{
-		AccessId:      utils.StringPtr(msgraph.PrivilegedAccessGroupRelationshipMember),
-		Action:        utils.StringPtr(msgraph.PrivilegedAccessGroupActionAdminAssign),
+		AccessId:      msgraph.PrivilegedAccessGroupRelationshipMember,
+		Action:        msgraph.PrivilegedAccessGroupActionAdminAssign,
 		GroupId:       pimGroup.ID(),
 		PrincipalId:   userMember.ID(),
 		Justification: utils.StringPtr("Hamilton Testing"),
@@ -84,14 +84,14 @@ func TestPrivilegedAccessGroupAssignmentScheduleClient(t *testing.T) {
 			StartDateTime: &future,
 			Expiration: &msgraph.ExpirationPattern{
 				EndDateTime: &end,
-				Type:        utils.StringPtr(msgraph.ExpirationPatternTypeAfterDateTime),
+				Type:        msgraph.ExpirationPatternTypeAfterDateTime,
 			},
 		},
 	})
 
 	reqMemberGroup := testPrivilegedAccessGroupAssignmentScheduleRequestsClient_Create(t, c, msgraph.PrivilegedAccessGroupAssignmentScheduleRequest{
-		AccessId:      utils.StringPtr(msgraph.PrivilegedAccessGroupRelationshipMember),
-		Action:        utils.StringPtr(msgraph.PrivilegedAccessGroupActionAdminAssign),
+		AccessId:      msgraph.PrivilegedAccessGroupRelationshipMember,
+		Action:        msgraph.PrivilegedAccessGroupActionAdminAssign,
 		GroupId:       pimGroup.ID(),
 		PrincipalId:   groupMember.ID(),
 		Justification: utils.StringPtr("Hamilton Testing"),
@@ -99,7 +99,7 @@ func TestPrivilegedAccessGroupAssignmentScheduleClient(t *testing.T) {
 			StartDateTime: &future,
 			Expiration: &msgraph.ExpirationPattern{
 				EndDateTime: &end,
-				Type:        utils.StringPtr(msgraph.ExpirationPatternTypeAfterDateTime),
+				Type:        msgraph.ExpirationPatternTypeAfterDateTime,
 			},
 		},
 	})

--- a/msgraph/privilegedaccess_groups_assignmentschedule_test.go
+++ b/msgraph/privilegedaccess_groups_assignmentschedule_test.go
@@ -108,21 +108,37 @@ func TestPrivilegedAccessGroupAssignmentScheduleClient(t *testing.T) {
 	testPrivilegedAccessGroupAssignmentScheduleClient_RequestsGet(t, c, *reqMemberUser.ID)
 	testPrivilegedAccessGroupAssignmentScheduleClient_RequestsGet(t, c, *reqMemberGroup.ID)
 
+	schedules := testPrivilegedAccessGroupAssignmentScheduleClient_List(t, c, odata.Query{
+		Filter: fmt.Sprintf("groupId eq '%s'", pimGroupId),
+	})
+	for _, sch := range *schedules {
+		testPrivilegedAccessGroupAssignmentScheduleClient_Get(t, c, *sch.ID)
+	}
+
+	instances := testPrivilegedAccessGroupAssignmentScheduleClient_InstancesList(t, c, odata.Query{
+		Filter: fmt.Sprintf("groupId eq '%s'", pimGroupId),
+	})
+	for _, inst := range *instances {
+		testPrivilegedAccessGroupAssignmentScheduleClient_InstancesGet(t, c, *inst.ID)
+	}
+
 	testPrivilegedAccessGroupAssignmentScheduleClient_RequestsCancel(t, c, *reqMemberUser.ID)
 	testPrivilegedAccessGroupAssignmentScheduleClient_RequestsCancel(t, c, *reqMemberGroup.ID)
-
 }
 
-func testPrivilegedAccessGroupAssignmentScheduleClient_List(t *testing.T, c *test.Test, query odata.Query) (requests *[]msgraph.PrivilegedAccessGroupAssignmentSchedule) {
-	requests, status, err := c.PrivilegedAccessGroupAssignmentScheduleClient.List(c.Context, query)
+func testPrivilegedAccessGroupAssignmentScheduleClient_List(t *testing.T, c *test.Test, query odata.Query) (schedules *[]msgraph.PrivilegedAccessGroupAssignmentSchedule) {
+	schedules, status, err := c.PrivilegedAccessGroupAssignmentScheduleClient.List(c.Context, query)
 	if err != nil {
 		t.Fatalf("PrivilegedAccessGroupAssignmentScheduleClient.List(): %v", err)
 	}
 	if status < 200 || status >= 300 {
 		t.Fatalf("PrivilegedAccessGroupAssignmentScheduleClient.List(): invalid status: %d", status)
 	}
-	if requests == nil {
+	if schedules == nil {
 		t.Fatal("PrivilegedAccessGroupAssignmentScheduleClient.List(): PrivilegedAccessGroupAssignmentSchedule was nil")
+	}
+	if len(*schedules) == 0 {
+		t.Fatal("PrivilegedAccessGroupAssignmentScheduleClient.List(): Returned zero results")
 	}
 	return
 }
@@ -141,16 +157,19 @@ func testPrivilegedAccessGroupAssignmentScheduleClient_Get(t *testing.T, c *test
 	return
 }
 
-func testPrivilegedAccessGroupAssignmentScheduleClient_InstancesList(t *testing.T, c *test.Test, query odata.Query) (requests *[]msgraph.PrivilegedAccessGroupAssignmentScheduleInstance) {
-	requests, status, err := c.PrivilegedAccessGroupAssignmentScheduleClient.InstancesList(c.Context, query)
+func testPrivilegedAccessGroupAssignmentScheduleClient_InstancesList(t *testing.T, c *test.Test, query odata.Query) (instances *[]msgraph.PrivilegedAccessGroupAssignmentScheduleInstance) {
+	instances, status, err := c.PrivilegedAccessGroupAssignmentScheduleClient.InstancesList(c.Context, query)
 	if err != nil {
 		t.Fatalf("PrivilegedAccessGroupAssignmentScheduleClient.InstancesList(): %v", err)
 	}
 	if status < 200 || status >= 300 {
 		t.Fatalf("PrivilegedAccessGroupAssignmentScheduleClient.InstancesList(): invalid status: %d", status)
 	}
-	if requests == nil {
+	if instances == nil {
 		t.Fatal("PrivilegedAccessGroupAssignmentScheduleClient.InstancesList(): PrivilegedAccessGroupAssignmentSchedule was nil")
+	}
+	if len(*instances) == 0 {
+		t.Fatal("PrivilegedAccessGroupAssignmentScheduleClient.List(): Returned zero results")
 	}
 	return
 }

--- a/msgraph/privilegedaccess_groups_assignmentschedule_test.go
+++ b/msgraph/privilegedaccess_groups_assignmentschedule_test.go
@@ -61,7 +61,7 @@ func TestPrivilegedAccessGroupAssignmentScheduleClient(t *testing.T) {
 
 	reqOwner := testPrivilegedAccessGroupAssignmentScheduleClient_RequestsCreate(t, c, msgraph.PrivilegedAccessGroupAssignmentScheduleRequest{
 		AccessId:      utils.StringPtr(msgraph.PrivilegedAccessGroupRelationshipOwner),
-		Action:        utils.StringPtr(msgraph.PrivilegedAccessGroupAssignmentActionAdminAssign),
+		Action:        utils.StringPtr(msgraph.PrivilegedAccessGroupActionAdminAssign),
 		GroupId:       utils.StringPtr(pimGroupId),
 		PrincipalId:   userOwner.ID(),
 		Justification: utils.StringPtr("Hamilton Testing"),
@@ -76,7 +76,7 @@ func TestPrivilegedAccessGroupAssignmentScheduleClient(t *testing.T) {
 
 	reqMemberUser := testPrivilegedAccessGroupAssignmentScheduleClient_RequestsCreate(t, c, msgraph.PrivilegedAccessGroupAssignmentScheduleRequest{
 		AccessId:      utils.StringPtr(msgraph.PrivilegedAccessGroupRelationshipMember),
-		Action:        utils.StringPtr(msgraph.PrivilegedAccessGroupAssignmentActionAdminAssign),
+		Action:        utils.StringPtr(msgraph.PrivilegedAccessGroupActionAdminAssign),
 		GroupId:       utils.StringPtr(pimGroupId),
 		PrincipalId:   userMember.ID(),
 		Justification: utils.StringPtr("Hamilton Testing"),
@@ -91,7 +91,7 @@ func TestPrivilegedAccessGroupAssignmentScheduleClient(t *testing.T) {
 
 	reqMemberGroup := testPrivilegedAccessGroupAssignmentScheduleClient_RequestsCreate(t, c, msgraph.PrivilegedAccessGroupAssignmentScheduleRequest{
 		AccessId:      utils.StringPtr(msgraph.PrivilegedAccessGroupRelationshipMember),
-		Action:        utils.StringPtr(msgraph.PrivilegedAccessGroupAssignmentActionAdminAssign),
+		Action:        utils.StringPtr(msgraph.PrivilegedAccessGroupActionAdminAssign),
 		GroupId:       utils.StringPtr(pimGroupId),
 		PrincipalId:   groupMember.ID(),
 		Justification: utils.StringPtr("Hamilton Testing"),

--- a/msgraph/privilegedaccess_groups_assignmentschedule_test.go
+++ b/msgraph/privilegedaccess_groups_assignmentschedule_test.go
@@ -57,9 +57,9 @@ func TestPrivilegedAccessGroupAssignmentScheduleClient(t *testing.T) {
 	})
 	defer testUsersClient_Delete(t, c, *userOwner.ID())
 
-	testPrivilegedAccessGroupAssignmentScheduleClient_RequestsList(t, c)
+	testPrivilegedAccessGroupAssignmentScheduleRequestsClient_List(t, c)
 
-	reqOwner := testPrivilegedAccessGroupAssignmentScheduleClient_RequestsCreate(t, c, msgraph.PrivilegedAccessGroupAssignmentScheduleRequest{
+	reqOwner := testPrivilegedAccessGroupAssignmentScheduleRequestsClient_Create(t, c, msgraph.PrivilegedAccessGroupAssignmentScheduleRequest{
 		AccessId:      utils.StringPtr(msgraph.PrivilegedAccessGroupRelationshipOwner),
 		Action:        utils.StringPtr(msgraph.PrivilegedAccessGroupActionAdminAssign),
 		GroupId:       utils.StringPtr(pimGroupId),
@@ -74,7 +74,7 @@ func TestPrivilegedAccessGroupAssignmentScheduleClient(t *testing.T) {
 		},
 	})
 
-	reqMemberUser := testPrivilegedAccessGroupAssignmentScheduleClient_RequestsCreate(t, c, msgraph.PrivilegedAccessGroupAssignmentScheduleRequest{
+	reqMemberUser := testPrivilegedAccessGroupAssignmentScheduleRequestsClient_Create(t, c, msgraph.PrivilegedAccessGroupAssignmentScheduleRequest{
 		AccessId:      utils.StringPtr(msgraph.PrivilegedAccessGroupRelationshipMember),
 		Action:        utils.StringPtr(msgraph.PrivilegedAccessGroupActionAdminAssign),
 		GroupId:       utils.StringPtr(pimGroupId),
@@ -89,7 +89,7 @@ func TestPrivilegedAccessGroupAssignmentScheduleClient(t *testing.T) {
 		},
 	})
 
-	reqMemberGroup := testPrivilegedAccessGroupAssignmentScheduleClient_RequestsCreate(t, c, msgraph.PrivilegedAccessGroupAssignmentScheduleRequest{
+	reqMemberGroup := testPrivilegedAccessGroupAssignmentScheduleRequestsClient_Create(t, c, msgraph.PrivilegedAccessGroupAssignmentScheduleRequest{
 		AccessId:      utils.StringPtr(msgraph.PrivilegedAccessGroupRelationshipMember),
 		Action:        utils.StringPtr(msgraph.PrivilegedAccessGroupActionAdminAssign),
 		GroupId:       utils.StringPtr(pimGroupId),
@@ -104,9 +104,9 @@ func TestPrivilegedAccessGroupAssignmentScheduleClient(t *testing.T) {
 		},
 	})
 
-	testPrivilegedAccessGroupAssignmentScheduleClient_RequestsGet(t, c, *reqOwner.ID)
-	testPrivilegedAccessGroupAssignmentScheduleClient_RequestsGet(t, c, *reqMemberUser.ID)
-	testPrivilegedAccessGroupAssignmentScheduleClient_RequestsGet(t, c, *reqMemberGroup.ID)
+	testPrivilegedAccessGroupAssignmentScheduleRequestsClient_Get(t, c, *reqOwner.ID)
+	testPrivilegedAccessGroupAssignmentScheduleRequestsClient_Get(t, c, *reqMemberUser.ID)
+	testPrivilegedAccessGroupAssignmentScheduleRequestsClient_Get(t, c, *reqMemberGroup.ID)
 
 	schedules := testPrivilegedAccessGroupAssignmentScheduleClient_List(t, c, odata.Query{
 		Filter: fmt.Sprintf("groupId eq '%s'", pimGroupId),
@@ -115,15 +115,15 @@ func TestPrivilegedAccessGroupAssignmentScheduleClient(t *testing.T) {
 		testPrivilegedAccessGroupAssignmentScheduleClient_Get(t, c, *sch.ID)
 	}
 
-	instances := testPrivilegedAccessGroupAssignmentScheduleClient_InstancesList(t, c, odata.Query{
+	instances := testPrivilegedAccessGroupAssignmentScheduleInstancesClient_List(t, c, odata.Query{
 		Filter: fmt.Sprintf("groupId eq '%s'", pimGroupId),
 	})
 	for _, inst := range *instances {
-		testPrivilegedAccessGroupAssignmentScheduleClient_InstancesGet(t, c, *inst.ID)
+		testPrivilegedAccessGroupAssignmentScheduleInstancesClient_Get(t, c, *inst.ID)
 	}
 
-	testPrivilegedAccessGroupAssignmentScheduleClient_RequestsCancel(t, c, *reqMemberUser.ID)
-	testPrivilegedAccessGroupAssignmentScheduleClient_RequestsCancel(t, c, *reqMemberGroup.ID)
+	testPrivilegedAccessGroupAssignmentScheduleRequestsClient_Cancel(t, c, *reqMemberUser.ID)
+	testPrivilegedAccessGroupAssignmentScheduleRequestsClient_Cancel(t, c, *reqMemberGroup.ID)
 }
 
 func testPrivilegedAccessGroupAssignmentScheduleClient_List(t *testing.T, c *test.Test, query odata.Query) (schedules *[]msgraph.PrivilegedAccessGroupAssignmentSchedule) {
@@ -155,90 +155,4 @@ func testPrivilegedAccessGroupAssignmentScheduleClient_Get(t *testing.T, c *test
 		t.Fatal("PrivilegedAccessGroupAssignmentScheduleClient.Get(): PrivilegedAccessGroupAssignmentSchedule was nil")
 	}
 	return
-}
-
-func testPrivilegedAccessGroupAssignmentScheduleClient_InstancesList(t *testing.T, c *test.Test, query odata.Query) (instances *[]msgraph.PrivilegedAccessGroupAssignmentScheduleInstance) {
-	instances, status, err := c.PrivilegedAccessGroupAssignmentScheduleClient.InstancesList(c.Context, query)
-	if err != nil {
-		t.Fatalf("PrivilegedAccessGroupAssignmentScheduleClient.InstancesList(): %v", err)
-	}
-	if status < 200 || status >= 300 {
-		t.Fatalf("PrivilegedAccessGroupAssignmentScheduleClient.InstancesList(): invalid status: %d", status)
-	}
-	if instances == nil {
-		t.Fatal("PrivilegedAccessGroupAssignmentScheduleClient.InstancesList(): PrivilegedAccessGroupAssignmentSchedule was nil")
-	}
-	if len(*instances) == 0 {
-		t.Fatal("PrivilegedAccessGroupAssignmentScheduleClient.List(): Returned zero results")
-	}
-	return
-}
-
-func testPrivilegedAccessGroupAssignmentScheduleClient_InstancesGet(t *testing.T, c *test.Test, id string) (request *msgraph.PrivilegedAccessGroupAssignmentScheduleInstance) {
-	request, status, err := c.PrivilegedAccessGroupAssignmentScheduleClient.InstancesGet(c.Context, id)
-	if err != nil {
-		t.Fatalf("PrivilegedAccessGroupAssignmentScheduleClient.InstancesGet(): %v", err)
-	}
-	if status < 200 || status >= 300 {
-		t.Fatalf("PrivilegedAccessGroupAssignmentScheduleClient.InstancesGet(): invalid status: %d", status)
-	}
-	if request == nil {
-		t.Fatal("PrivilegedAccessGroupAssignmentScheduleClient.InstancesGet(): PrivilegedAccessGroupAssignmentSchedule was nil")
-	}
-	return
-}
-
-func testPrivilegedAccessGroupAssignmentScheduleClient_RequestsCreate(t *testing.T, c *test.Test, r msgraph.PrivilegedAccessGroupAssignmentScheduleRequest) (request *msgraph.PrivilegedAccessGroupAssignmentScheduleRequest) {
-	request, status, err := c.PrivilegedAccessGroupAssignmentScheduleClient.RequestsCreate(c.Context, r)
-	if err != nil {
-		t.Fatalf("PrivilegedAccessGroupAssignmentScheduleClient.Create(): %v", err)
-	}
-	if status < 200 || status >= 300 {
-		t.Fatalf("PrivilegedAccessGroupAssignmentScheduleClient.Create(): invalid status: %d", status)
-	}
-	if request == nil {
-		t.Fatal("PrivilegedAccessGroupAssignmentScheduleClient.Create(): PrivilegedAccessGroupAssignmentScheduleRequest was nil")
-	}
-	if request.ID == nil {
-		t.Fatal("PrivilegedAccessGroupAssignmentScheduleClient.Create(): PrivilegedAccessGroupAssignmentScheduleRequest.ID was nil")
-	}
-	return
-}
-
-func testPrivilegedAccessGroupAssignmentScheduleClient_RequestsList(t *testing.T, c *test.Test) (requests *[]msgraph.PrivilegedAccessGroupAssignmentScheduleRequest) {
-	requests, status, err := c.PrivilegedAccessGroupAssignmentScheduleClient.RequestsList(c.Context, odata.Query{})
-	if err != nil {
-		t.Fatalf("PrivilegedAccessGroupAssignmentScheduleClient.List(): %v", err)
-	}
-	if status < 200 || status >= 300 {
-		t.Fatalf("PrivilegedAccessGroupAssignmentScheduleClient.List(): invalid status: %d", status)
-	}
-	if requests == nil {
-		t.Fatal("PrivilegedAccessGroupAssignmentScheduleClient.List(): PrivilegedAccessGroupAssignmentScheduleRequest was nil")
-	}
-	return
-}
-
-func testPrivilegedAccessGroupAssignmentScheduleClient_RequestsGet(t *testing.T, c *test.Test, id string) (request *msgraph.PrivilegedAccessGroupAssignmentScheduleRequest) {
-	request, status, err := c.PrivilegedAccessGroupAssignmentScheduleClient.RequestsGet(c.Context, id)
-	if err != nil {
-		t.Fatalf("PrivilegedAccessGroupAssignmentScheduleClient.Get(): %v", err)
-	}
-	if status < 200 || status >= 300 {
-		t.Fatalf("PrivilegedAccessGroupAssignmentScheduleClient.Get(): invalid status: %d", status)
-	}
-	if request == nil {
-		t.Fatal("PrivilegedAccessGroupAssignmentScheduleClient.Get(): PrivilegedAccessGroupAssignmentScheduleRequest was nil")
-	}
-	return
-}
-
-func testPrivilegedAccessGroupAssignmentScheduleClient_RequestsCancel(t *testing.T, c *test.Test, id string) {
-	status, err := c.PrivilegedAccessGroupAssignmentScheduleClient.RequestsCancel(c.Context, id)
-	if err != nil {
-		t.Fatalf("PrivilegedAccessGroupAssignmentScheduleClient.Cancel(): %v", err)
-	}
-	if status < 200 || status >= 300 {
-		t.Fatalf("PrivilegedAccessGroupAssignmentScheduleClient.Cancel(): invalid status: %d", status)
-	}
 }

--- a/msgraph/role_eligibility_schedule_request_test.go
+++ b/msgraph/role_eligibility_schedule_request_test.go
@@ -39,7 +39,7 @@ func TestRoleEligibilityScheduleRequestClient(t *testing.T) {
 		ScheduleInfo: &msgraph.RequestSchedule{
 			StartDateTime: &now,
 			Expiration: &msgraph.ExpirationPattern{
-				Type: utils.StringPtr(msgraph.ExpirationPatternTypeNoExpiration),
+				Type: msgraph.ExpirationPatternTypeNoExpiration,
 			},
 		},
 	})

--- a/msgraph/valuetypes.go
+++ b/msgraph/valuetypes.go
@@ -698,24 +698,24 @@ const (
 	PreferredSingleSignOnModeSaml         PreferredSingleSignOnMode = "saml"
 )
 
+type PrivilegedAccessGroupAction = string
+
+const (
+	PrivilegedAccessGroupActionAdminAssign    PrivilegedAccessGroupAction = "adminAssign"
+	PrivilegedAccessGroupActionAdminUpdate    PrivilegedAccessGroupAction = "adminUpdate"
+	PrivilegedAccessGroupActionAdminRemove    PrivilegedAccessGroupAction = "adminRemove"
+	PrivilegedAccessGroupActionAdminExtend    PrivilegedAccessGroupAction = "adminExtend"
+	PrivilegedAccessGroupActionAdminRenew     PrivilegedAccessGroupAction = "adminRenew"
+	PrivilegedAccessGroupActionSelfActivate   PrivilegedAccessGroupAction = "selfActivate"
+	PrivilegedAccessGroupActionSelfDeactivate PrivilegedAccessGroupAction = "selfDeactivate"
+)
+
 type PrivilegedAccessGroupAssignmentType = string
 
 const (
 	PrivilegedAccessGroupAssignmentAssigned  PrivilegedAccessGroupAssignmentType = "assigned"
 	PrivilegedAccessGroupAssignmentActivated PrivilegedAccessGroupAssignmentType = "activated"
 	PrivilegedAccessGroupAssignmentUnknown   PrivilegedAccessGroupAssignmentType = "unknownFutureValue"
-)
-
-type PrivilegedAccessGroupAssignmentAction = string
-
-const (
-	PrivilegedAccessGroupAssignmentActionAdminAssign    PrivilegedAccessGroupAssignmentAction = "adminAssign"
-	PrivilegedAccessGroupAssignmentActionAdminUpdate    PrivilegedAccessGroupAssignmentAction = "adminUpdate"
-	PrivilegedAccessGroupAssignmentActionAdminRemove    PrivilegedAccessGroupAssignmentAction = "adminRemove"
-	PrivilegedAccessGroupAssignmentActionAdminExtend    PrivilegedAccessGroupAssignmentAction = "adminExtend"
-	PrivilegedAccessGroupAssignmentActionAdminRenew     PrivilegedAccessGroupAssignmentAction = "adminRenew"
-	PrivilegedAccessGroupAssignmentActionSelfActivate   PrivilegedAccessGroupAssignmentAction = "selfActivate"
-	PrivilegedAccessGroupAssignmentActionSelfDeactivate PrivilegedAccessGroupAssignmentAction = "selfDeactivate"
 )
 
 type PrivilegedAccessGroupAssignmentStatus = string

--- a/msgraph/valuetypes.go
+++ b/msgraph/valuetypes.go
@@ -698,6 +698,58 @@ const (
 	PreferredSingleSignOnModeSaml         PreferredSingleSignOnMode = "saml"
 )
 
+type PrivilegedAccessGroupAssignmentType = string
+
+const (
+	PrivilegedAccessGroupAssignmentAssigned  PrivilegedAccessGroupAssignmentType = "assigned"
+	PrivilegedAccessGroupAssignmentActivated PrivilegedAccessGroupAssignmentType = "activated"
+	PrivilegedAccessGroupAssignmentUnknown   PrivilegedAccessGroupAssignmentType = "unknownFutureValue"
+)
+
+type PrivilegedAccessGroupAssignmentAction = string
+
+const (
+	PrivilegedAccessGroupAssignmentActionAdminAssign    PrivilegedAccessGroupAssignmentAction = "adminAssign"
+	PrivilegedAccessGroupAssignmentActionAdminUpdate    PrivilegedAccessGroupAssignmentAction = "adminUpdate"
+	PrivilegedAccessGroupAssignmentActionAdminRemove    PrivilegedAccessGroupAssignmentAction = "adminRemove"
+	PrivilegedAccessGroupAssignmentActionAdminExtend    PrivilegedAccessGroupAssignmentAction = "adminExtend"
+	PrivilegedAccessGroupAssignmentActionAdminRenew     PrivilegedAccessGroupAssignmentAction = "adminRenew"
+	PrivilegedAccessGroupAssignmentActionSelfActivate   PrivilegedAccessGroupAssignmentAction = "selfActivate"
+	PrivilegedAccessGroupAssignmentActionSelfDeactivate PrivilegedAccessGroupAssignmentAction = "selfDeactivate"
+)
+
+type PrivilegedAccessGroupAssignmentStatus = string
+
+const (
+	PrivilegedAccessGroupAssignmentStatusCanceled                 PrivilegedAccessGroupAssignmentStatus = "Canceled"
+	PrivilegedAccessGroupAssignmentStatusDenied                   PrivilegedAccessGroupAssignmentStatus = "Denied"
+	PrivilegedAccessGroupAssignmentStatusFailed                   PrivilegedAccessGroupAssignmentStatus = "Failed"
+	PrivilegedAccessGroupAssignmentStatusGranted                  PrivilegedAccessGroupAssignmentStatus = "Granted"
+	PrivilegedAccessGroupAssignmentStatusPendingAdminDecision     PrivilegedAccessGroupAssignmentStatus = "PendingAdminDecision"
+	PrivilegedAccessGroupAssignmentStatusPendingApproval          PrivilegedAccessGroupAssignmentStatus = "PendingApproval"
+	PrivilegedAccessGroupAssignmentStatusPendingProvisioning      PrivilegedAccessGroupAssignmentStatus = "PendingProvisioning"
+	PrivilegedAccessGroupAssignmentStatusPendingScheduledCreation PrivilegedAccessGroupAssignmentStatus = "PendingScheduleCreation"
+	PrivilegedAccessGroupAssignmentStatusProvisioned              PrivilegedAccessGroupAssignmentStatus = "Provisioned"
+	PrivilegedAccessGroupAssignmentStatusRevoked                  PrivilegedAccessGroupAssignmentStatus = "Revoked"
+	PrivilegedAccessGroupAssignmentStatusScheduleCreated          PrivilegedAccessGroupAssignmentStatus = "ScheduleCreated"
+)
+
+type PrivilegedAccessGroupMemberType = string
+
+const (
+	PrivilegedAccessGroupMemberDirect  PrivilegedAccessGroupMemberType = "direct"
+	PrivilegedAccessGroupMemberGroup   PrivilegedAccessGroupMemberType = "group"
+	PrivilegedAccessGroupMemberUnknown PrivilegedAccessGroupMemberType = "unknownFutureValue"
+)
+
+type PrivilegedAccessGroupRelationship = string
+
+const (
+	PrivilegedAccessGroupRelationshipOwner   PrivilegedAccessGroupRelationship = "owner"
+	PrivilegedAccessGroupRelationshipMember  PrivilegedAccessGroupRelationship = "member"
+	PrivilegedAccessGroupRelationshipUnknown PrivilegedAccessGroupRelationship = "unknownFutureValue"
+)
+
 type RecurrencePatternType = string
 
 const (


### PR DESCRIPTION
This is the first PR to provide support for Privileged Management of AAD Groups. This implements part of #248. Depends on #276.