### PR TITLE
Add 404 retry on Instantiate

### DIFF
--- a/msgraph/application_templates.go
+++ b/msgraph/application_templates.go
@@ -95,8 +95,9 @@ func (c *ApplicationTemplatesClient) Instantiate(ctx context.Context, applicatio
 	}
 
 	resp, status, _, err := c.BaseClient.Post(ctx, PostHttpRequestInput{
-		Body:             body,
-		ValidStatusCodes: []int{http.StatusCreated},
+		Body:                   body,
+		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
+		ValidStatusCodes:       []int{http.StatusCreated},
 		Uri: Uri{
 			Entity: fmt.Sprintf("/applicationTemplates/%s/instantiate", *applicationTemplate.ID),
 		},


### PR DESCRIPTION
Hello,

We're using the Terraform resource [azuread_application](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/resources/application)

When using this resource we're referencing a template via `template_id` and we're seeing intermittent errors
```
{"@level":"error","@message":"Error: Could not instantiate application from template","@module":"terraform.ui","@timestamp":"2024-05-08T02:43:41.520121Z","diagnostic":{"severity":"error","summary":"Could not instantiate application from template","detail":"ApplicationTemplatesClient.BaseClient.Post(): unexpected status 404 with OData error: NotFound: Graph call failed with httpCode=NotFound, errorCode=, errorMessage=, reason=Not Found.","address":"module.dummy-application.azuread_application.saml_application"
```
I'm wondering if its possible to add a `RetryOn404ConsistencyFailureFunc` to the post to help with this intermittent issue.
If this looks good/acceptable, what is the timeline to pushing this out to the Terraform Provider? 

