### PR TITLE
[Breaking Change] Move ExpirationPattern Duration to a String

### DIFF
--- a/msgraph/models.go
+++ b/msgraph/models.go
@@ -1013,7 +1013,7 @@ type ExtensionSchemaProperty struct {
 }
 
 type ExpirationPattern struct {
-	Duration    *time.Duration         `json:"duration,omitempty"`
+	Duration    *string                `json:"duration,omitempty"`
 	EndDateTime *time.Time             `json:"endDateTime,omitempty"`
 	Type        *ExpirationPatternType `json:"type,omitempty"`
 }


### PR DESCRIPTION
According to the Graph documentation for an [expirationPattern](https://learn.microsoft.com/en-us/graph/api/resources/expirationpattern?view=graph-rest-1.0) the Duration needs to be an ISO8601 string. This PR changes the model from `time.Duration` to `string` since Go doesn't have an internal ISO8601 package. 

expirationPattern is currently only referenced by Access Packages, and the Duration property is not used in the Azure AD Terraform provider.