### PR TITLE
Remove 404 retry, add custom ctx with timeout

### DIFF
--- a/msgraph/application_templates.go
+++ b/msgraph/application_templates.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"time"
 
 	"github.com/hashicorp/go-azure-sdk/sdk/odata"
 )
@@ -94,11 +93,6 @@ func (c *ApplicationTemplatesClient) Instantiate(ctx context.Context, applicatio
 	if err != nil {
 		return nil, status, fmt.Errorf("json.Marshal(): %v", err)
 	}
-
-	// This post call can often timeout and return a 404, particularly against US Gov cloud. The aim here is to give it longer to complete on azure's backend
-	// before timeout occurs
-	ctx, cancel := context.WithTimeout(ctx, 45*time.Second)
-	defer cancel()
 
 	resp, status, _, err := c.BaseClient.Post(ctx, PostHttpRequestInput{
 		Body:             body,


### PR DESCRIPTION
This PR Removes the Retryon404 added by @amarbut24  and extends the context timeout. 

Since having the 404retry in place, it has done the desired effect of retrying, but what appears to happen is we end up with duplicate apps, which then cause a conflict. 

My assumption here is the post to MS Graph takes multiple actions on the backend, which can take time to complete (expecially in US gov, texas data center). 

Ive been able to reproduce the same issue using the offical MS Graph powershell cmdlets against US Gov Azure tenants so this issue is not specific to hamilton, but more of an azure issue. 

My hope with this PR is extending the context timeout to 45 seconds, will give the client longer to wait for the response. If Azure is the one returning the 404, then there is likely nothing we can do, and Microsoft will need to fix. 