### PR TITLE
Add `updateAllowedCombinations` to `AuthenticationStrengthPoliciesClient`

### DIFF
--- a/msgraph/authentication_strength_policy.go
+++ b/msgraph/authentication_strength_policy.go
@@ -141,6 +141,42 @@ func (c *AuthenticationStrengthPoliciesClient) Update(ctx context.Context, Authe
 	return status, nil
 }
 
+// Update amends an existing AuthenticationStrengthPolicy's allowed combinations
+func (c *AuthenticationStrengthPoliciesClient) UpdateAllowedCombinations(ctx context.Context, policy AuthenticationStrengthPolicy) (int, error) {
+	var status int
+
+	if policy.ID == nil {
+		return status, errors.New("cannot update AuthenticationStrengthPolicy with nil ID")
+	}
+
+	if policy.AllowedCombinations == nil {
+		return status, errors.New("cannot update AuthenticationStrengthPolicy with nil AllowedCombinations")
+	}
+
+	allowedCombinations := AuthenticationStrengthPolicy{
+		AllowedCombinations: policy.AllowedCombinations,
+	}
+
+	body, err := json.Marshal(allowedCombinations)
+	if err != nil {
+		return status, fmt.Errorf("json.Marshal(): %v", err)
+	}
+
+	_, status, _, err = c.BaseClient.Post(ctx, PostHttpRequestInput{
+		Body:                   body,
+		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
+		ValidStatusCodes:       []int{http.StatusOK},
+		Uri: Uri{
+			Entity: fmt.Sprintf("/policies/authenticationStrengthPolicies/%s/updateAllowedCombinations", *policy.ID),
+		},
+	})
+	if err != nil {
+		return status, fmt.Errorf("AuthenticationStrengthPoliciesClient.BaseClient.Post(): %v", err)
+	}
+
+	return status, nil
+}
+
 // Delete removes a AuthenticationStrengthPolicy.
 func (c *AuthenticationStrengthPoliciesClient) Delete(ctx context.Context, id string) (int, error) {
 	_, status, _, err := c.BaseClient.Delete(ctx, DeleteHttpRequestInput{

--- a/msgraph/authentication_strength_policy_test.go
+++ b/msgraph/authentication_strength_policy_test.go
@@ -27,6 +27,14 @@ func TestAuthenticationStrengthPolicyClient(t *testing.T) {
 	}
 	testAuthenticationStrengthPoliciesClient_Update(t, c, updatePolicy)
 
+	updateAllowedCombinations := msgraph.AuthenticationStrengthPolicy{
+		ID:                  policy.ID,
+		DisplayName:         utils.StringPtr(fmt.Sprintf("test-policy-updated-%s", c.RandomString)),
+		AllowedCombinations: &[]string{"password, hardwareOath", "deviceBasedPush"},
+	}
+
+	testAuthenticationStrengthPoliciesClient_UpdateAllowedCombinations(t, c, updateAllowedCombinations)
+
 	testAuthenticationStrengthPoliciesClient_List(t, c)
 	testAuthenticationStrengthPoliciesClient_Get(t, c, *policy.ID)
 	testAuthenticationStrengthPoliciesClient_Delete(t, c, *policy.ID)
@@ -71,6 +79,16 @@ func testAuthenticationStrengthPoliciesClient_Update(t *testing.T, c *test.Test,
 	}
 	if status < 200 || status >= 300 {
 		t.Fatalf("AuthenticationStrengthPolicyClient.Update(): invalid status: %d", status)
+	}
+}
+
+func testAuthenticationStrengthPoliciesClient_UpdateAllowedCombinations(t *testing.T, c *test.Test, policy msgraph.AuthenticationStrengthPolicy) {
+	status, err := c.AuthenticationStrengthPoliciesClient.UpdateAllowedCombinations(c.Context, policy)
+	if err != nil {
+		t.Fatalf("AuthenticationStrengthPolicyClient.UpdateAllowedCombinations(): %v", err)
+	}
+	if status < 200 || status >= 300 {
+		t.Fatalf("AuthenticationStrengthPolicyClient.UpdateAllowedCombinations(): invalid status: %d", status)
 	}
 }
 


### PR DESCRIPTION
It turns out you can't update the `allowedCombinations` field using the normal update endpoint. You'll get the following error
```
AuthenticationStrengthPoliciesClient.BaseClient.Patch(): unexpected status 405 with OData error: methodNotAllowed: Combinations can only be updated using updateAllowedCombinations action.: Combinations can only be updated
│ using updateAllowedCombinations action.
```
Instead there is a specific endpoint you must use documented here:
https://learn.microsoft.com/en-us/graph/api/authenticationstrengthpolicy-updateallowedcombinations?view=graph-rest-1.0&tabs=http

Currently I'm passing through the whole `AuthenticationStrengthPolicy` object but technically it should only be the `allowedCombinations` field without the display name etc.
If it's preferred I can create an object that only has `allowedCombinations` for use here but wasn't sure if that was needed given that Graph seems to ignore the extra fields