### PR TITLE
Fix missing odata type for externalTenants configuration

### DIFF
--- a/internal/test/json.go
+++ b/internal/test/json.go
@@ -1,0 +1,20 @@
+package test
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+func AssertJsonMarshalEquals(value interface{}, expected string) error {
+	bytes, err := json.MarshalIndent(value, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshaling failed with error %s", err)
+	}
+
+	actual := string(bytes)
+	if actual != expected {
+		return fmt.Errorf("expected marshalled json to equal %s but was %s", expected, actual)
+	}
+
+	return nil
+}

--- a/msgraph/conditionalaccesspolicy_test.go
+++ b/msgraph/conditionalaccesspolicy_test.go
@@ -1,7 +1,6 @@
 package msgraph_test
 
 import (
-	"encoding/json"
 	"fmt"
 	"testing"
 
@@ -200,24 +199,15 @@ func testUser_Delete(t *testing.T, c *test.Test, user *msgraph.User) {
 	}
 }
 
-func assertJsonMarshalEquals(t *testing.T, value interface{}, expected string) {
-	bytes, err := json.MarshalIndent(value, "", "  ")
-	if err != nil {
-		t.Fatalf("Marshalling failed with error %s", err)
-	}
-	actual := string(bytes)
-	if actual != expected {
-		t.Errorf("Expected marshalled json to equal %s but was %s", expected, actual)
-	}
-}
-
 func TestConditionalAccessPolicy_MarshalConditionsUsersGuestsOrExternalUsersNull(t *testing.T) {
 	usersCondition := &msgraph.ConditionalAccessUsers{}
 	expected := `{
   "includeGuestsOrExternalUsers": null,
   "excludeGuestsOrExternalUsers": null
 }`
-	assertJsonMarshalEquals(t, usersCondition, expected)
+	if err := test.AssertJsonMarshalEquals(usersCondition, expected); err != nil {
+		t.Fatal(err)
+	}
 }
 
 func TestConditionalAccessPolicy_MarshalConditionsUsersGuestsOrExternalUsersAll(t *testing.T) {
@@ -242,7 +232,9 @@ func TestConditionalAccessPolicy_MarshalConditionsUsersGuestsOrExternalUsersAll(
   },
   "excludeGuestsOrExternalUsers": null
 }`
-	assertJsonMarshalEquals(t, usersCondition, expected)
+	if err := test.AssertJsonMarshalEquals(usersCondition, expected); err != nil {
+		t.Fatal(err)
+	}
 }
 
 func TestConditionalAccessPolicy_MarshalConditionsUsersGuestsOrExternalUsersEnumerated(t *testing.T) {
@@ -272,5 +264,7 @@ func TestConditionalAccessPolicy_MarshalConditionsUsersGuestsOrExternalUsersEnum
   },
   "excludeGuestsOrExternalUsers": null
 }`
-	assertJsonMarshalEquals(t, usersCondition, expected)
+	if err := test.AssertJsonMarshalEquals(usersCondition, expected); err != nil {
+		t.Fatal(err)
+	}
 }

--- a/msgraph/models.go
+++ b/msgraph/models.go
@@ -732,26 +732,14 @@ func (c ConditionalAccessGuestsOrExternalUsers) MarshalJSON() ([]byte, error) {
 		conditionalAccessGuestsOrExternalUsers: (*conditionalAccessGuestsOrExternalUsers)(&c),
 	}
 
-	const externalTenantsTypeAll = "#microsoft.graph.conditionalAccessAllExternalTenants"
-	const externalTenantsTypeEnumerated = "#microsoft.graph.conditionalAccessEnumeratedExternalTenants"
-	setExternalTenantsObjectType := func(c *conditionalAccessGuestsOrExternalUsers) {
-		if c == nil {
-			return
-		}
-		if c.ExternalTenants == nil {
-			return
-		}
-		if c.ExternalTenants.MembershipKind == nil {
-			return
-		}
+	if c.ExternalTenants != nil && c.ExternalTenants.MembershipKind != nil {
 		switch *c.ExternalTenants.MembershipKind {
 		case ConditionalAccessExternalTenantsMembershipKindAll:
-			c.ExternalTenants.ODataType = utils.StringPtr(externalTenantsTypeAll)
+			c.ExternalTenants.ODataType = utils.StringPtr("#microsoft.graph.conditionalAccessAllExternalTenants")
 		case ConditionalAccessExternalTenantsMembershipKindEnumerated:
-			c.ExternalTenants.ODataType = utils.StringPtr(externalTenantsTypeEnumerated)
+			c.ExternalTenants.ODataType = utils.StringPtr("#microsoft.graph.conditionalAccessEnumeratedExternalTenants")
 		}
 	}
-	setExternalTenantsObjectType(guestOrExternalUsers.conditionalAccessGuestsOrExternalUsers)
 
 	buf, err := json.Marshal(&guestOrExternalUsers)
 	return buf, err

--- a/msgraph/models.go
+++ b/msgraph/models.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/hashicorp/go-azure-sdk/sdk/odata"
 	"github.com/manicminer/hamilton/errors"
+	"github.com/manicminer/hamilton/internal/utils"
 )
 
 type AccessPackage struct {
@@ -709,9 +710,9 @@ type ConditionalAccessGuestsOrExternalUsers struct {
 }
 
 type ConditionalAccessExternalTenants struct {
+	ODataType      *odata.Type                                     `json:"@odata.type,omitempty"`
 	MembershipKind *ConditionalAccessExternalTenantsMembershipKind `json:"membershipKind,omitempty"`
 	Members        *[]string                                       `json:"members,omitempty"`
-
 }
 
 func (c ConditionalAccessGuestsOrExternalUsers) MarshalJSON() ([]byte, error) {
@@ -730,6 +731,28 @@ func (c ConditionalAccessGuestsOrExternalUsers) MarshalJSON() ([]byte, error) {
 		GuestOrExternalUserTypes:               val,
 		conditionalAccessGuestsOrExternalUsers: (*conditionalAccessGuestsOrExternalUsers)(&c),
 	}
+
+	const externalTenantsTypeAll = "#microsoft.graph.conditionalAccessAllExternalTenants"
+	const externalTenantsTypeEnumerated = "#microsoft.graph.conditionalAccessEnumeratedExternalTenants"
+	setExternalTenantsObjectType := func(c *conditionalAccessGuestsOrExternalUsers) {
+		if c == nil {
+			return
+		}
+		if c.ExternalTenants == nil {
+			return
+		}
+		if c.ExternalTenants.MembershipKind == nil {
+			return
+		}
+		switch *c.ExternalTenants.MembershipKind {
+		case ConditionalAccessExternalTenantsMembershipKindAll:
+			c.ExternalTenants.ODataType = utils.StringPtr(externalTenantsTypeAll)
+		case ConditionalAccessExternalTenantsMembershipKindEnumerated:
+			c.ExternalTenants.ODataType = utils.StringPtr(externalTenantsTypeEnumerated)
+		}
+	}
+	setExternalTenantsObjectType(guestOrExternalUsers.conditionalAccessGuestsOrExternalUsers)
+
 	buf, err := json.Marshal(&guestOrExternalUsers)
 	return buf, err
 }


### PR DESCRIPTION
Without setting the correct @odata.type for both
possible values all and enumerated, a patch will fail when first enumerating and setting members and then changing to type all because the stored object
is of the wrong type.

References #261