### PR TITLE
Support for `attributeSets`

### DIFF
--- a/internal/test/testing.go
+++ b/internal/test/testing.go
@@ -102,6 +102,7 @@ type Test struct {
 	ApplicationTemplatesClient                *msgraph.ApplicationTemplatesClient
 	ApplicationsClient                        *msgraph.ApplicationsClient
 	AppRoleAssignedToClient                   *msgraph.AppRoleAssignedToClient
+	AttributeSetsClient                       *msgraph.AttributeSetsClient
 	AuthenticationMethodsClient               *msgraph.AuthenticationMethodsClient
 	AuthenticationStrengthPoliciesClient      *msgraph.AuthenticationStrengthPoliciesClient
 	B2CUserFlowClient                         *msgraph.B2CUserFlowClient
@@ -244,6 +245,11 @@ func NewTest(t *testing.T) (c *Test) {
 	c.AppRoleAssignedToClient.BaseClient.Authorizer = c.Connections["default"].Authorizer
 	c.AppRoleAssignedToClient.BaseClient.Endpoint = *endpoint
 	c.AppRoleAssignedToClient.BaseClient.RetryableClient.RetryMax = retry
+
+	c.AttributeSetsClient = msgraph.NewAttributeSetsClient()
+	c.AttributeSetsClient.BaseClient.Authorizer = c.Connections["default"].Authorizer
+	c.AttributeSetsClient.BaseClient.Endpoint = *endpoint
+	c.AttributeSetsClient.BaseClient.RetryableClient.RetryMax = retry
 
 	c.AuthenticationMethodsClient = msgraph.NewAuthenticationMethodsClient()
 	c.AuthenticationMethodsClient.BaseClient.Authorizer = c.Connections["default"].Authorizer

--- a/msgraph/attributesets.go
+++ b/msgraph/attributesets.go
@@ -1,0 +1,145 @@
+package msgraph
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// AttributeSetsClient performs operations on Attribute Sets.
+type AttributeSetsClient struct {
+	BaseClient Client
+}
+
+// NewAttributeSetsClient returns a new AttributeSetsClient.
+func NewAttributeSetsClient() *AttributeSetsClient {
+	return &AttributeSetsClient{
+		BaseClient: NewClient(Version10),
+	}
+}
+
+// List returns a list of AttributeSet
+func (c *AttributeSetsClient) List(ctx context.Context, query odata.Query) (*[]AttributeSet, int, error) {
+	resp, status, _, err := c.BaseClient.Get(ctx, GetHttpRequestInput{
+		DisablePaging:    query.Top > 0,
+		OData:            query,
+		ValidStatusCodes: []int{http.StatusOK},
+		Uri: Uri{
+			Entity: "/directory/attributeSets",
+		},
+	})
+
+	if err != nil {
+		return nil, status, fmt.Errorf("AttributeSetsClient.BaseClient.Get(): %v", err)
+	}
+
+	defer resp.Body.Close()
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, status, fmt.Errorf("io.ReadAll(): %v", err)
+	}
+
+	var data struct {
+		AttributeSets []AttributeSet `json:"value"`
+	}
+
+	if err := json.Unmarshal(respBody, &data); err != nil {
+		return nil, status, fmt.Errorf("json.Unmarshal(): %v", err)
+	}
+
+	return &data.AttributeSets, status, nil
+}
+
+// Get retrieves an AttributeSet
+func (c *AttributeSetsClient) Get(ctx context.Context, id string, query odata.Query) (*AttributeSet, int, error) {
+	resp, status, _, err := c.BaseClient.Get(ctx, GetHttpRequestInput{
+		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
+		OData:                  query,
+		ValidStatusCodes:       []int{http.StatusOK},
+		Uri: Uri{
+			Entity: fmt.Sprintf("/directory/attributeSets/%s", id),
+		},
+	})
+	if err != nil {
+		return nil, status, fmt.Errorf("AttributeSetsClient.BaseClient.Get(): %v", err)
+	}
+
+	defer resp.Body.Close()
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, status, fmt.Errorf("io.ReadAll(): %v", err)
+	}
+
+	var attributeSet AttributeSet
+	if err := json.Unmarshal(respBody, &attributeSet); err != nil {
+		return nil, status, fmt.Errorf("json.Unmarshal(): %v", err)
+	}
+
+	return &attributeSet, status, nil
+}
+
+// Create creates an AttributeSet
+func (c *AttributeSetsClient) Create(ctx context.Context, attributeSet AttributeSet) (*AttributeSet, int, error) {
+	var status int
+
+	body, err := json.Marshal(attributeSet)
+	if err != nil {
+		return nil, status, fmt.Errorf("json.Marshal(): %v", err)
+	}
+
+	resp, status, _, err := c.BaseClient.Post(ctx, PostHttpRequestInput{
+		Body:                   body,
+		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
+		OData: odata.Query{
+			Metadata: odata.MetadataFull,
+		},
+		ValidStatusCodes: []int{http.StatusCreated},
+		Uri: Uri{
+			Entity: "/directory/attributeSets",
+		},
+	})
+	if err != nil {
+		return nil, status, fmt.Errorf("AttributeSetsClient.BaseClient.Post(): %v", err)
+	}
+
+	defer resp.Body.Close()
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, status, fmt.Errorf("io.ReadAll(): %v", err)
+	}
+
+	var newAttributeSet AttributeSet
+	if err := json.Unmarshal(respBody, &newAttributeSet); err != nil {
+		return nil, status, fmt.Errorf("json.Unmarshal(): %v", err)
+	}
+
+	return &newAttributeSet, status, nil
+}
+
+// Update updates an AttributeSet
+func (c *AttributeSetsClient) Update(ctx context.Context, attributeSet AttributeSet) (int, error) {
+	var status int
+
+	body, err := json.Marshal(attributeSet)
+	if err != nil {
+		return status, fmt.Errorf("json.Marshal(): %v", err)
+	}
+
+	_, status, _, err = c.BaseClient.Patch(ctx, PatchHttpRequestInput{
+		Body:                   body,
+		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
+		ValidStatusCodes: []int{http.StatusNoContent},
+		Uri: Uri{
+			Entity: fmt.Sprintf("/directory/attributeSets/%s", *attributeSet.ID),
+		},
+	})
+	if err != nil {
+		return status, fmt.Errorf("AttributeSetsClient.BaseClient.Patch(): %v", err)
+	}
+
+	return status, nil
+}

--- a/msgraph/attributesets_test.go
+++ b/msgraph/attributesets_test.go
@@ -1,0 +1,85 @@
+package msgraph_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+	"github.com/manicminer/hamilton/internal/test"
+	"github.com/manicminer/hamilton/internal/utils"
+	"github.com/manicminer/hamilton/msgraph"
+)
+
+func TestAttributeSetsClient(t *testing.T) {
+	c := test.NewTest(t)
+	defer c.CancelFunc()
+
+	randomString := test.RandomString()
+
+	attributeSet := testAttributeSetsClient_Create(t, c, msgraph.AttributeSet{
+		ID:                  utils.StringPtr(fmt.Sprintf("testing%s", randomString)),
+		Description:         utils.StringPtr("This is a test attribute set"),
+		MaxAttributesPerSet: utils.Int32Ptr(20),
+	})
+
+	testAttributeSetsClient_Get(t, c, *attributeSet.ID)
+
+	attributeSet.Description = utils.StringPtr("This is an updated test attribute set")
+	attributeSet.MaxAttributesPerSet = utils.Int32Ptr(25)
+
+	testAttributeSetsClient_Update(t, c, *attributeSet)
+
+	testAttributeSetsClient_List(t, c)
+}
+
+func testAttributeSetsClient_Create(t *testing.T, c *test.Test, as msgraph.AttributeSet) (attributeSet *msgraph.AttributeSet) {
+	attributeSet, status, err := c.AttributeSetsClient.Create(c.Context, as)
+	if err != nil {
+		t.Fatalf("AttributeSetsClient.Create(): %v", err)
+	}
+	if status < 200 || status >= 300 {
+		t.Fatalf("AttributeSetsClient.Create(): invalid status: %d", status)
+	}
+	if attributeSet == nil {
+		t.Fatal("AttributeSetsClient.Create(): attributeSet was nil")
+	}
+	if attributeSet.ID == nil {
+		t.Fatal("AttributeSetsClient.Create(): attributeSet.ID was nil")
+	}
+	return
+}
+
+func testAttributeSetsClient_Update(t *testing.T, c *test.Test, as msgraph.AttributeSet) {
+	status, err := c.AttributeSetsClient.Update(c.Context, as)
+	if err != nil {
+		t.Fatalf("AttributeSetsClient.Update(): %v", err)
+	}
+	if status < 200 || status >= 300 {
+		t.Fatalf("AttributeSetsClient.Update(): invalid status: %d", status)
+	}
+}
+
+func testAttributeSetsClient_Get(t *testing.T, c *test.Test, id string) (attributeSet *msgraph.AttributeSet) {
+	attributeSet, status, err := c.AttributeSetsClient.Get(c.Context, id, odata.Query{})
+	if err != nil {
+		t.Fatalf("AttributeSetsClient.Get(): %v", err)
+	}
+	if status < 200 || status >= 300 {
+		t.Fatalf("AttributeSetsClient.Get(): invalid status: %d", status)
+	}
+	if attributeSet == nil {
+		t.Fatal("AttributeSetsClient.Get(): attributeSet was nil")
+	}
+	return
+}
+
+func testAttributeSetsClient_List(t *testing.T, c *test.Test) (attributeSets *[]msgraph.AttributeSet) {
+	attributeSets, _, err := c.AttributeSetsClient.List(c.Context, odata.Query{})
+	if err != nil {
+		t.Fatalf("AttributeSetsClient.List(): %v", err)
+	}
+	if attributeSets == nil {
+		t.Fatal("AttributeSetsClient.List(): attributeSet was nil")
+	}
+	return
+}

--- a/msgraph/models.go
+++ b/msgraph/models.go
@@ -576,6 +576,12 @@ type AssignmentReviewSettings struct {
 	AccessReviewTimeoutBehavior     AccessReviewTimeoutBehaviorType `json:"accessReviewTimeoutBehavior,omitempty"`
 }
 
+type AttributeSet struct {
+	Description         *string `json:"description,omitempty"`
+	ID                  *string `json:"id,omitempty"`
+	MaxAttributesPerSet *int32  `json:"maxAttributesPerSet,omitempty"`
+}
+
 type AuditActivityInitiator struct {
 	App  *AppIdentity  `json:"app,omitempty"`
 	User *UserIdentity `json:"user,omitempty"`


### PR DESCRIPTION
Adds support for [attributeSets](https://learn.microsoft.com/en-us/graph/api/resources/attributeset?view=graph-rest-1.0)

**Warning!** attributeSets cannot be DELETED or RENAMED, they are permanent. (see [here](https://learn.microsoft.com/en-us/entra/fundamentals/custom-security-attributes-add?tabs=ms-powershell#add-an-attribute-set))

Related:
https://github.com/hashicorp/terraform-provider-azuread/issues/913