### PR TITLE
Improve performance of GET requests

### DIFF
--- a/internal/test/metrics.go
+++ b/internal/test/metrics.go
@@ -1,0 +1,48 @@
+package test
+
+import (
+	"fmt"
+	"runtime"
+	"runtime/metrics"
+	"time"
+)
+
+// WithMetrics runs f and prints the total CPU time and max heap memory used during its execution
+func WithMetrics(f func()) {
+	cpuSample := make([]metrics.Sample, 1)
+	cpuSample[0].Name = "/cpu/classes/user:cpu-seconds"
+	memorySample := make([]metrics.Sample, 1)
+	memorySample[0].Name = "/memory/classes/heap/objects:bytes"
+	runtime.GC()
+
+	ticker := time.NewTicker(10 * time.Millisecond)
+	done := make(chan bool)
+	go func() {
+		maxMemory := uint64(0)
+		for {
+			select {
+			case <-done:
+				fmt.Printf("Max heap memory: %d MiB\n", maxMemory/1024/1024)
+				return
+			case _ = <-ticker.C:
+				metrics.Read(memorySample)
+				memory := memorySample[0].Value.Uint64()
+				if memory > maxMemory {
+					maxMemory = memory
+				}
+			}
+		}
+	}()
+
+	metrics.Read(cpuSample)
+	cpuSecondsBefore := cpuSample[0].Value.Float64()
+
+	f()
+
+	metrics.Read(cpuSample)
+	cpuSecondsAfter := cpuSample[0].Value.Float64()
+	fmt.Printf("Total CPU time: %.0f ms\n", (cpuSecondsAfter-cpuSecondsBefore)*1000)
+
+	ticker.Stop()
+	done <- true
+}

--- a/internal/test/testing.go
+++ b/internal/test/testing.go
@@ -146,7 +146,7 @@ func NewTest(t *testing.T) (c *Test) {
 	if deadline, ok := t.Deadline(); ok {
 		ctx, cancel = context.WithDeadline(ctx, deadline)
 	} else {
-		ctx, cancel = context.WithTimeout(ctx, 5*time.Minute)
+		ctx, cancel = context.WithTimeout(ctx, 50*time.Minute)
 	}
 
 	c = &Test{

--- a/msgraph/fasterclient.go
+++ b/msgraph/fasterclient.go
@@ -188,6 +188,16 @@ func (c Client) fasterPerformRequest(req *http.Request, input FasterGetHttpReque
 		}
 	}
 
+	if c.DisableRetries || c.ResponseMiddlewares != nil {
+		o, result, nextLink, err = FasterFromResponse(resp, resultType)
+		if err != nil {
+			return status, nil, nil, err
+		}
+		if resp == nil {
+			return status, nil, nil, fmt.Errorf("nil response received")
+		}
+	}
+
 	status = resp.StatusCode
 	if !containsStatusCode(input.GetValidStatusCodes(), status) {
 		f := input.GetValidStatusFunc()

--- a/msgraph/fasterclient.go
+++ b/msgraph/fasterclient.go
@@ -128,6 +128,7 @@ func (c Client) fasterPerformRequest(req *http.Request, input FasterGetHttpReque
 	var resp *http.Response
 	var o *OData
 	var result interface{}
+	var nextLink *odata.Link
 	var err error
 
 	var reqBody []byte
@@ -144,7 +145,7 @@ func (c Client) fasterPerformRequest(req *http.Request, input FasterGetHttpReque
 				return true, nil
 			}
 
-			o, result, _, err = FasterFromResponse(resp, resultType)
+			o, result, nextLink, err = FasterFromResponse(resp, resultType)
 			if err != nil {
 				return false, err
 			}
@@ -173,6 +174,9 @@ func (c Client) fasterPerformRequest(req *http.Request, input FasterGetHttpReque
 	if err != nil {
 		return status, nil, nil, err
 	}
+	if resp == nil {
+		return status, nil, nil, fmt.Errorf("nil response received")
+	}
 
 	if c.ResponseMiddlewares != nil {
 		for _, m := range *c.ResponseMiddlewares {
@@ -182,14 +186,6 @@ func (c Client) fasterPerformRequest(req *http.Request, input FasterGetHttpReque
 			}
 			resp = r
 		}
-	}
-
-	o, result, nextLink, err := FasterFromResponse(resp, resultType)
-	if err != nil {
-		return status, nil, nil, err
-	}
-	if resp == nil {
-		return status, nil, nil, fmt.Errorf("nil response received")
 	}
 
 	status = resp.StatusCode

--- a/msgraph/fasterclient.go
+++ b/msgraph/fasterclient.go
@@ -245,8 +245,11 @@ func (c Client) FasterGet(ctx context.Context, input FasterGetHttpRequestInput, 
 		return status, err
 	}
 
-	// equivalent of *result = append(*result, partial)
-	reflect.ValueOf(result).Elem().Set(reflect.AppendSlice(reflect.ValueOf(result).Elem(), reflect.ValueOf(partial).Elem()))
+	// Append the partial result to the result
+	if !reflect.ValueOf(partial).IsZero() {
+		// equivalent of *result = append(*result, partial)
+		reflect.ValueOf(result).Elem().Set(reflect.AppendSlice(reflect.ValueOf(result).Elem(), reflect.ValueOf(partial).Elem()))
+	}
 
 	if input.DisablePaging || nextLink == nil || partial == nil {
 		// No more pages, reassign result and return

--- a/msgraph/fasterclient.go
+++ b/msgraph/fasterclient.go
@@ -1,0 +1,105 @@
+package msgraph
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// FasterGet performs a GET request.
+func (c Client) FasterGet(ctx context.Context, input GetHttpRequestInput) (*http.Response, int, *odata.OData, error) {
+	var status int
+
+	// Check for a raw uri, else build one from the Uri field
+	url := input.rawUri
+	if url == "" {
+		// Append odata query parameters
+		input.Uri.Params = input.OData.AppendValues(input.Uri.Params)
+
+		var err error
+		url, err = c.buildUri(input.Uri)
+		if err != nil {
+			return nil, status, nil, fmt.Errorf("unable to make request: %v", err)
+		}
+	}
+
+	// Build a new request
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, http.NoBody)
+	if err != nil {
+		return nil, status, nil, err
+	}
+
+	// Perform the request
+	resp, status, o, err := c.performRequest(req, input)
+	if err != nil {
+		return nil, status, o, err
+	}
+
+	// Check for json content before handling pagination
+	contentType := strings.ToLower(resp.Header.Get("Content-Type"))
+	if strings.HasPrefix(contentType, "application/json") {
+		// Read the response body and close it
+		respBody, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return nil, status, o, fmt.Errorf("could not parse response body")
+		}
+		resp.Body.Close()
+
+		// Unmarshall firstOdata
+		var firstOdata odata.OData
+		if err := json.Unmarshal(respBody, &firstOdata); err != nil {
+			return nil, status, o, err
+		}
+
+		firstValue, ok := firstOdata.Value.([]interface{})
+		if input.DisablePaging || firstOdata.NextLink == nil || firstValue == nil || !ok {
+			// No more pages, reassign response body and return
+			resp.Body = io.NopCloser(bytes.NewBuffer(respBody))
+			return resp, status, o, nil
+		}
+
+		// Get the next page, recursively
+		nextInput := input
+		nextInput.rawUri = string(*firstOdata.NextLink)
+		nextResp, status, o, err := c.FasterGet(ctx, nextInput)
+		if err != nil {
+			return resp, status, o, err
+		}
+
+		// Read the next page response body and close it
+		nextRespBody, err := io.ReadAll(nextResp.Body)
+		if err != nil {
+			return nil, status, o, fmt.Errorf("could not parse response body")
+		}
+		nextResp.Body.Close()
+
+		// Unmarshall firstOdata from the next page
+		var nextOdata odata.OData
+		if err := json.Unmarshal(nextRespBody, &nextOdata); err != nil {
+			return resp, status, o, err
+		}
+
+		if nextValue, ok := nextOdata.Value.([]interface{}); ok {
+			// Next page has results, append to current page
+			value := append(firstValue, nextValue...)
+			nextOdata.Value = &value
+		}
+
+		// Marshal the entire result, along with fields from the final page
+		newJson, err := json.Marshal(nextOdata)
+		if err != nil {
+			return resp, status, o, err
+		}
+
+		// Reassign the response body
+		resp.Body = io.NopCloser(bytes.NewBuffer(newJson))
+	}
+
+	return resp, status, o, nil
+}

--- a/msgraph/fasterclient.go
+++ b/msgraph/fasterclient.go
@@ -246,7 +246,7 @@ func (c Client) FasterGet(ctx context.Context, input FasterGetHttpRequestInput, 
 	}
 
 	// Append the partial result to the result
-	if !reflect.ValueOf(partial).IsZero() {
+	if reflect.ValueOf(partial).IsValid() && !reflect.ValueOf(partial).IsZero() {
 		// equivalent of *result = append(*result, partial)
 		reflect.ValueOf(result).Elem().Set(reflect.AppendSlice(reflect.ValueOf(result).Elem(), reflect.ValueOf(partial).Elem()))
 	}

--- a/msgraph/users.go
+++ b/msgraph/users.go
@@ -308,8 +308,8 @@ func (c *UsersClient) RestoreDeleted(ctx context.Context, id string) (*User, int
 
 // ListGroupMemberships returns a list of Groups the user is member of, optionally queried using OData.
 func (c *UsersClient) ListGroupMemberships(ctx context.Context, id string, query odata.Query) (*[]Group, int, error) {
-	resp, status, _, err := c.BaseClient.FasterGet(ctx, GetHttpRequestInput{
-		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
+	resp, status, _, err := c.BaseClient.FasterGet(ctx, FasterGetHttpRequestInput{
+		ConsistencyFailureFunc: FasterRetryOn404ConsistencyFailureFunc,
 		DisablePaging:          query.Top > 0,
 		OData:                  query,
 		ValidStatusCodes:       []int{http.StatusOK},

--- a/msgraph/users.go
+++ b/msgraph/users.go
@@ -308,7 +308,7 @@ func (c *UsersClient) RestoreDeleted(ctx context.Context, id string) (*User, int
 
 // ListGroupMemberships returns a list of Groups the user is member of, optionally queried using OData.
 func (c *UsersClient) ListGroupMemberships(ctx context.Context, id string, query odata.Query) (*[]Group, int, error) {
-	resp, status, _, err := c.BaseClient.Get(ctx, GetHttpRequestInput{
+	resp, status, _, err := c.BaseClient.FasterGet(ctx, GetHttpRequestInput{
 		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
 		DisablePaging:          query.Top > 0,
 		OData:                  query,

--- a/msgraph/users_test.go
+++ b/msgraph/users_test.go
@@ -66,7 +66,9 @@ func TestUsersClient(t *testing.T) {
 		childGroupIds = append(childGroupIds, *childGroup.ID())
 	}
 
-	testUsersClient_ListGroupMemberships(t, c, *user.ID(), childGroupIds)
+	test.WithMetrics(func() {
+		testUsersClient_ListGroupMemberships(t, c, *user.ID(), childGroupIds)
+	})
 
 	testGroupsClient_Delete(t, c, *parentGroup.ID())
 	for _, id := range childGroupIds {


### PR DESCRIPTION
👋 hamilton maintainers!

I am opening this to ask whether it would make sense to include some new code, or patch existing code, in order to improve resource consumption of the `Get` method - particularly memory usage but also CPU.

I came to this problem as part of my day work at SUSE for Rancher, which uses hamilton to implement Entra ID (formerly Azure AD) integration. In some high-scale use tests we have users with principals in the thousands, groups in the millions and group assignments per principal in the hundreds - and enough traffic to need multiple (tens of) goroutines to periodically refresh all these objects in parallel. In extreme cases we have seen hundreds of MBs to GiBs worth of heap objects, which tend to cause out-of-memory situations.

Here is an example of a similar flame graph:
![image](https://github.com/manicminer/hamilton/assets/250541/fbab24d7-8efe-4b28-a21f-73ef0d68bb08)


Of course our usage pattern isn't typical, and we are working at ways to change the way we interact with the library. Nevertheless according to my analysis `Get` (and code called by it) does quite a bit of needless computation:

 - OData `json.Unmarshal` calls are amplified by a factor of 2 due to the error handling in `OData.UnmarshalJSON`
 - `FromResponse` calls, which drive `OData.UnmarshalJSON` calls, are amplified by a factor of 2 by `performRequest`
 - `Get` needlessly re-unmarshal responses once after `FasterResponse` (again with the amplification factors above), and especially
 - `Get` un-marshals and subsequently re-marshals responses if they are paginated. This unmarshaling-marshaling extra round is repeated by the number of pages


This PR cuts down unmarshaling to one pass only (divided in sub-passes via `json.RawMessage`) and eliminates remarshaling altogether.


I could not find ways to achieve this without altering the `OData` struct and structs/methods which use it (`ConsistencyFailureFunc`, `ValidStatusFunc`, `GetHttpRequestInput`), therefore, I opted for a completely new code path in `fasterclient.go`. The approach can be changed if API changes are acceptable.

For now and for the sake of discussion, I only patched the one endpoint that really hurts my use case: `ListGroupMemberships`. Changes are minimal other than using the `FasterGet` method in place of `Get` - ideally this could be extended to all other (internal) usages of `Get`.


I am also contributing code to exercise `ListGroupMemberships` more thoroughly so that the effects of the patch are evident. Furthermore I added a utility method that will output CPU and memory usage during the test run.


My results are as follows:

|             |          main |    faster_get |
|-------------|--------------:|--------------:|
| Run 1       |        610 ms |        273 ms |
| Run 2       |        817 ms |        122 ms |
| Run 3       |        643 ms |        353 ms |
| **Average** |    **690 ms** |    **249 ms** |

**CPU load is ~36.14% of the original**

|             |          main | faster_get |
|------------:|--------------:|-----------:|
|       Run 1 |        21 MiB |      3 MiB |
|       Run 2 |        22 MiB |      3 MiB |
|       Run 3 |        23 MiB |      3 MiB |
| **Average** |    **22 MiB** |  **3 MiB** |

**Memory consumption is ~13.64% of the original**


Is there any interest to merge such an improvement? What would be needed to have a similar PR accepted?

Thanks in advance, I hope this helps