### PR TITLE
Fix error dropping when making requests

### DIFF
--- a/msgraph/client.go
+++ b/msgraph/client.go
@@ -58,6 +58,10 @@ type Uri struct {
 // RetryableErrorHandler ensures that the response is returned after exhausting retries for a request
 // We can't return an error here, or net/http will not return the response
 func RetryableErrorHandler(resp *http.Response, err error, numTries int) (*http.Response, error) {
+	if resp == nil {
+		return nil, err
+	}
+
 	return resp, nil
 }
 

--- a/msgraph/client_test.go
+++ b/msgraph/client_test.go
@@ -1,0 +1,72 @@
+package msgraph
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func TestClient_GetWithError(t *testing.T) {
+	// This creates a listener on a random available port.
+	l, err := net.Listen("tcp", ":0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	port := l.Addr().(*net.TCPAddr).Port
+	l.Close()
+
+	hc := NewClient(VersionBeta)
+	hc.Endpoint = fmt.Sprintf("https://localhost:%d/", port)
+	hc.RetryableClient.RetryMax = 2
+
+	_, _, _, err = hc.Get(context.Background(), GetHttpRequestInput{
+		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
+		ValidStatusCodes:       []int{http.StatusOK},
+		Uri: Uri{
+			Entity: "/users/test",
+		},
+	})
+	if err == nil {
+		t.Error("expected to get an error, got nil")
+	}
+	if msg := err.Error(); !strings.Contains(msg, "connect: connection refused") {
+		log.Fatalf("got %s, want message with 'connection refused'", msg)
+	}
+}
+
+func TestClient_GetWithResponseAndError(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/beta/users/test" {
+			n, _ := strconv.Atoi(r.FormValue("n"))
+			if n < 15 {
+				http.Redirect(w, r, fmt.Sprintf("%s?n=%d", r.URL.Path, 1), http.StatusTemporaryRedirect)
+				return
+			}
+		}
+	}))
+	defer ts.Close()
+
+	hc := NewClient(VersionBeta)
+	hc.Endpoint = ts.URL
+	hc.RetryableClient.RetryMax = 2
+
+	_, _, _, err := hc.Get(context.Background(), GetHttpRequestInput{
+		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
+		ValidStatusCodes:       []int{http.StatusOK},
+		Uri: Uri{
+			Entity: "/users/test",
+		},
+	})
+	if err == nil {
+		t.Error("expected to get an error, got nil")
+	}
+	if msg := err.Error(); !strings.Contains(msg, "stopped after 10 redirects") {
+		log.Fatalf("got %s, want message with 'stopped after 10 redirects'", msg)
+	}
+}


### PR DESCRIPTION
This removes the custom ErrorHandler configuration.

Currently, if there's an error trying to connect to the upstream API, the actual error message is dropped, and it falls back to the underlying Go client which warns that the Transport returned no error and no response.

After it's exhausted the retries, if the `ErrorHandler` is configured, it simply returns whatever the `ErrorHandler` returns https://github.com/hashicorp/go-retryablehttp/blob/main/client.go#L749-L751

If there's no response (perhaps because it can't connect) at all, `RetryableErrorHandler` was returning `nil, nil` which the Go client https://github.com/golang/go/blob/2e1003e2f7e42efc5771812b9ee6ed264803796c/src/net/http/client.go#L276 will complain about, and, the error message is dropped, so no way to diagnose the issue.