### PR TITLE
Service Principals: support the `appMetadata` field

### DIFF
--- a/msgraph/models.go
+++ b/msgraph/models.go
@@ -1439,6 +1439,7 @@ type ServicePrincipal struct {
 	AppDisplayName                      *string                       `json:"appDisplayName,omitempty"`
 	AppId                               *string                       `json:"appId,omitempty"`
 	ApplicationTemplateId               *string                       `json:"applicationTemplateId,omitempty"`
+	AppMetadata                         *ServicePrincipalAppMetadata  `json:"appMetadata,omitempty"`
 	AppOwnerOrganizationId              *string                       `json:"appOwnerOrganizationId,omitempty"`
 	AppRoleAssignmentRequired           *bool                         `json:"appRoleAssignmentRequired,omitempty"`
 	AppRoles                            *[]AppRole                    `json:"appRoles,omitempty"`
@@ -1479,6 +1480,11 @@ func (s *ServicePrincipal) UnmarshalJSON(data []byte) error {
 		return err
 	}
 	return nil
+}
+
+type ServicePrincipalAppMetadata struct {
+	Version *int              `json:"version,omitempty"`
+	Data    *[]KeyValueObject `json:"data,omitempty"`
 }
 
 type SynchronizationSchedule struct {

--- a/msgraph/valuetypes.go
+++ b/msgraph/valuetypes.go
@@ -22,6 +22,11 @@ func (s StringNullWhenEmpty) MarshalJSON() ([]byte, error) {
 	return json.Marshal(string(s))
 }
 
+type KeyValueObject struct {
+	Key   *string `json:"key,omitempty"`
+	Value *string `json:"value,omitempty"`
+}
+
 type AccessPackageCatalogState = string
 
 const (


### PR DESCRIPTION
Support the `appMetadata` field, which reveals details of the managed identity the SP is linked to